### PR TITLE
fix: resolve CI/CD blocking issues (#30)

### DIFF
--- a/python/confiture/cli/main.py
+++ b/python/confiture/cli/main.py
@@ -440,6 +440,9 @@ def build(
         # Override to exclude seeds if --schema-only is specified
         if schema_only:
             builder.include_dirs = [d for d in builder.include_dirs if "seed" not in str(d).lower()]
+            builder.include_configs = [
+                cfg for cfg in builder.include_configs if "seed" not in str(cfg["path"]).lower()
+            ]
             # Recalculate base_dir after filtering
             if builder.include_dirs:
                 builder.base_dir = builder._find_common_parent(builder.include_dirs)

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -81,7 +81,7 @@ class TestMigrationBase:
         mock_conn = Mock()
 
         # Missing down() - ABC prevents instantiation
-        with pytest.raises(TypeError, match="abstract method down"):
+        with pytest.raises(TypeError, match="abstract method.*down"):
 
             class MissingDownMigration(Migration):
                 version = "001"
@@ -93,7 +93,7 @@ class TestMigrationBase:
             MissingDownMigration(connection=mock_conn)
 
         # Missing up() - ABC prevents instantiation
-        with pytest.raises(TypeError, match="abstract method up"):
+        with pytest.raises(TypeError, match="abstract method.*up"):
 
             class MissingUpMigration(Migration):
                 version = "001"


### PR DESCRIPTION
## Summary

Resolved 2 critical CI/CD blocking issues preventing the project from passing quality gates:

1. **--schema-only flag not excluding seed files**
   - The `--schema-only` flag in the build command filtered `include_dirs` but not `include_configs`
   - Since `find_sql_files()` uses `include_configs` to discover files, seed files were still being included
   - Hash computation failed with: `ValueError: '/path/db/seeds/data.sql' is not in the subpath of '/path/db/schema'`
   - **Fix**: Also filter `include_configs` when `--schema-only` is specified (3-line change)

2. **Abstract method regex pattern too strict**
   - Test regex pattern `"abstract method down"` was not matching actual error message format
   - Actual message included quotes and additional text: `"Can't instantiate abstract class ... abstract method 'down'"`
   - **Fix**: Updated regex patterns to `"abstract method.*down"` for flexibility

## Test Results

- ✅ All 3,783 tests passing (was 2 failing)
- ✅ Ruff linting: All checks passed
- ✅ Ruff formatting: 401 files formatted
- ✅ Rust checks: cargo fmt ✓, clippy ✓
- ✅ Type checking: Passing (with acceptable psycopg3 continue-on-error)
- ✅ Security scans: Passing

## Changes Made

- `python/confiture/cli/main.py`: Filter both `include_dirs` and `include_configs` when `--schema-only` is specified
- `tests/unit/test_migration.py`: Update regex patterns to match flexible abstract method error messages

## Verification

All CI/CD quality gates are now passing:
- ✅ Tests gate
- ✅ Lint gate
- ✅ Type check gate
- ✅ Rust checks gate
- ✅ Security gate

The project is ready for release preparation.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)