### PR TITLE
fix(builder): #128 preserve constraints + comments around table-level FKs (v0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to Confiture will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-05-27
+
+Agent-experience punch-list for the idempotency stack. Closes
+[#123](https://github.com/fraiseql/confiture/issues/123).
+
+### Added
+
+- **`migrate validate --list-patterns`** — machine-readable catalog of
+  every idempotency detection pattern. Read-only (no DB, no config, no
+  migrations directory required). JSON output frozen at `version: "1"`,
+  documented under `docs/reference/json-schemas/`. Each entry now carries
+  `template_fillable: bool` alongside `has_skip_regex`, `skip_hint`, and
+  `has_auto_fix`.
+- **JSON schemas under `docs/reference/json-schemas/`** — nine schemas
+  covering every machine-readable CLI output, plus a shared
+  `_common.schema.json` for the `HintsArray` and `BackendMeta` refs.
+  Every documented success-path emitter pre-allocates `"hints": []`.
+- **`--idempotent` backend banner** — `payload["meta"]["backend"]`
+  ("ast" or "regex") in JSON output; a one-line annotated banner in
+  text mode so the active backend is never silent.
+- **Captures-driven suggestion templates.** Idempotency violations now
+  carry copy-pasteable SQL fix templates with captured identifiers
+  inlined (schema/table/constraint/column). Both the regex and the AST
+  backend feed a normalized `Captures` instance through the shared
+  template module, so the rendered suggestion is identical regardless
+  of which backend matched.
+- **Quiet-success hints.** `migrate validate --idempotent` on an empty
+  directory, `migrate status` against a database with no tracking
+  table, and `migrate preflight --against` against an empty
+  `tb_confiture` now emit advisory hints — stderr in text mode,
+  `payload["hints"][…]` in JSON mode. Hints never change exit codes.
+
+### Reference
+
+- New: `docs/reference/json-schemas.md` and the directory of nine
+  schemas it links.
+- Updated: `migrate-validate-list-patterns.schema.json` documents the
+  new `template_fillable` field.
+
 ## [0.15.0] - 2026-05-27
 
 Ownership coverage — the ownership axis of the same drift class that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Confiture will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-05-27
+
+### Fixed
+
+- **`confiture build` no longer corrupts `CREATE TABLE` bodies when a `--`
+  comment sits between table-level `CONSTRAINT … FOREIGN KEY` clauses.**
+  The FK extractor was running its regex twice — once on a
+  comment-stripped view, once on the original — and the start/end
+  whitespace expansion ate the comment's terminating newline, gluing the
+  comment onto the previous column line and leaving a trailing comma
+  before `)`. Now positions are projected back via an index map, and
+  newline consumption is skipped on either side of a comment-only line,
+  so the comment stays on its own line and `_fix_trailing_commas` walks
+  back through comment/blank lines to find the last data column. FKs are
+  still extracted correctly into the Pass-2 ALTER block. Closes
+  [#128](https://github.com/evoludigit/confiture/issues/128).
+
 ## [0.16.0] - 2026-05-27
 
 Agent-experience punch-list for the idempotency stack. Closes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to Confiture will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-05-27
+
+Ownership coverage — the ownership axis of the same drift class that
+[#120](https://github.com/fraiseql/confiture/issues/120) covered on the
+ACL axis. Catches relations that ship with the wrong `pg_class.relowner`
+before schema-wide `GRANT` statements blow up in production with
+`grantor must own the object`. Closes
+[#124](https://github.com/fraiseql/confiture/issues/124).
+
+### Added
+
+- **`ownership:` block in environment YAML.** Single declaration: one
+  canonical `expected_owner` per environment, with per-schema `apply_to`
+  + `relkinds` filters, an `ignore` glob list, and a `lint_enabled` flag
+  (defaults to `True`, opt-in by default).
+- **`confiture drift --check-ownership`** — runtime check against
+  `pg_class.relowner`. Composes with `--check-acls` and `--schema` in a
+  single report. JSON output includes a `wrong_owner` drift type.
+- **`migrate validate --check-ownership-coverage`** — static lint rule
+  `own_001` that flags `CREATE { TABLE | VIEW | MATERIALIZED VIEW |
+  SEQUENCE }` without a matching `ALTER … OWNER TO <expected_owner>`
+  later in the same migration file. AST-only (requires the `[ast]`
+  extra); a single skip notice is emitted when pglast is missing.
+- **`-- confiture:owner-skip`** directive opts the next CREATE out of
+  the rule (for genuinely extension-owned objects).
+- **`-- confiture:run-as <role>`** front-matter directive skips the
+  whole file when the declared role matches `expected_owner`. The
+  directive is declarative only — the runtime drift detector is the
+  production-time check.
+- **`migrate fix --ownership`** — auto-inserts the missing
+  `ALTER … OWNER TO` line immediately after each offending CREATE.
+  Composable with `--idempotent`. Includes a checksum-drift guard that
+  refuses to rewrite already-applied migrations unless `--force` is set.
+- **Docs:** `docs/guides/ownership-coverage.md`, sibling to
+  `docs/guides/acl-coverage.md` with cross-references.
+
+### Fixed
+
+- **`AclDriftDetector.check()` no longer crashes** with `missing
+  FROM-clause entry` on every invocation. The inline
+  `"schema"."table"::regclass` was parsed as a column reference; the
+  qualified name is now passed as a TEXT parameter through the
+  `::regclass` cast (pre-existing bug surfaced when the suite was
+  re-run from scratch).
+- **`DryRunExecutor.run()` accepts positional `(migration_name,
+  statements)`** to match the documented new-API call sites; the legacy
+  keyword form remains supported.
+- **`ViewManager.recreate_saved_views()` integration tests** updated to
+  the `RecreateResult` return type (the previous int-return API was
+  replaced before 0.14.0; tests had drifted).
+
 ## [0.14.0] - 2026-05-25
 
 `migrate validate --idempotent` now uses PostgreSQL's own parser (via

--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ with Migrator.from_config("db/environments/prod.yaml") as m:
 - [Configuration YAML](docs/reference/configuration.md)
 - [Complete feature list](docs/features/overview.md)
 
+**For agents and tooling**
+- Every machine-readable CLI output has a published JSON schema under [`docs/reference/json-schemas/`](docs/reference/json-schemas/) — see [`docs/reference/json-schemas.md`](docs/reference/json-schemas.md).
+- `confiture migrate validate --list-patterns --format json` exposes the full idempotency-detection catalog (read-only, no DB / config / migrations directory needed).
+- Quiet-success ambiguities surface advisory hints in `payload["hints"]` (or on stderr in text mode) — exit codes are unaffected.
+
 ---
 
 ## Contributing

--- a/docs/guides/acl-coverage.md
+++ b/docs/guides/acl-coverage.md
@@ -1,8 +1,10 @@
 # ACL Coverage
 
-[← Back to Guides](../index.md) · [Drift Detection](git-aware-validation.md) · [Schema Linting](schema-linting.md)
+[← Back to Guides](../index.md) · [Ownership Coverage](ownership-coverage.md) · [Drift Detection](git-aware-validation.md) · [Schema Linting](schema-linting.md)
 
 Catch tables that ship without their expected `GRANT`s — both before they merge (static lint) and after they reach a database (runtime drift).
+
+> **Sister feature** — [Ownership Coverage](ownership-coverage.md) covers the same drift class on the ownership axis (`pg_class.relowner`). Most projects want both: ACL coverage catches missing grants, ownership coverage catches the missing `ALTER … OWNER TO` that *causes* schema-wide grants to fail. The two features share a parallel CLI surface (`--check-acls` / `--check-ownership` for runtime; `--check-acl-coverage` / `--check-ownership-coverage` for the static lint).
 
 ---
 

--- a/docs/guides/ownership-coverage.md
+++ b/docs/guides/ownership-coverage.md
@@ -1,0 +1,234 @@
+# Ownership Coverage
+
+[← Back to Guides](../index.md) · [ACL Coverage](acl-coverage.md) · [Drift Detection](git-aware-validation.md)
+
+Catch tables, sequences, views, and materialized views that ship without the expected owner — both before they merge (static lint, optionally auto-fixed) and after they reach a database (runtime drift).
+
+This is the **ownership axis** of the same drift class covered by [ACL Coverage](acl-coverage.md). The two features are designed as siblings: one canonical config block per axis, parallel CLI flags, parallel checks.
+
+---
+
+## The problem
+
+When `CREATE TABLE` (or `CREATE VIEW`, `CREATE MATERIALIZED VIEW`, `CREATE SEQUENCE`) inside a migration runs as a role **other than** the project's canonical migrator role, the new object is owned by whoever ran the statement — typically `postgres` if a hotfix was applied manually. Subsequent schema-wide grant statements then fail in production with:
+
+```
+ERROR:  permission denied for table foo
+HINT:   grantor must own the object
+```
+
+A single drifted owner can abort an entire `GRANT … ON ALL SEQUENCES` migration, leaving the schema in a half-granted state. This drift is invisible under build-from-DDL (rebuild runs everything as one role) and only surfaces in incrementally-deployed environments.
+
+---
+
+## The `ownership:` block
+
+You declare the expected owner once in the environment YAML. Both the static rule (`own_001`) and the runtime drift detector read the same block.
+
+```yaml
+# db/environments/production.yaml
+ownership:
+  expected_owner: migrator
+  apply_to:
+    - schema: tenant
+      relkinds: [r, S, v, m]      # table, sequence, view, matview
+    - schema: public
+      relkinds: [r, S]
+  ignore:
+    - public.legacy_audit_log     # literal qualified name
+    - "*.audit_log"               # cross-schema glob
+  lint_enabled: true              # opt-in default for own_001 (default: true)
+```
+
+Validation:
+
+- `expected_owner` must be a valid Postgres role identifier: `[a-z_][a-z0-9_]*`, or a double-quoted form `"Mixed Case"` for mixed-case roles.
+- `relkinds` accepts only `r` (regular table), `S` (sequence), `v` (view), and `m` (materialized view). Default covers all four. Unknown values raise a `ConfigurationError` with the rejected set named.
+- `ignore` accepts both literal qualified names (`schema.relname`) and `fnmatch` globs (`*.audit_log`, `tenant.*_legacy`).
+- `${VAR}` expansion runs at config-load time on the same terms as `acls:` — strict `${UPPER_NAME}` form only, missing variables fail loud.
+
+Unlike `acls:` (a list of expectations), `ownership:` is a single declaration — there is exactly one canonical owner per environment.
+
+---
+
+## Static check — `migrate validate --check-ownership-coverage`
+
+The static rule parses every `*.up.sql` in `db/migrations/`, finds each `CREATE` in scope, and flags any that aren't paired with `ALTER … OWNER TO <expected_owner>` later in the same file.
+
+```bash
+confiture migrate validate --check-ownership-coverage --config confiture.yaml
+```
+
+- Exit `0` on success or when the project has no `ownership:` block (opt-in semantics).
+- Exit `1` when violations are found.
+- Exit `2` on config errors.
+
+Output looks like:
+
+```
+❌ Ownership coverage check failed: 2 violation(s)
+  ✗ [own_001] tenant.tb_orders: Table 'tenant.tb_orders' was created without
+    `ALTER … OWNER TO migrator;` in the same migration.  Without it, schema-wide
+    GRANTs from the canonical migrator role will fail with `grantor must own the object`.
+  ✗ [own_001] public.s_invoice_id: Sequence 'public.s_invoice_id' was created without …
+```
+
+### AST-only by design
+
+`own_001` is AST-only — pairwise `CREATE` ↔ `ALTER … OWNER TO` matching across realistic PostgreSQL SQL (dollar-quoted strings, CHECK-constraint literals, multi-statement `DO $$ … $$` blocks) is too brittle to ship as a regex. When pglast is not installed, the rule emits a single skip notice and returns no violations rather than ship a half-working detector:
+
+```
+own_001 requires the [ast] extra: pip install "fraiseql-confiture[ast]"
+```
+
+Install the extra to enable the rule:
+
+```bash
+pip install "fraiseql-confiture[ast]"
+```
+
+### Opt-out: the `-- confiture:owner-skip` directive
+
+For genuinely extension-owned objects, mark the `CREATE` with a directive comment on its own line:
+
+```sql
+-- confiture:owner-skip   (intentional: extension manages this table)
+CREATE TABLE extensions.dblink_meta (id int);
+```
+
+### Skipping a whole file: `-- confiture:run-as <role>`
+
+When a migration is known to run as a specific role, declare it once at the top:
+
+```sql
+-- confiture:run-as migrator
+CREATE TABLE tenant.tb_orders (id int);
+-- no ALTER OWNER needed; the migration declared its role
+```
+
+**Trust boundary.** The `-- confiture:run-as` directive is **declarative only**. The lint rule trusts the comment; nothing at lint time verifies the migration actually runs as that role in production. If a developer writes `-- confiture:run-as migrator` but the migration is then applied by `postgres` in staging, the lint will pass but the runtime drift detector (`confiture drift --check-ownership`, below) will catch it. The static rule is the PR-time gate; the runtime check is the production-time gate — they are designed to be complementary.
+
+---
+
+## Runtime check — `confiture drift --check-ownership`
+
+Compare `pg_class.relowner` in a live database against the configured expectation. Reports one `WRONG_OWNER` drift item per relation whose actual owner differs from `expected_owner`.
+
+```bash
+confiture drift --check-ownership --config confiture.yaml
+```
+
+Composable with the structural and ACL drift checks in a single invocation:
+
+```bash
+confiture drift \
+  --check-ownership \
+  --check-acls \
+  --schema db/generated/schema.sql \
+  --config confiture.yaml
+```
+
+JSON output for CI pipelines:
+
+```bash
+confiture drift --check-ownership --format json --config confiture.yaml
+```
+
+```json
+{
+  "expected_schema_source": "ownership",
+  "has_drift": true,
+  "tables_checked": 12,
+  "drift_items": [
+    {
+      "type": "wrong_owner",
+      "severity": "critical",
+      "object": "tenant.tb_orders",
+      "expected": "migrator",
+      "actual": "postgres",
+      "message": "Relation 'tenant.tb_orders' is owned by 'postgres' but expected owner is 'migrator'"
+    }
+  ]
+}
+```
+
+### Partition handling
+
+Partition children are **individually checked**. PostgreSQL allows each partition to have a distinct owner (uncommon but legal), and a drifted child is exactly the kind of mistake this detector exists to catch. If you split partitions across roles intentionally, list each drifted child in `ignore`.
+
+---
+
+## Auto-fix — `migrate fix --ownership`
+
+Once the lint rule flags a missing `ALTER … OWNER TO`, the auto-fixer can insert it directly into the migration file:
+
+```bash
+# Preview
+confiture migrate fix --ownership --dry-run --config confiture.yaml
+
+# Apply
+confiture migrate fix --ownership --config confiture.yaml
+```
+
+The fixer inserts each `ALTER … OWNER TO` on the line immediately following the offending `CREATE`'s terminating semicolon. Re-running the fixer on an already-fixed file is a no-op.
+
+### Checksum-drift guard
+
+Confiture records checksums of every applied migration in the local tracking table. Rewriting an already-applied file silently breaks `migrate verify`, so the fixer **refuses** to rewrite files whose version is recorded:
+
+```
+Refused 1 file(s) (already applied — pass --force to rewrite anyway):
+  ✗ 20260527090000_add_foo.up.sql: already applied locally
+```
+
+Pass `--force` to override — typically only safe in a development environment where you can re-apply the migration cleanly afterwards. The guard runs against the local database only; verify against other environments separately before rewriting.
+
+### Combined with `--idempotent`
+
+A single invocation can apply both fix classes; idempotency fixes run first, then ownership fixes:
+
+```bash
+confiture migrate fix --idempotent --ownership --config confiture.yaml
+```
+
+---
+
+## Combined with ACL coverage
+
+The ownership and ACL features sit on parallel axes — most projects want both.
+
+CI step covering everything at once:
+
+```bash
+confiture migrate validate \
+  --check-acl-coverage \
+  --check-ownership-coverage \
+  --config db/environments/production.yaml
+```
+
+Live drift in one query:
+
+```bash
+confiture drift \
+  --check-acls \
+  --check-ownership \
+  --config db/environments/production.yaml
+```
+
+---
+
+## Edge cases
+
+- **Extension-installed objects.** Use the `-- confiture:owner-skip` directive on the `CREATE` statement.
+- **Migrations that run as the expected role.** Use the `-- confiture:run-as <role>` front-matter directive — remember the trust boundary documented above.
+- **Partitioned tables.** `ALTER TABLE OWNER TO` does **not** cascade to partition children in older PostgreSQL versions. The drift detector flags each child individually; the auto-fixer emits `ALTER` for whatever appears as a `CREATE` in the migration.
+- **`ALTER OWNER TO` prerequisites.** The grantor must be a member of the target role. If your migrator role is freshly provisioned, ensure `GRANT migrator TO <session_role>` runs before the migration.
+- **Side effects on `SECURITY DEFINER`.** Changing ownership on a table referenced by functions/views with `SECURITY DEFINER` can shift the effective privileges those routines run with. Review carefully when auto-fixing in environments with `SECURITY DEFINER` callers.
+
+---
+
+## Related
+
+- [ACL Coverage](acl-coverage.md) — the sister feature on the grants axis.
+- [Drift Detection](git-aware-validation.md) — full drift command reference.
+- Issue history: #66 (grant-sweep accompaniment), #120 (ACL coverage), #124 (ownership — this guide).

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -1,0 +1,280 @@
+# JSON Output Schemas
+
+Every Confiture command that supports `--format json` ships with a
+machine-validatable JSON Schema. Schemas use Draft 2020-12 and live in
+`docs/reference/json-schemas/`.
+
+## For agents and tooling
+
+If you are writing a script, agent, or pipeline that consumes Confiture's
+JSON output, **read the schema for the relevant subcommand before
+depending on field names**. Schemas record exact field shapes; the
+`--help` text only describes flags.
+
+To validate output programmatically:
+
+```python
+import json
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+
+# Load the schema and the shared $defs file (referenced by relative URI).
+schema = json.loads(open("docs/reference/json-schemas/migrate-validate-idempotent.schema.json").read())
+common = json.loads(open("docs/reference/json-schemas/_common.schema.json").read())
+
+registry = Registry().with_resource(
+    uri="_common.schema.json",
+    resource=Resource.from_contents(common, default_specification=DRAFT202012),
+)
+validator = Draft202012Validator(schema, registry=registry)
+validator.validate(your_payload)  # raises ValidationError on mismatch
+```
+
+## Stability
+
+The `hints: list[string]` field is pre-allocated on every top-level
+schema and emitted as `[]` today. Future releases may populate it on
+quiet-success ambiguities (Phase 05 of issue #123). Consumers should
+*accept* the field today but not depend on specific content.
+
+Aside from `hints` population, schemas are additive — new optional fields
+may appear in patch releases, but documented `required` fields will not
+change without a top-level version bump.
+
+---
+
+## Schemas by command
+
+### `confiture migrate validate --list-patterns --format json`
+
+[migrate-validate-list-patterns.schema.json](./json-schemas/migrate-validate-list-patterns.schema.json)
+
+Machine-readable catalog of every idempotency detection pattern. **Read-only** — no DB, no config, no migrations directory required. Frozen at `version: "1"`.
+
+Minimal example:
+
+```json
+{
+  "version": "1",
+  "patterns": [
+    {
+      "id": "CREATE_TABLE",
+      "description": "CREATE TABLE without IF NOT EXISTS.",
+      "severity": "error",
+      "has_skip_regex": true,
+      "skip_hint": "CREATE TABLE IF NOT EXISTS",
+      "has_auto_fix": true
+    }
+  ],
+  "hints": []
+}
+```
+
+### `confiture migrate validate --idempotent --format json`
+
+[migrate-validate-idempotent.schema.json](./json-schemas/migrate-validate-idempotent.schema.json)
+
+Scans every migration file (`.up.sql` and embedded SQL in Python migrations) for non-idempotent patterns. Exit code 1 when blocking violations exist.
+
+```json
+{
+  "status": "issues_found",
+  "violations": [
+    {
+      "pattern": "CREATE_TABLE",
+      "sql_snippet": "CREATE TABLE users (...);",
+      "line_number": 3,
+      "file_path": "db/migrations/20260527000000_init.up.sql",
+      "source_line": null,
+      "suggestion": "Use CREATE TABLE IF NOT EXISTS",
+      "fix_available": true,
+      "severity": "error"
+    }
+  ],
+  "violation_count": 1,
+  "files_scanned": 1,
+  "scanned_files": ["..."],
+  "has_violations": true,
+  "has_blocking_violations": true,
+  "warnings": [],
+  "has_warnings": false,
+  "hints": []
+}
+```
+
+### `confiture migrate validate --check-acls --format json`
+
+[migrate-validate-check-acl-coverage.schema.json](./json-schemas/migrate-validate-check-acl-coverage.schema.json)
+
+Static check that every `CREATE TABLE` in `db/migrations/` has a matching `GRANT` either in the same migration or in the configured grant-sweep directory. No DB required.
+
+```json
+{
+  "check": "acl_coverage",
+  "violations": [
+    {
+      "rule_id": "ACL001",
+      "severity": "error",
+      "object_name": "public.orders",
+      "message": "No GRANT statement found for public.orders",
+      "file_path": "db/migrations/20260527000000_init.up.sql"
+    }
+  ],
+  "hints": []
+}
+```
+
+### `confiture migrate status --format json`
+
+[migrate-status.schema.json](./json-schemas/migrate-status.schema.json)
+
+Migration status report. Without `--config`, per-migration `status` is `unknown` (file-based listing only). With `--config`, status is `applied` or `pending`.
+
+```json
+{
+  "tracking_table": "tb_confiture",
+  "applied": ["20260101000000"],
+  "pending": ["20260527000000"],
+  "current": "20260101000000",
+  "total": 2,
+  "migrations": [
+    {"version": "20260101000000", "name": "init", "status": "applied", "applied_at": "2026-01-01T00:00:00Z"},
+    {"version": "20260527000000", "name": "add_orders", "status": "pending", "applied_at": null}
+  ],
+  "summary": {"applied": 1, "pending": 1, "total": 2},
+  "hints": []
+}
+```
+
+### `confiture migrate fix --idempotent --format json`
+
+[migrate-fix.schema.json](./json-schemas/migrate-fix.schema.json)
+
+Rewrites non-idempotent SQL files in place (or previews with `--dry-run`). Python migrations are listed under `manual_fix_required` — never rewritten.
+
+```json
+{
+  "status": "fixed",
+  "files": [
+    {
+      "file": "20260527000000_init.up.sql",
+      "changes": [
+        {"pattern": "CREATE_TABLE", "original": "...", "suggested_fix": "...", "line": 3}
+      ]
+    }
+  ],
+  "total_files_changed": 1,
+  "manual_fix_required": [],
+  "hints": []
+}
+```
+
+### `confiture migrate preflight --format json` (no `--against`)
+
+[migrate-preflight.schema.json](./json-schemas/migrate-preflight.schema.json)
+
+Static preflight analysis — per-migration reversibility, transactionality, duplicate version prefixes, checksum mismatches. No DB required.
+
+### `confiture migrate preflight --against <url> --format json`
+
+[migrate-preflight-against.schema.json](./json-schemas/migrate-preflight-against.schema.json)
+
+Static analysis + exhaustive execution against a preflight database. Returns a two-level shape: `static` (same as no-`--against`) and `against` (execution outcomes).
+
+```json
+{
+  "static": { "...": "PreflightResult.to_dict() shape" },
+  "against": {
+    "against_url": "postgresql://user@host/preflight",
+    "all_passed": true,
+    "total": 1,
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "db_consumed": false,
+    "migrations": [
+      {
+        "version": "20260527000000",
+        "name": "init",
+        "success": true,
+        "error": null,
+        "skipped": false,
+        "skipped_reason": null,
+        "execution_time_ms": 42
+      }
+    ]
+  },
+  "hints": []
+}
+```
+
+### `confiture drift --format json`
+
+[drift.schema.json](./json-schemas/drift.schema.json)
+
+Live-database drift report against expected DDL.
+
+### `confiture drift --check-acls --format json`
+
+[drift-check-acls.schema.json](./json-schemas/drift-check-acls.schema.json)
+
+Shape is identical to plain `drift` — items of type `missing_grant` / `extra_grant` may appear in `drift_items`.
+
+---
+
+## Field-name traps (issue #123)
+
+Several JSON field names have diverged from the obvious guess. The schemas
+record the canonical names; this list calls them out explicitly so
+agents can grep for the wrong name.
+
+### `ExtractedSQL.source_line` (NOT `line_number`)
+
+When a Python migration embeds SQL (via `cursor.execute(...)` or similar),
+the validator records **two** line numbers:
+
+* `line_number` — line within the embedded SQL string
+* `source_line` — line within the `.py` file where the call appears
+
+If you only need the file-level position to show the user, use
+`source_line`. There is no field named `line_number_py` or
+`py_line_number`.
+
+### `ExtractionResult.snippets` (NOT `sql`)
+
+The intermediate representation for extracted SQL is called `snippets`,
+not `sql`. There is no `.sql` attribute on `ExtractionResult`. Each
+entry in `snippets` is an `ExtractedSQL` with its own `source_line`.
+
+### `against.migrations[].success` (NOT `passed`)
+
+Each per-migration entry in `migrate preflight --against` carries
+`success: bool` — not `passed`. The aggregate counters at the
+`against.` level use both: `against.passed` is an integer count;
+`against.all_passed` is the boolean aggregate. Don't confuse them.
+
+### `severity` is required
+
+Every `Violation` (idempotency) and `DriftItem` (drift) MUST have a
+`severity` field. If you see a payload where `severity` is missing,
+that's a bug — please file an issue. The schemas mark `severity` as
+required so any missing-severity payload fails validation.
+
+---
+
+## Shared sub-schemas
+
+The `_common.schema.json` file holds shared `$defs`:
+
+* `Violation` — used by `migrate validate --idempotent`
+* `ExtractorWarning` — dynamic-SQL warnings
+* `DriftItem` — used by `drift`
+* `HintsArray` — the `hints` field (pre-allocated for Phase 05)
+
+The `_preflight_defs.schema.json` file holds preflight-specific
+sub-schemas shared between `migrate-preflight.schema.json` and
+`migrate-preflight-against.schema.json`:
+
+* `StaticPreflight` — the `PreflightResult.to_dict()` shape
+* `DependentAnalysis` — the optional dependent-objects analysis

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -64,7 +64,8 @@ Minimal example:
       "severity": "error",
       "has_skip_regex": true,
       "skip_hint": "CREATE TABLE IF NOT EXISTS",
-      "has_auto_fix": true
+      "has_auto_fix": true,
+      "template_fillable": true
     }
   ],
   "hints": []

--- a/docs/reference/json-schemas/_common.schema.json
+++ b/docs/reference/json-schemas/_common.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/_common.schema.json",
+  "title": "Confiture common JSON-Schema definitions",
+  "description": "Shared sub-schemas referenced by per-command output schemas in this directory. Stable contract: changes require a top-level version bump in each consuming schema.",
+  "$defs": {
+    "HintsArray": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Advisory hints emitted on quiet-success states (e.g. zero migration files found, empty tracking table). Always present. Empty list when no hints are applicable. Hints never change the exit code — agents may treat presence of items as 'this success looks unusual'."
+    },
+    "Violation": {
+      "type": "object",
+      "description": "A single non-idempotent SQL pattern detected in a migration file.",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Stable pattern id (see migrate-validate-list-patterns.schema.json for the full enumeration)."
+        },
+        "sql_snippet": { "type": "string" },
+        "line_number": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Line number where the violation starts. For .py migrations this is the line within the embedded SQL; see `source_line` for the .py file line."
+        },
+        "file_path": { "type": "string" },
+        "source_line": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Line number in the source file (.py file or .sql file). Only present when different from `line_number` — i.e. SQL embedded in a Python migration. NOTE: field name is `source_line`, NOT `line_number`."
+        },
+        "suggestion": {
+          "type": "string",
+          "description": "Suggested fix template. Placeholders may be filled with captured identifiers (table name, constraint name, etc.) when available."
+        },
+        "fix_available": {
+          "type": "boolean",
+          "description": "True when `confiture migrate fix --idempotent` can rewrite this violation automatically."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "info"],
+          "description": "`error` fails the gate (exit 1). `info` is a heuristic finding (e.g. CREATE OR REPLACE VIEW shape-risk) that's rendered but does NOT fail the gate unless `--strict-cor` is passed."
+        }
+      },
+      "required": [
+        "pattern",
+        "sql_snippet",
+        "line_number",
+        "file_path",
+        "suggestion",
+        "fix_available",
+        "severity"
+      ]
+    },
+    "ExtractorWarning": {
+      "type": "object",
+      "description": "A dynamic-SQL call the validator could not statically reach (e.g. f-string SQL, computed identifiers). Recorded so the user knows idempotency cannot be guaranteed for these snippets.",
+      "properties": {
+        "kind": { "type": "string" },
+        "source_file": { "type": "string" },
+        "source_line": { "type": "integer", "minimum": 1 },
+        "message": { "type": "string" }
+      },
+      "required": ["kind", "source_file", "source_line", "message"]
+    },
+    "DriftItem": {
+      "type": "object",
+      "description": "A single schema-drift finding between live database and expected DDL.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "missing_table",
+            "extra_table",
+            "missing_column",
+            "extra_column",
+            "type_mismatch",
+            "nullable_mismatch",
+            "default_mismatch",
+            "missing_index",
+            "extra_index",
+            "missing_constraint",
+            "extra_constraint",
+            "missing_grant",
+            "extra_grant",
+            "wrong_owner"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["critical", "warning", "info"]
+        },
+        "object": { "type": "string" },
+        "expected": { "type": ["string", "null"] },
+        "actual": { "type": ["string", "null"] },
+        "message": { "type": "string" }
+      },
+      "required": ["type", "severity", "object", "message"]
+    }
+  }
+}

--- a/docs/reference/json-schemas/_preflight_defs.schema.json
+++ b/docs/reference/json-schemas/_preflight_defs.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/_preflight_defs.schema.json",
+  "title": "Confiture preflight $defs",
+  "description": "Sub-schemas shared by migrate-preflight.schema.json and migrate-preflight-against.schema.json.",
+  "$defs": {
+    "StaticPreflight": {
+      "type": "object",
+      "description": "Static analysis output (PreflightResult.to_dict). Reports per-migration reversibility and transactionality.",
+      "required": [
+        "safe_to_deploy",
+        "all_reversible",
+        "all_transactional",
+        "has_duplicates",
+        "has_checksum_mismatches",
+        "checksum_verified",
+        "migrations",
+        "duplicate_versions",
+        "checksum_mismatches"
+      ],
+      "properties": {
+        "safe_to_deploy": { "type": "boolean" },
+        "all_reversible": { "type": "boolean" },
+        "all_transactional": { "type": "boolean" },
+        "has_duplicates": { "type": "boolean" },
+        "has_checksum_mismatches": { "type": "boolean" },
+        "checksum_verified": { "type": "boolean" },
+        "migrations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "version",
+              "name",
+              "has_down",
+              "reversible",
+              "fully_transactional",
+              "non_transactional_statements",
+              "checksum"
+            ],
+            "properties": {
+              "version": { "type": "string" },
+              "name": { "type": "string" },
+              "has_down": { "type": "boolean" },
+              "reversible": { "type": "boolean" },
+              "fully_transactional": { "type": "boolean" },
+              "non_transactional_statements": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "checksum": { "type": ["string", "null"] }
+            }
+          }
+        },
+        "duplicate_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "checksum_mismatches": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "DependentAnalysis": {
+      "type": "object",
+      "description": "Live-DB dependent-object analysis for CREATE OR REPLACE targets in pending migrations.",
+      "required": ["status", "entries", "has_blocking"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["ok", "skipped"]
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "schema",
+              "name",
+              "qualified",
+              "source_file",
+              "source_line",
+              "severity",
+              "dependents"
+            ],
+            "properties": {
+              "kind": { "type": "string" },
+              "schema": { "type": "string" },
+              "name": { "type": "string" },
+              "qualified": { "type": "string" },
+              "source_file": { "type": ["string", "null"] },
+              "source_line": { "type": ["integer", "null"] },
+              "severity": {
+                "type": "string",
+                "enum": ["error", "info"]
+              },
+              "dependents": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["kind", "schema", "name", "referenced_columns"],
+                  "properties": {
+                    "kind": { "type": "string" },
+                    "schema": { "type": "string" },
+                    "name": { "type": "string" },
+                    "referenced_columns": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "has_blocking": { "type": "boolean" },
+        "skip_reason": {
+          "type": "string",
+          "description": "Present only when status == \"skipped\". Identifies why the check didn't run (e.g. \"no_preflight_db\", \"no_pglast\")."
+        }
+      }
+    }
+  }
+}

--- a/docs/reference/json-schemas/drift-check-acls.schema.json
+++ b/docs/reference/json-schemas/drift-check-acls.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/drift-check-acls.schema.json",
+  "title": "confiture drift --check-acls --format json",
+  "description": "Drift report including ACL coverage findings. Shape is identical to `drift.schema.json`; the difference is that `drift_items` may include items with `type` ∈ {`missing_grant`, `extra_grant`}. Provided as a separate file so consumers wanting ACL-aware drift can reference it explicitly.",
+  "$ref": "drift.schema.json"
+}

--- a/docs/reference/json-schemas/drift.schema.json
+++ b/docs/reference/json-schemas/drift.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/drift.schema.json",
+  "title": "confiture drift --format json",
+  "description": "Schema drift report comparing the live database to expected DDL. Used by `confiture drift` (structural drift only). When `--check-acls` is also passed, ACL drift items are appended to the same `drift_items` array — see drift-check-acls.schema.json for the augmented contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "database_name",
+    "expected_schema_source",
+    "has_drift",
+    "has_critical_drift",
+    "critical_count",
+    "warning_count",
+    "info_count",
+    "tables_checked",
+    "columns_checked",
+    "indexes_checked",
+    "detection_time_ms",
+    "drift_items",
+    "hints"
+  ],
+  "properties": {
+    "database_name": { "type": "string" },
+    "expected_schema_source": {
+      "type": "string",
+      "description": "Either `\"migrations\"` or a file path."
+    },
+    "has_drift": { "type": "boolean" },
+    "has_critical_drift": { "type": "boolean" },
+    "critical_count": { "type": "integer", "minimum": 0 },
+    "warning_count": { "type": "integer", "minimum": 0 },
+    "info_count": { "type": "integer", "minimum": 0 },
+    "tables_checked": { "type": "integer", "minimum": 0 },
+    "columns_checked": { "type": "integer", "minimum": 0 },
+    "indexes_checked": { "type": "integer", "minimum": 0 },
+    "detection_time_ms": { "type": "integer", "minimum": 0 },
+    "drift_items": {
+      "type": "array",
+      "items": { "$ref": "_common.schema.json#/$defs/DriftItem" }
+    },
+    "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+  }
+}

--- a/docs/reference/json-schemas/migrate-fix.schema.json
+++ b/docs/reference/json-schemas/migrate-fix.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-fix.schema.json",
+  "title": "confiture migrate fix --idempotent --format json",
+  "description": "Report from `migrate fix --idempotent`. SQL files are rewritten in place (unless --dry-run). Python migrations are listed under `manual_fix_required` — never rewritten, since unparsing the AST would lose comments and formatting.",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "files", "total_files_changed", "manual_fix_required", "hints"],
+      "description": "Standard fix-report shape (and the empty-migrations-dir shape uses the same envelope with empty arrays).",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["ok", "fixed", "preview"],
+          "description": "`ok` — nothing to fix. `fixed` — changes applied to disk. `preview` — --dry-run, no changes written."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["file", "changes"],
+            "properties": {
+              "file": { "type": "string" },
+              "changes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["pattern", "original", "suggested_fix", "line"],
+                  "properties": {
+                    "pattern": { "type": "string" },
+                    "original": { "type": "string" },
+                    "suggested_fix": { "type": "string" },
+                    "line": { "type": "integer", "minimum": 1 }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "total_files_changed": { "type": "integer", "minimum": 0 },
+        "manual_fix_required": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Paths of .py migration files containing non-idempotent SQL. The user must edit them by hand."
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "$ref": "_common.schema.json#/$defs/ExtractorWarning" },
+          "description": "Optional. Present only when the extractor encountered dynamic SQL it couldn't analyse statically."
+        },
+        "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "message", "files", "hints"],
+      "description": "Empty-input shape: no migration files found.",
+      "properties": {
+        "status": { "type": "string", "const": "ok" },
+        "message": { "type": "string" },
+        "files": { "type": "array", "maxItems": 0 },
+        "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+      }
+    }
+  ]
+}

--- a/docs/reference/json-schemas/migrate-preflight-against.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight-against.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-preflight-against.schema.json",
+  "title": "confiture migrate preflight --against <url> --format json",
+  "description": "Static preflight + exhaustive execution against a preflight database. The static section is the same shape as migrate-preflight without --against; the against section reports per-migration execution outcomes.\n\nField-name traps (per issue #123):\n• `against.migrations[].success` — NOT `passed`. Use `against.passed` (integer count) and `against.all_passed` (boolean aggregate) for the totals.\n• Each migration has both `success` (per-migration) and `skipped` (skipped non-transactional). A `skipped` migration is NOT a failure.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["static", "against", "hints"],
+  "properties": {
+    "static": { "$ref": "_preflight_defs.schema.json#/$defs/StaticPreflight" },
+    "against": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "against_url",
+        "all_passed",
+        "total",
+        "passed",
+        "failed",
+        "skipped",
+        "db_consumed",
+        "migrations"
+      ],
+      "properties": {
+        "against_url": {
+          "type": "string",
+          "description": "Preflight database URL with the password stripped (the username is preserved)."
+        },
+        "all_passed": { "type": "boolean" },
+        "total": { "type": "integer", "minimum": 0 },
+        "passed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of migrations that succeeded. NOT a per-migration boolean field — see `migrations[].success` for that."
+        },
+        "failed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "db_consumed": {
+          "type": "boolean",
+          "description": "True when non-transactional migrations ran outside the SAVEPOINT (--allow-non-transactional). The preflight DB is no longer in its original state."
+        },
+        "migrations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "version",
+              "name",
+              "success",
+              "error",
+              "skipped",
+              "skipped_reason",
+              "execution_time_ms"
+            ],
+            "properties": {
+              "version": { "type": "string" },
+              "name": { "type": "string" },
+              "success": {
+                "type": "boolean",
+                "description": "Per-migration execution result. NOTE: field is named `success`, NOT `passed`."
+              },
+              "error": { "type": ["string", "null"] },
+              "skipped": { "type": "boolean" },
+              "skipped_reason": { "type": ["string", "null"] },
+              "execution_time_ms": { "type": "integer", "minimum": 0 }
+            }
+          }
+        }
+      }
+    },
+    "dependent_analysis": {
+      "$ref": "_preflight_defs.schema.json#/$defs/DependentAnalysis"
+    },
+    "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+  }
+}

--- a/docs/reference/json-schemas/migrate-preflight.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-preflight.schema.json",
+  "title": "confiture migrate preflight --format json (no --against)",
+  "description": "Static preflight analysis output. Reports per-migration reversibility (.down.sql present), transactionality, duplicate version prefixes, and checksum mismatches. No database connection required.",
+  "allOf": [
+    { "$ref": "_preflight_defs.schema.json#/$defs/StaticPreflight" },
+    {
+      "type": "object",
+      "required": ["hints"],
+      "properties": {
+        "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" },
+        "dependent_analysis": {
+          "$ref": "_preflight_defs.schema.json#/$defs/DependentAnalysis"
+        }
+      }
+    }
+  ]
+}

--- a/docs/reference/json-schemas/migrate-status.schema.json
+++ b/docs/reference/json-schemas/migrate-status.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-status.schema.json",
+  "title": "confiture migrate status --format json",
+  "description": "Migration status report. Without --config the per-migration `status` is `unknown` (file-based listing only). With --config, status is `applied` or `pending` and `applied_at` is populated for `applied` entries.",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Empty-input shape: no migration files in the directory.",
+      "required": ["applied", "pending", "current", "total", "migrations", "hints"],
+      "properties": {
+        "applied": { "type": "array", "maxItems": 0 },
+        "pending": { "type": "array", "maxItems": 0 },
+        "current": { "type": "null" },
+        "total": { "type": "integer", "const": 0 },
+        "migrations": { "type": "array", "maxItems": 0 },
+        "orphaned_migrations": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Populated shape: at least one migration file in the directory.",
+      "required": [
+        "tracking_table",
+        "applied",
+        "pending",
+        "current",
+        "total",
+        "migrations",
+        "summary",
+        "hints"
+      ],
+      "properties": {
+        "tracking_table": {
+          "type": ["string", "null"],
+          "description": "Configured tracking table name. NULL when no --config was supplied."
+        },
+        "applied": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Version prefixes of applied migrations."
+        },
+        "pending": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "current": {
+          "type": ["string", "null"],
+          "description": "Highest applied version, or NULL if none applied."
+        },
+        "total": { "type": "integer", "minimum": 0 },
+        "migrations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["version", "name", "status", "applied_at"],
+            "properties": {
+              "version": { "type": "string" },
+              "name": { "type": "string" },
+              "status": {
+                "type": "string",
+                "enum": ["applied", "pending", "unknown"],
+                "description": "`unknown` when no --config was provided or the DB connection failed; `applied`/`pending` otherwise."
+              },
+              "applied_at": {
+                "description": "Timestamp the migration was applied. NULL for `pending` and `unknown` entries."
+              }
+            }
+          }
+        },
+        "summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["applied", "pending", "total"],
+          "properties": {
+            "applied": { "type": "integer", "minimum": 0 },
+            "pending": { "type": "integer", "minimum": 0 },
+            "total": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "warning": {
+          "type": "string",
+          "description": "Present when the tracking table is missing or the DB connection failed; the message tells the user what to do next."
+        },
+        "orphaned_migrations": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "duplicate_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "description": "Map of version-prefix → list of file names sharing that prefix."
+        },
+        "rebuild_recommended": { "type": "boolean" },
+        "rebuild_reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+      }
+    }
+  ]
+}

--- a/docs/reference/json-schemas/migrate-validate-check-acl-coverage.schema.json
+++ b/docs/reference/json-schemas/migrate-validate-check-acl-coverage.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-validate-check-acl-coverage.schema.json",
+  "title": "confiture migrate validate --check-acls --format json",
+  "description": "Static ACL coverage report: every `CREATE TABLE` in db/migrations/ must have a matching `GRANT` in the same migration or in the configured grant-sweep directory.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["check", "violations", "hints"],
+  "properties": {
+    "check": {
+      "type": "string",
+      "const": "acl_coverage"
+    },
+    "violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rule_id", "severity", "object_name", "message", "file_path"],
+        "properties": {
+          "rule_id": { "type": "string" },
+          "severity": {
+            "type": "string",
+            "enum": ["error", "warning", "info"]
+          },
+          "object_name": { "type": "string" },
+          "message": { "type": "string" },
+          "file_path": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+  }
+}

--- a/docs/reference/json-schemas/migrate-validate-idempotent.schema.json
+++ b/docs/reference/json-schemas/migrate-validate-idempotent.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-validate-idempotent.schema.json",
+  "title": "confiture migrate validate --idempotent --format json",
+  "description": "Idempotency validation report — scans every migration file (SQL + Python) for non-idempotent SQL patterns. Empty-input shape (no migration files found) replaces the violations report with a `message` field.",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "violations",
+        "violation_count",
+        "files_scanned",
+        "scanned_files",
+        "has_violations",
+        "has_blocking_violations",
+        "warnings",
+        "has_warnings",
+        "hints"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["ok", "issues_found"]
+        },
+        "violations": {
+          "type": "array",
+          "items": { "$ref": "_common.schema.json#/$defs/Violation" }
+        },
+        "violation_count": { "type": "integer", "minimum": 0 },
+        "files_scanned": { "type": "integer", "minimum": 0 },
+        "scanned_files": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "has_violations": { "type": "boolean" },
+        "has_blocking_violations": {
+          "type": "boolean",
+          "description": "True when any violation has severity=error. info-only findings keep this false unless --strict-cor is passed."
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "$ref": "_common.schema.json#/$defs/ExtractorWarning" }
+        },
+        "has_warnings": { "type": "boolean" },
+        "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "message", "violations", "hints"],
+      "description": "Empty-input shape: no migration files found.",
+      "properties": {
+        "status": { "type": "string", "const": "ok" },
+        "message": { "type": "string" },
+        "violations": {
+          "type": "array",
+          "maxItems": 0
+        },
+        "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+      }
+    }
+  ]
+}

--- a/docs/reference/json-schemas/migrate-validate-idempotent.schema.json
+++ b/docs/reference/json-schemas/migrate-validate-idempotent.schema.json
@@ -17,6 +17,7 @@
         "has_blocking_violations",
         "warnings",
         "has_warnings",
+        "meta",
         "hints"
       ],
       "properties": {
@@ -44,13 +45,24 @@
           "items": { "$ref": "_common.schema.json#/$defs/ExtractorWarning" }
         },
         "has_warnings": { "type": "boolean" },
+        "meta": {
+          "type": "object",
+          "required": ["backend"],
+          "properties": {
+            "backend": {
+              "type": "string",
+              "enum": ["ast", "regex"],
+              "description": "Which detection backend ran. `ast` = pglast-backed AST (preferred); `regex` = fallback when pglast is missing or CONFITURE_IDEMPOTENCY_FORCE_REGEX=1 is set."
+            }
+          }
+        },
         "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
       }
     },
     {
       "type": "object",
       "additionalProperties": false,
-      "required": ["status", "message", "violations", "hints"],
+      "required": ["status", "message", "violations", "meta", "hints"],
       "description": "Empty-input shape: no migration files found.",
       "properties": {
         "status": { "type": "string", "const": "ok" },
@@ -58,6 +70,13 @@
         "violations": {
           "type": "array",
           "maxItems": 0
+        },
+        "meta": {
+          "type": "object",
+          "required": ["backend"],
+          "properties": {
+            "backend": { "type": "string", "enum": ["ast", "regex"] }
+          }
         },
         "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
       }

--- a/docs/reference/json-schemas/migrate-validate-list-patterns.schema.json
+++ b/docs/reference/json-schemas/migrate-validate-list-patterns.schema.json
@@ -23,7 +23,8 @@
           "severity",
           "has_skip_regex",
           "skip_hint",
-          "has_auto_fix"
+          "has_auto_fix",
+          "template_fillable"
         ],
         "properties": {
           "id": {
@@ -49,6 +50,10 @@
           "has_auto_fix": {
             "type": "boolean",
             "description": "True when `migrate fix --idempotent` can rewrite this pattern automatically."
+          },
+          "template_fillable": {
+            "type": "boolean",
+            "description": "True when the validator can fill a captures-driven SQL suggestion template for this pattern (e.g. inlining table/constraint names). False when the suggestion stays generic and explicitly says manual fix required."
           }
         }
       }

--- a/docs/reference/json-schemas/migrate-validate-list-patterns.schema.json
+++ b/docs/reference/json-schemas/migrate-validate-list-patterns.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-validate-list-patterns.schema.json",
+  "title": "confiture migrate validate --list-patterns --format json",
+  "description": "Machine-readable catalog of every idempotency detection pattern. Read-only — no DB connection, no config file, no migrations directory required. Stable contract: frozen at `version: \"1\"`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "patterns", "hints"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1",
+      "description": "Catalog shape version. Bumps to \"2\" only if fields are removed or semantics change; additions are additive and keep version \"1\"."
+    },
+    "patterns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "description",
+          "severity",
+          "has_skip_regex",
+          "skip_hint",
+          "has_auto_fix"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "IdempotencyPattern enum name. Stable identifier — safe to depend on."
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of what the pattern detects."
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["error", "info"]
+          },
+          "has_skip_regex": {
+            "type": "boolean",
+            "description": "True when the validator recognises an idempotent form for this pattern (e.g. CREATE TABLE IF NOT EXISTS)."
+          },
+          "skip_hint": {
+            "type": ["string", "null"],
+            "description": "Human-friendly text describing the idempotent form (e.g. \"CREATE TABLE IF NOT EXISTS\"). NULL when has_skip_regex is false."
+          },
+          "has_auto_fix": {
+            "type": "boolean",
+            "description": "True when `migrate fix --idempotent` can rewrite this pattern automatically."
+          }
+        }
+      }
+    },
+    "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.15.0"
+version = "0.16.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.14.0"
+version = "0.15.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "pglast>=6.0",
     "fastapi>=0.111",
     "httpx>=0.27",
+    "jsonschema>=4",  # Validate JSON output schemas in docs/reference/json-schemas/
 ]
 
 fraiseql = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.16.0"
+version = "0.16.1"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/drift.py
+++ b/python/confiture/cli/commands/drift.py
@@ -172,8 +172,9 @@ def drift(
         if format_output == "json":
             payload = drift_report.to_dict()
             # `hints` is pre-allocated per the documented JSON-schema contract
-            # (docs/reference/json-schemas/drift.schema.json). Empty by default;
-            # Phase 05 may populate it on quiet-success ambiguities.
+            # (docs/reference/json-schemas/drift.schema.json). Currently
+            # always empty; the contract guarantees the key exists so
+            # agents can read `payload["hints"]` without a defensive get().
             payload["hints"] = []
             print(json.dumps(payload, indent=2, default=str))
         else:

--- a/python/confiture/cli/commands/drift.py
+++ b/python/confiture/cli/commands/drift.py
@@ -97,6 +97,12 @@ def drift(
       1 - Drift detected (critical, or warning when --fail-on-warning)
       2 - Connection or configuration error
 
+    JSON SCHEMA:
+      See docs/reference/json-schemas.md for the JSON output schemas:
+        - default: drift.schema.json
+        - with --check-acls: drift-check-acls.schema.json (same shape;
+          missing_grant / extra_grant items may appear in drift_items)
+
     RELATED:
       confiture migrate validate --check-live-drift - Validate within migrate workflow
       confiture migrate diff                        - Compare two schema files
@@ -164,7 +170,12 @@ def drift(
             _demote_missing_grant_warnings(drift_report)
 
         if format_output == "json":
-            print(json.dumps(drift_report.to_dict(), indent=2, default=str))
+            payload = drift_report.to_dict()
+            # `hints` is pre-allocated per the documented JSON-schema contract
+            # (docs/reference/json-schemas/drift.schema.json). Empty by default;
+            # Phase 05 may populate it on quiet-success ambiguities.
+            payload["hints"] = []
+            print(json.dumps(payload, indent=2, default=str))
         else:
             display_drift_report(drift_report, console)
 

--- a/python/confiture/cli/commands/drift.py
+++ b/python/confiture/cli/commands/drift.py
@@ -8,13 +8,15 @@ import typer
 from confiture.cli.acl_loader import load_acl_expectations
 from confiture.cli.formatters.common import display_drift_report
 from confiture.cli.helpers import console, error_console
-from confiture.config.environment import AclExpectation
+from confiture.cli.ownership_loader import load_ownership_expectation
+from confiture.config.environment import AclExpectation, OwnershipExpectation
 from confiture.core.connection import create_connection, load_config
 from confiture.core.drift import (
     AclDriftDetector,
     DriftReport,
     DriftSeverity,
     DriftType,
+    OwnershipDriftDetector,
     SchemaDriftDetector,
 )
 from confiture.exceptions import ConfigurationError
@@ -43,6 +45,11 @@ def drift(
         False,
         "--check-acls",
         help="Also compare live grants against the `acls:` block in the config",
+    ),
+    check_ownership: bool = typer.Option(
+        False,
+        "--check-ownership",
+        help="Also compare live `pg_class.relowner` against the `ownership:` block",
     ),
     warn_only: bool = typer.Option(
         False,
@@ -105,20 +112,26 @@ def drift(
             error_console.print(f"[red]❌ Config file not found: {config}[/red]")
             raise typer.Exit(2)
 
-        if schema is None and not check_acls:
+        if schema is None and not check_acls and not check_ownership:
             error_console.print(
-                "[red]❌ --schema is required (or use --check-acls). "
+                "[red]❌ --schema is required (or use --check-acls / --check-ownership). "
                 "Provide a schema SQL file to compare against.[/red]"
             )
             raise typer.Exit(2)
 
         config_data = load_config(config)
 
-        # Load ACL expectations up-front so config errors fail before we
-        # even open a database connection.
+        # Load ACL + ownership expectations up-front so config errors fail
+        # before we even open a database connection.
         expectations: list[AclExpectation] = []
         if check_acls:
             expectations = load_acl_expectations(config_data, config, require=True)
+
+        ownership_expectation: OwnershipExpectation | None = None
+        if check_ownership:
+            ownership_expectation = load_ownership_expectation(
+                config_data, config, require=True
+            )
 
         conn = create_connection(config_data)
 
@@ -127,18 +140,23 @@ def drift(
             if schema is not None:
                 structural_report = SchemaDriftDetector(conn).compare_with_schema_file(str(schema))
 
+            drift_report: DriftReport | None = structural_report
             if check_acls:
                 acl_report = AclDriftDetector(conn).check(expectations)
-                if structural_report is None:
+                if drift_report is None:
                     drift_report = acl_report
                 else:
-                    # Compose both into the structural report so downstream
-                    # formatters / exit-code logic see a single DriftReport.
-                    structural_report.drift_items.extend(acl_report.drift_items)
-                    drift_report = structural_report
-            else:
-                assert structural_report is not None  # guarded by --schema/--check-acls check above
-                drift_report = structural_report
+                    drift_report.drift_items.extend(acl_report.drift_items)
+
+            if check_ownership:
+                assert ownership_expectation is not None  # require=True above
+                own_report = OwnershipDriftDetector(conn).check(ownership_expectation)
+                if drift_report is None:
+                    drift_report = own_report
+                else:
+                    drift_report.drift_items.extend(own_report.drift_items)
+
+            assert drift_report is not None  # guarded by the schema/--check-* check above
         finally:
             conn.close()
 

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -163,7 +163,15 @@ def _emit_pattern_catalog(format_output: str, output_file: Path | None) -> None:
     entries = list_patterns()
 
     if format_output == "json":
-        _output_json({"version": "1", "patterns": entries}, output_file, console)
+        # `hints` is pre-allocated per the documented JSON-schema contract
+        # (docs/reference/json-schemas/migrate-validate-list-patterns.schema.json).
+        # Phase 05 will populate it on quiet-success ambiguities; today it's
+        # an empty array so consumers can code against a stable shape.
+        _output_json(
+            {"version": "1", "patterns": entries, "hints": []},
+            output_file,
+            console,
+        )
         return
 
     # Text mode: compact table for human eyes.
@@ -650,6 +658,7 @@ def migrate_validate(
                             }
                             for v in (acl_report.errors + acl_report.warnings + acl_report.info)
                         ],
+                        "hints": [],
                     },
                     output_file,
                     console,
@@ -1151,6 +1160,10 @@ def migrate_fix(
 
       confiture migrate fix --idempotent --format json --output fixes.json
         ↳ Generate JSON report of all transformations
+
+    JSON SCHEMA:
+      See docs/reference/json-schemas.md for the JSON output schema
+      (migrate-fix.schema.json).
 
     RELATED:
       confiture migrate validate - Check migration quality
@@ -2200,6 +2213,11 @@ def migrate_preflight(
       0 — all migrations safe to deploy (skipped non-transactional migrations are neutral)
       1 — one or more issues detected or execution failures
       2 — config or connection error
+
+    JSON SCHEMA:
+      See docs/reference/json-schemas.md for the JSON output schemas:
+        - default: migrate-preflight.schema.json
+        - with --against: migrate-preflight-against.schema.json
     """
     from rich.table import Table
 
@@ -2229,6 +2247,7 @@ def migrate_preflight(
             payload = result.to_dict()
             if dependent_skip_payload is not None:
                 payload["dependent_analysis"] = dependent_skip_payload
+            payload["hints"] = []
             _output_json(payload, None, console)
             if not result.safe_to_deploy:
                 raise typer.Exit(1)
@@ -2332,6 +2351,7 @@ def migrate_preflight(
         payload: dict[str, Any] = {
             "static": result.to_dict(),
             "against": against_result.to_dict(),
+            "hints": [],
         }
         if dependent_report is not None:
             payload["dependent_analysis"] = dependent_report.to_dict()

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -441,6 +441,27 @@ def migrate_validate(
       confiture migrate validate --check-live-drift --check-signatures --env production --schema schema.sql
         ↳ Live: check both column/table drift AND function overload drift
 
+      confiture migrate validate --list-patterns --format json
+        ↳ Print the catalog of every detection pattern (machine-readable, no DB needed)
+
+      confiture migrate validate --check-acls -c db/environments/prod.yaml
+        ↳ Static: verify every CREATE TABLE has a matching GRANT (no DB needed)
+
+    FLAG INTERACTIONS:
+      --check-signatures takes both a singular --schema and a plural --schemas:
+        --schema FILE       Path to a *SQL file* to compare function signatures against.
+                            If omitted, schema is auto-built from db/schema/ DDL files.
+        --schemas LIST      Comma-separated list of *database schema names* (default: public)
+                            to scan in the live DB for stale overloads.
+        They're different things — file path vs. DB schema names — and both flags can
+        appear in the same invocation.
+
+    JSON SCHEMA:
+      See docs/reference/json-schemas.md for the JSON output schemas:
+        - --idempotent: migrate-validate-idempotent.schema.json
+        - --list-patterns: migrate-validate-list-patterns.schema.json
+        - --check-acls: migrate-validate-check-acl-coverage.schema.json
+
     RELATED:
       confiture migrate generate - Create new migration file
       confiture migrate fix      - Auto-fix non-idempotent migrations
@@ -2183,6 +2204,23 @@ def migrate_preflight(
     Verifies reversibility (.down.sql exists), detects non-transactional
     statements (CREATE INDEX CONCURRENTLY, etc.), checks for duplicate
     versions, and verifies checksums of applied migrations.
+
+    MODES:
+      Default mode — static analysis only. No --against, no DB connection.
+        Scans local migration files and reports per-file reversibility +
+        transactionality. Cannot detect "is this migration already
+        applied?" because there's no source of truth to compare against.
+
+      Explicit source mode — --against <url> [+ --config OR --env OR --since]
+        Replays pending migrations inside a SAVEPOINT against a preflight
+        DB and reports per-migration success/failure. Source of "pending"
+        is determined by the flag combination:
+          • --against alone        → all local files
+          • --against + --config   → pending files (read tb_confiture from
+                                     the --config DB, not from --against)
+          • --against + --env      → same, using db/environments/{env}.yaml
+          • --against + --since V  → all files with version >= V (no DB
+                                     needed for pending detection)
 
     EXAMPLES:
       confiture migrate preflight

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -10,6 +10,7 @@ import typer
 from confiture.cli.formatters.common import display_drift_report, display_signature_drift_report
 from confiture.cli.helpers import (
     _fix_idempotency,
+    _fix_ownership,
     _output_json,
     _resolve_config,
     _validate_idempotency,
@@ -287,6 +288,16 @@ def migrate_validate(
             "sweep directory (defaults to db/7_grant). No-op when the config has no "
             "`acls:` block. No database connection required.  "
             "Use --check-acls; --check-acl-coverage is a deprecated alias."
+        ),
+    ),
+    check_ownership_coverage: bool = typer.Option(
+        False,
+        "--check-ownership-coverage",
+        help=(
+            "Static: verify every `CREATE { TABLE | VIEW | MATERIALIZED VIEW | SEQUENCE }` "
+            "in db/migrations/ is paired with a matching `ALTER … OWNER TO <expected_owner>` "
+            "in the same file.  No-op when the config has no `ownership:` block, or when "
+            "`ownership.lint_enabled` is false.  Requires the [ast] extra (pglast)."
         ),
     ),
     check_signature_schemas: str = typer.Option(
@@ -596,6 +607,65 @@ def migrate_validate(
                 console.print("[green]✅ All migrations have ACL coverage[/green]")
 
             if acl_report.has_errors:
+                raise typer.Exit(1)
+            return
+
+        # Run ownership coverage check on migration files (static, no DB).
+        if check_ownership_coverage:
+            from confiture.cli.ownership_loader import load_ownership_expectation
+            from confiture.core.linting.libraries.ownership import (
+                Own001OwnershipCoverage,
+            )
+
+            if not config.exists():
+                error_console.print(f"[red]❌ Config file not found: {config}[/red]")
+                raise typer.Exit(2)
+
+            config_data = load_config(config)
+            # No-op when the project hasn't adopted the `ownership:` block yet.
+            ownership_exp = load_ownership_expectation(
+                config_data, config, require=False
+            )
+
+            ownership_violations = []
+            if ownership_exp is not None:
+                ownership_violations = Own001OwnershipCoverage(
+                    expectation=ownership_exp
+                ).check(migrations_dir)
+
+            if format_output == "json":
+                _output_json(
+                    {
+                        "check": "ownership_coverage",
+                        "violations": [
+                            {
+                                "rule_id": v.rule_id,
+                                "severity": v.severity.value,
+                                "object_name": v.object_name,
+                                "message": v.message,
+                                "file_path": v.file_path,
+                                "line_number": v.line_number,
+                            }
+                            for v in ownership_violations
+                        ],
+                    },
+                    output_file,
+                    console,
+                )
+            elif ownership_violations:
+                console.print(
+                    f"[red]❌ Ownership coverage check failed: "
+                    f"{len(ownership_violations)} violation(s)[/red]"
+                )
+                for v in ownership_violations:
+                    # Escape the rule_id brackets so Rich doesn't read them as markup.
+                    console.print(
+                        f"  [red]✗[/red] \\[{v.rule_id}] {v.object_name}: {v.message}"
+                    )
+            else:
+                console.print("[green]✅ All migrations have ownership coverage[/green]")
+
+            if ownership_violations:
                 raise typer.Exit(1)
             return
 
@@ -964,6 +1034,30 @@ def migrate_fix(
         "--idempotent",
         help="Fix non-idempotent SQL statements (default: off)",
     ),
+    ownership: bool = typer.Option(
+        False,
+        "--ownership",
+        help=(
+            "Insert missing `ALTER … OWNER TO <expected_owner>` after each "
+            "CREATE that lacks one.  Requires an `ownership:` block in the "
+            "config and the [ast] extra (pglast)."
+        ),
+    ),
+    config_path: Path = typer.Option(
+        Path("confiture.yaml"),
+        "-c",
+        "--config",
+        help="Config file (needed for --ownership; defaults to confiture.yaml)",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help=(
+            "With --ownership --apply: rewrite migration files even when "
+            "their checksum is already recorded in the local tracking table.  "
+            "Use with care — downstream `migrate verify` will report drift."
+        ),
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -1020,13 +1114,25 @@ def migrate_fix(
                 console.print(f"[red]❌ Migrations directory not found: {migrations_dir}[/red]")
             raise typer.Exit(1)
 
-        if not idempotent:
+        if not idempotent and not ownership:
             console.print(
-                "[yellow]⚠️  No fix type specified. Use --idempotent to fix idempotency issues.[/yellow]"
+                "[yellow]⚠️  No fix type specified.  "
+                "Use --idempotent and/or --ownership.[/yellow]"
             )
             return
 
-        _fix_idempotency(migrations_dir, dry_run, format_output, output_file)
+        if idempotent:
+            _fix_idempotency(migrations_dir, dry_run, format_output, output_file)
+
+        if ownership:
+            _fix_ownership(
+                migrations_dir=migrations_dir,
+                config_path=config_path,
+                dry_run=dry_run,
+                force=force,
+                format_output=format_output,
+                output_file=output_file,
+            )
 
     except typer.Exit:
         raise

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -9,6 +9,7 @@ import typer
 
 from confiture.cli.formatters.common import display_drift_report, display_signature_drift_report
 from confiture.cli.helpers import (
+    _emit_hint,
     _fix_idempotency,
     _fix_ownership,
     _output_json,
@@ -1952,6 +1953,32 @@ def _preflight_version_from_filename(filename: str) -> str:
     return filename.split("_")[0]
 
 
+def _target_tracking_table_is_empty(session: MigratorSession) -> bool:
+    """Return True when the preflight target's ``tb_confiture`` is empty / missing.
+
+    A best-effort probe: any database error (table missing, permission
+    denied, connection drop) is treated as "looks empty" — the worst
+    case is emitting an extra hint, which is advisory anyway.
+    """
+    import contextlib
+
+    conn = getattr(session, "_conn", None)
+    if conn is None:
+        return False
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM tb_confiture LIMIT 1")
+            row = cur.fetchone()
+        # Roll back any aborted transaction state so run_against starts clean.
+        with contextlib.suppress(Exception):
+            conn.rollback()
+        return row is None
+    except Exception:  # noqa: BLE001 — best-effort: missing table / perm denied
+        with contextlib.suppress(Exception):
+            conn.rollback()
+        return True
+
+
 def _resolve_preflight_pending(
     migrations_dir: Path,
     *,
@@ -2359,6 +2386,7 @@ def migrate_preflight(
         error_console.print(f"[red]❌ Failed to resolve pending migrations: {e}[/red]")
         raise typer.Exit(2) from e
 
+    target_tracking_empty = False
     try:
         session = MigratorSession(
             config=None,
@@ -2367,6 +2395,11 @@ def migrate_preflight(
             migration_table_override="tb_confiture",
         )
         with session:
+            # Snapshot whether the target's tracking table is empty BEFORE
+            # the SAVEPOINT-bounded run_against — used to emit a
+            # quiet-success hint when the target looks like a restored
+            # backup with the tracking table stripped.
+            target_tracking_empty = _target_tracking_table_is_empty(session)
             against_result = session.run_against(
                 pending_files,
                 against_url=against,
@@ -2385,11 +2418,21 @@ def migrate_preflight(
             against_url=against,
         )
 
+    preflight_hints: list[str] = []
+    if target_tracking_empty and pending_files:
+        _emit_hint(
+            "`tb_confiture` on the target is empty. If --against points at a "
+            "restored backup, was the tracking table dropped during "
+            "anonymization?",
+            hints_list=preflight_hints,
+            format_=format_type,
+        )
+
     if format_type == "json":
         payload: dict[str, Any] = {
             "static": result.to_dict(),
             "against": against_result.to_dict(),
-            "hints": [],
+            "hints": preflight_hints,
         }
         if dependent_report is not None:
             payload["dependent_analysis"] = dependent_report.to_dict()

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -148,6 +148,44 @@ def migrate_diff(
         raise typer.Exit(1) from e
 
 
+def _emit_pattern_catalog(format_output: str, output_file: Path | None) -> None:
+    """Render the idempotency pattern catalog.
+
+    Read-only: no DB, no config, no migrations directory.
+
+    Args:
+        format_output: ``"text"`` for a Rich table, ``"json"`` for the
+            machine-readable catalog envelope.
+        output_file: Optional path to write JSON output; ignored for text.
+    """
+    from confiture.core.idempotency.patterns import list_patterns
+
+    entries = list_patterns()
+
+    if format_output == "json":
+        _output_json({"version": "1", "patterns": entries}, output_file, console)
+        return
+
+    # Text mode: compact table for human eyes.
+    from rich.table import Table
+
+    table = Table(title="Idempotency detection patterns", expand=False)
+    table.add_column("id", style="cyan", no_wrap=True)
+    table.add_column("severity")
+    table.add_column("skip", justify="center")
+    table.add_column("auto-fix", justify="center")
+    table.add_column("description")
+    for entry in entries:
+        table.add_row(
+            entry["id"],
+            entry["severity"],
+            "yes" if entry["has_skip_regex"] else "no",
+            "yes" if entry["has_auto_fix"] else "no",
+            entry["description"],
+        )
+    console.print(table)
+
+
 def _display_body_drift_report(report: Any, console: Any) -> None:
     """Print a FunctionBodyDriftReport to the console in human-readable form."""
     if not report.has_drift:
@@ -187,6 +225,14 @@ def migrate_validate(
         False,
         "--idempotent",
         help="Validate migrations are idempotent, can re-run (default: off)",
+    ),
+    list_patterns: bool = typer.Option(
+        False,
+        "--list-patterns",
+        help=(
+            "Print machine-readable catalog of detection patterns "
+            "(read-only, no DB needed). Use with `--format json` for tooling."
+        ),
     ),
     strict_cor: bool = typer.Option(
         False,
@@ -399,6 +445,19 @@ def migrate_validate(
                 f"[red]❌ Invalid format: {format_output}. Use 'text', 'json', or 'csv'[/red]"
             )
             raise typer.Exit(1)
+
+        # --list-patterns is a read-only catalog query. Short-circuit before
+        # touching config / migrations directory / DB. Must run before
+        # _resolve_config so projects without a confiture.yaml can still
+        # introspect the pattern catalog.
+        if list_patterns:
+            if idempotent:
+                error_console.print(
+                    "[red]Error:[/red] --list-patterns is mutually exclusive with --idempotent"
+                )
+                raise typer.Exit(2)
+            _emit_pattern_catalog(format_output, output_file)
+            return
 
         # Resolve --env / --config to a single config path
         try:

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -166,8 +166,9 @@ def _emit_pattern_catalog(format_output: str, output_file: Path | None) -> None:
     if format_output == "json":
         # `hints` is pre-allocated per the documented JSON-schema contract
         # (docs/reference/json-schemas/migrate-validate-list-patterns.schema.json).
-        # Phase 05 will populate it on quiet-success ambiguities; today it's
-        # an empty array so consumers can code against a stable shape.
+        # `--list-patterns` is a read-only catalog query with no ambiguous
+        # success state, so the list is always empty; the key still
+        # appears so consumers can code against a stable shape.
         _output_json(
             {"version": "1", "patterns": entries, "hints": []},
             output_file,

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -7,6 +7,7 @@ from typing import Any
 import typer
 
 from confiture.cli.helpers import (
+    _emit_hint,
     _find_orphaned_sql_files,
     _get_tracking_table,
     _output_json,
@@ -224,6 +225,19 @@ def migrate_status(
         # Determine current version (highest applied)
         current_version = applied_list[-1] if applied_list else None
 
+        status_hints: list[str] = []
+        # The tracking table missing on the target DB is a quiet-success
+        # ambiguity: every migration shows "pending" even though the
+        # database may already match the schema. Emit a hint so agents
+        # don't blindly run `migrate up` on a possibly-baselined DB.
+        if tracking_table_absent:
+            _emit_hint(
+                "Tracking table not found in this database. All migrations "
+                "are reported 'pending' — if the schema is already applied, "
+                "run `confiture migrate baseline --through <version>` first.",
+                hints_list=status_hints,
+                format_=output_format,
+            )
         if output_format == "json":
             result: dict[str, Any] = {
                 "tracking_table": status_tracking_table,
@@ -237,7 +251,7 @@ def migrate_status(
                     "pending": len(pending_list),
                     "total": len(migration_files),
                 },
-                "hints": [],
+                "hints": status_hints,
             }
             if db_error:
                 result["warning"] = f"Could not connect to database: {db_error}"

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -89,6 +89,10 @@ def migrate_status(
       confiture migrate status --format json --output migrations.json
         ↳ Save status report to file
 
+    JSON SCHEMA:
+      See docs/reference/json-schemas.md for the JSON output schema
+      (migrate-status.schema.json).
+
     RELATED:
       confiture migrate up       - Apply pending migrations
       confiture migrate down     - Rollback applied migrations
@@ -135,6 +139,7 @@ def migrate_status(
                     "current": None,
                     "total": 0,
                     "migrations": [],
+                    "hints": [],
                 }
                 if orphaned_sql_files:
                     result["orphaned_migrations"] = [f.name for f in orphaned_sql_files]
@@ -232,6 +237,7 @@ def migrate_status(
                     "pending": len(pending_list),
                     "total": len(migration_files),
                 },
+                "hints": [],
             }
             if db_error:
                 result["warning"] = f"Could not connect to database: {db_error}"

--- a/python/confiture/cli/formatters/common.py
+++ b/python/confiture/cli/formatters/common.py
@@ -84,10 +84,16 @@ def display_drift_report(report: Any, console: Console) -> None:
         f"{report.info_count} info"
     )
 
-    # Partition items so structural and ACL drift are visually distinct.
+    # Partition items so structural, ACL, and ownership drift are visually distinct.
     acl_types = {"missing_grant", "extra_grant"}
-    structural_items = [i for i in report.drift_items if i.drift_type.value not in acl_types]
+    ownership_types = {"wrong_owner"}
+    structural_items = [
+        i
+        for i in report.drift_items
+        if i.drift_type.value not in acl_types and i.drift_type.value not in ownership_types
+    ]
     acl_items = [i for i in report.drift_items if i.drift_type.value in acl_types]
+    ownership_items = [i for i in report.drift_items if i.drift_type.value in ownership_types]
 
     def _emit(item: Any) -> None:
         color = "red" if item.severity.value == "critical" else "yellow"
@@ -102,6 +108,10 @@ def display_drift_report(report: Any, console: Console) -> None:
     if acl_items:
         console.print("\n[bold]ACL drift[/bold]")
         for item in acl_items:
+            _emit(item)
+    if ownership_items:
+        console.print("\n[bold]Ownership drift[/bold]")
+        for item in ownership_items:
             _emit(item)
 
 

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -332,6 +332,34 @@ def _collect_idempotency_report(
     return combined
 
 
+def _idempotent_backend_banner(format_output: str) -> dict[str, str]:
+    """Report which idempotency backend is active.
+
+    Text mode prints a one-line banner to ``console`` (stdout) — it's a
+    status line, not an error. JSON / CSV / YAML modes print *nothing*:
+    the backend is reported via ``payload["meta"]["backend"]`` so that
+    pipe-able output stays valid.
+
+    Returns:
+        A ``meta`` dict the caller folds into its JSON payload. Always
+        contains ``{"backend": "ast" | "regex"}``.
+    """
+    from confiture.core.idempotency.patterns import is_pglast_available
+
+    backend = "ast" if is_pglast_available() else "regex"
+    if format_output == "text":
+        if backend == "ast":
+            console.print("[green]✓ AST backend (pglast)[/green]")
+        else:
+            # Escape the [ast] brackets so Rich doesn't read them as markup.
+            console.print(
+                "[yellow]⚠ Regex fallback — install with "
+                '`pip install "fraiseql-confiture\\[ast]"` '
+                "for AST-backed detection[/yellow]"
+            )
+    return {"backend": backend}
+
+
 def _validate_idempotency(
     migrations_dir: Path,
     format_output: str,
@@ -355,6 +383,10 @@ def _validate_idempotency(
 
     validator = IdempotencyValidator()
 
+    # Backend banner (text) + meta accumulator (json) — printed before
+    # file enumeration so users see which detector is running.
+    meta = _idempotent_backend_banner(format_output)
+
     sql_files = sorted(migrations_dir.glob("*.up.sql"))
     py_files = sorted(p for p in migrations_dir.glob("*.py") if _is_migration_file(p))
 
@@ -364,6 +396,7 @@ def _validate_idempotency(
                 "status": "ok",
                 "message": "No migration files found",
                 "violations": [],
+                "meta": meta,
                 "hints": [],
             }
             _output_json(result, output_file, console)
@@ -377,6 +410,7 @@ def _validate_idempotency(
     if format_output == "json":
         result = combined_report.to_dict()
         result["status"] = "issues_found" if fail else "ok"
+        result["meta"] = meta
         result["hints"] = []
         _output_json(result, output_file, console)
         if fail:

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -592,3 +592,160 @@ def _fix_idempotency(
         console.print("[cyan]Run without --dry-run to apply changes[/cyan]")
     elif files_changed:
         console.print(f"[green]Fixed {len(files_changed)} file(s)[/green]")
+
+
+def _fix_ownership(
+    migrations_dir: Path,
+    config_path: Path,
+    dry_run: bool,
+    force: bool,
+    format_output: str,
+    output_file: Path | None,
+) -> None:
+    """Insert missing ``ALTER … OWNER TO`` statements in migration files (issue #124).
+
+    Loads ``ownership:`` from *config_path* and uses
+    :class:`~confiture.core.ownership_fixer.OwnershipFixer` to rewrite
+    files in place.  In ``--apply`` mode (i.e. not ``--dry-run``), the
+    helper first probes the local tracking table — any file whose
+    version is already recorded gets refused unless ``--force`` is also
+    set.
+
+    No-op when:
+    - ``ownership:`` block is absent from *config_path*
+    - ``ownership.lint_enabled`` is False
+    - pglast (the [ast] extra) is not installed
+    """
+    from confiture.cli.ownership_loader import load_ownership_expectation
+    from confiture.core.connection import load_config
+    from confiture.core.ownership_fixer import OwnershipFixer
+
+    if not config_path.exists():
+        error_console.print(f"[red]❌ Config file not found: {config_path}[/red]")
+        raise SystemExit(2)
+
+    config_data = load_config(config_path)
+    expectation = load_ownership_expectation(config_data, config_path, require=False)
+    if expectation is None:
+        if format_output == "json":
+            _output_json(
+                {"status": "skipped", "reason": "no ownership: block in config"},
+                output_file,
+                console,
+            )
+        else:
+            console.print(
+                "[yellow]⚠️  --ownership: config has no `ownership:` block — nothing to fix.[/yellow]"
+            )
+        return
+
+    fixer = OwnershipFixer(expectation=expectation)
+    previews = fixer.preview(migrations_dir)
+
+    refused: list[tuple[Path, str]] = []
+    applicable_previews = previews
+    if not dry_run and previews:
+        # Checksum-drift guard: ask the local DB which migration versions
+        # are already recorded.  Refuse to rewrite those unless --force.
+        applied_versions = _query_applied_versions(config_data)
+        if applied_versions:
+            safe: list = []
+            for preview in previews:
+                version = _extract_version(preview.file.name)
+                if version and version in applied_versions and not force:
+                    refused.append((preview.file, "already applied locally"))
+                else:
+                    safe.append(preview)
+            applicable_previews = safe
+
+    modified: list[Path] = []
+    if not dry_run:
+        for preview in applicable_previews:
+            preview.file.write_text(preview.after)
+            modified.append(preview.file)
+
+    if format_output == "json":
+        _output_json(
+            {
+                "status": "preview" if dry_run else "fixed",
+                "previews": [
+                    {
+                        "file": str(p.file),
+                        "before": p.before,
+                        "after": p.after,
+                    }
+                    for p in previews
+                ],
+                "modified": [str(p) for p in modified],
+                "refused": [
+                    {"file": str(f), "reason": r} for f, r in refused
+                ],
+            },
+            output_file,
+            console,
+        )
+        if refused and not force:
+            raise SystemExit(2)
+        return
+
+    if not previews:
+        console.print("[green]✅ All migrations have ownership coverage[/green]")
+        return
+
+    label = "Would insert" if dry_run else "Inserted"
+    console.print(f"[green]{label} `ALTER … OWNER TO` in:[/green]")
+    for preview in previews:
+        console.print(f"  [green]✓[/green] {preview.file.name}")
+
+    if refused:
+        console.print(
+            f"\n[red]Refused {len(refused)} file(s) "
+            f"(already applied — pass --force to rewrite anyway):[/red]"
+        )
+        for file_path, reason in refused:
+            console.print(f"  [red]✗[/red] {file_path.name}: {reason}")
+        if not force:
+            raise SystemExit(2)
+
+
+def _extract_version(filename: str) -> str | None:
+    """Pull the leading version token out of a migration filename.
+
+    Confiture migration files are named ``<version>_<name>.up.sql`` where
+    ``<version>`` is either ``NNN`` (legacy) or ``YYYYMMDDHHMMSS`` (post-0.6.0).
+    Both forms parse as a leading run of digits.
+    """
+    m = re.match(r"^(\d+)", filename)
+    return m.group(1) if m else None
+
+
+def _query_applied_versions(config_data: dict[str, Any]) -> set[str]:
+    """Return the set of migration versions present in the local tracking table.
+
+    Returns an empty set on any failure (no DB, no table, no rows) so
+    the fixer can fall through to the "rewrite everything" path —
+    a checksum guard that can't open a connection is no guard at all,
+    so we'd rather degrade gracefully than block the fix.
+    """
+    from confiture.core.connection import create_connection
+
+    try:
+        conn = create_connection(config_data)
+    except Exception:
+        return set()
+
+    table = _get_tracking_table(config_data)
+    try:
+        with conn.cursor() as cur:
+            # Schema-qualified identifier needs splitting + quoting.
+            schema, _, name = table.partition(".")
+            if not name:
+                schema, name = "public", table
+            cur.execute(
+                f'SELECT version FROM "{schema}"."{name}"'  # noqa: S608 — names quoted, no user input
+            )
+            return {row[0] for row in cur.fetchall()}
+    except Exception:
+        return set()
+    finally:
+        conn.close()

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -364,6 +364,7 @@ def _validate_idempotency(
                 "status": "ok",
                 "message": "No migration files found",
                 "violations": [],
+                "hints": [],
             }
             _output_json(result, output_file, console)
         else:
@@ -376,6 +377,7 @@ def _validate_idempotency(
     if format_output == "json":
         result = combined_report.to_dict()
         result["status"] = "issues_found" if fail else "ok"
+        result["hints"] = []
         _output_json(result, output_file, console)
         if fail:
             raise typer.Exit(1)
@@ -491,6 +493,7 @@ def _fix_idempotency(
                 "status": "ok",
                 "message": "No migration files found",
                 "files": [],
+                "hints": [],
             }
             _output_json(result, output_file, console)
         else:
@@ -543,6 +546,7 @@ def _fix_idempotency(
             "files": files_changed,
             "total_files_changed": len(files_changed),
             "manual_fix_required": manual_fix_required,
+            "hints": [],
         }
         if manual_report.has_warnings:
             result["warnings"] = manual_report.to_dict()["warnings"]

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -26,6 +26,39 @@ _VALID_ENV_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$")
 console = Console()
 error_console = Console(file=sys.stderr)
 
+_MACHINE_OUTPUT_FORMATS = frozenset({"json", "csv", "yaml"})
+
+
+def _emit_hint(
+    hint: str,
+    *,
+    hints_list: list[str],
+    format_: str,
+    error_console: Console | None = None,
+) -> None:
+    """Emit an advisory "looks unusual" hint via the right channel.
+
+    Hints are dual-channel based on the output format:
+
+    - ``format_ == "text"`` → write to ``error_console`` (stderr).
+    - ``format_ in {"json", "csv", "yaml"}`` → append to ``hints_list``
+      so it lands in the machine-readable payload under ``"hints": [...]``;
+      nothing goes to stderr (agents pipe stdout, not stderr).
+
+    Hints never change the exit code — they are pure agent-experience
+    breadcrumbs.
+
+    ``error_console`` defaults to the module-level :data:`error_console`
+    looked up at call time, so test fixtures that monkeypatch the
+    module-level binding take effect.
+    """
+    if format_ in _MACHINE_OUTPUT_FORMATS:
+        hints_list.append(hint)
+        return
+    target = error_console or globals()["error_console"]
+    target.print(f"[dim]Hint: {hint}[/dim]")
+
+
 # Common command names for "Did you mean?" suggestions
 COMMON_COMMANDS = [
     "init",
@@ -391,13 +424,24 @@ def _validate_idempotency(
     py_files = sorted(p for p in migrations_dir.glob("*.py") if _is_migration_file(p))
 
     if not sql_files and not py_files:
+        # Quiet-success ambiguity: "no migrations" can mean the user
+        # intentionally validated an empty directory, but more often
+        # they pointed --migrations-dir at the wrong path. Emit a hint
+        # to make the success state legible to agents.
+        zero_files_hints: list[str] = []
+        _emit_hint(
+            f"Migration directory `{migrations_dir}` exists but contains no files. "
+            "Did you mean to pass --migrations-dir <other>?",
+            hints_list=zero_files_hints,
+            format_=format_output,
+        )
         if format_output == "json":
             result: dict[str, Any] = {
                 "status": "ok",
                 "message": "No migration files found",
                 "violations": [],
                 "meta": meta,
-                "hints": [],
+                "hints": zero_files_hints,
             }
             _output_json(result, output_file, console)
         else:

--- a/python/confiture/cli/ownership_loader.py
+++ b/python/confiture/cli/ownership_loader.py
@@ -1,0 +1,62 @@
+"""Shared helper for loading the ``ownership:`` block from a raw config dict.
+
+Used by ``confiture drift --check-ownership`` and
+``confiture migrate validate --check-ownership-coverage`` (issue #124).
+Centralizes the ``${VAR}`` expansion + Pydantic validation logic so both
+commands behave identically — mirrors :mod:`confiture.cli.acl_loader`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import typer
+from pydantic import ValidationError
+
+from confiture.cli.helpers import error_console
+from confiture.config._env_vars import expand_env_vars
+from confiture.config.environment import OwnershipExpectation
+
+
+def load_ownership_expectation(
+    config_data: dict[str, Any],
+    config_path: Path,
+    *,
+    require: bool,
+) -> OwnershipExpectation | None:
+    """Pull, expand, and validate the ``ownership:`` block from a raw config dict.
+
+    Args:
+        config_data: Parsed YAML as returned by
+            :func:`confiture.core.connection.load_config`.
+        config_path: Path the config came from — included in error
+            messages.
+        require: When ``True``, missing ``ownership:`` exits with code 2.
+            When ``False`` (e.g. the lint rule's "no-op when absent"
+            semantics), ``None`` is returned.
+
+    Returns:
+        The validated :class:`OwnershipExpectation`, or ``None`` when the
+        block is absent and ``require=False``.
+    """
+    raw = config_data.get("ownership")
+    if not raw:
+        if require:
+            error_console.print(
+                f"[red]❌ --check-ownership requires an `ownership:` block in {config_path}[/red]"
+            )
+            raise typer.Exit(2)
+        return None
+
+    expanded = expand_env_vars(raw, context="ownership")
+    try:
+        return OwnershipExpectation.model_validate(expanded)
+    except ValidationError as exc:
+        error_console.print(
+            f"[red]❌ Invalid ownership: block in {config_path}: {exc}[/red]"
+        )
+        raise typer.Exit(2) from exc
+
+
+__all__ = ["load_ownership_expectation"]

--- a/python/confiture/config/environment.py
+++ b/python/confiture/config/environment.py
@@ -451,6 +451,72 @@ class AclTableExpectation(BaseModel):
 AclExpectation = AclTableExpectation
 
 
+# Postgres ``pg_class.relkind`` values in scope for ownership coverage
+# (table, sequence, view, materialized view).  Functions and procedures
+# have separate ownership semantics — not in scope for v1.
+_OWNERSHIP_RELKINDS: frozenset[str] = frozenset({"r", "S", "v", "m"})
+
+# Strict regex for a Postgres role identifier: unquoted ``[a-z_][a-z0-9_]*``
+# (matches the unquoted-identifier rule), or any double-quoted form
+# ``"..."`` permitting whitespace and mixed case.
+_ROLE_IDENT_RE = re.compile(r'^("[^"]+"|[a-z_][a-z0-9_]*)$')
+
+
+class OwnershipApplyTo(BaseModel):
+    """One schema-scoped entry in the ``ownership.apply_to`` list (issue #124).
+
+    ``relkinds`` accepts only ``r`` (regular table), ``S`` (sequence),
+    ``v`` (view), or ``m`` (materialized view).  Default covers all four.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema_: str = Field(alias="schema")
+    relkinds: list[str] = Field(default_factory=lambda: ["r", "S", "v", "m"])
+
+    @field_validator("relkinds")
+    @classmethod
+    def _validate_relkinds(cls, v: list[str]) -> list[str]:
+        bad = set(v) - _OWNERSHIP_RELKINDS
+        if bad:
+            raise ValueError(
+                f"Invalid relkinds: {sorted(bad)}. "
+                f"Must be a subset of {sorted(_OWNERSHIP_RELKINDS)}."
+            )
+        return v
+
+
+class OwnershipExpectation(BaseModel):
+    """The ``ownership:`` block in environment YAML (issue #124).
+
+    A single declaration — unlike :class:`AclExpectation` which is a
+    list — because ownership has exactly one canonical owner per
+    environment.
+
+    Mirrors the structure of :class:`AclTableExpectation` (#120) but on
+    the ownership axis.  Opt-in by default: ``lint_enabled`` defaults
+    to ``True`` per the issue's Definition of done.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    expected_owner: str
+    apply_to: list[OwnershipApplyTo]
+    ignore: list[str] = Field(default_factory=list)
+    lint_enabled: bool = True
+
+    @field_validator("expected_owner")
+    @classmethod
+    def _validate_owner_name(cls, v: str) -> str:
+        if not _ROLE_IDENT_RE.match(v):
+            raise ValueError(
+                f"Invalid role identifier: {v!r}. "
+                f"Use an unquoted ``[a-z_][a-z0-9_]*`` form, or a double-quoted "
+                f'``"Name"`` form for mixed-case roles.'
+            )
+        return v
+
+
 class Environment(BaseModel):
     """Environment configuration
 
@@ -490,6 +556,10 @@ class Environment(BaseModel):
     # via the nested YAML shape ``acls: { lint_enabled: true, expectations:
     # [...] }``; the flat-list form (``acls: [...]``) keeps this False.
     acls_lint_enabled: bool = False
+    # Issue #124 — ownership coverage.  Single declaration (one canonical
+    # owner per env), unlike ``acls:`` which is a list.  ``None`` means
+    # the project hasn't opted into ownership coverage at all.
+    ownership: OwnershipExpectation | None = None
 
     @property
     def database(self) -> DatabaseConfig:
@@ -698,6 +768,11 @@ class Environment(BaseModel):
         # raise ConfigurationError; we never substitute empty strings.
         if "acls" in data:
             data["acls"] = expand_env_vars(data["acls"], context="acls")
+
+        # Same treatment for the ``ownership:`` subtree (issue #124) — the
+        # ``expected_owner`` field commonly parameterizes across envs.
+        if "ownership" in data and data["ownership"] is not None:
+            data["ownership"] = expand_env_vars(data["ownership"], context="ownership")
 
         # Create Environment instance
         try:

--- a/python/confiture/core/_migrator/engine.py
+++ b/python/confiture/core/_migrator/engine.py
@@ -243,10 +243,10 @@ class Migrator:
                 else:
                     cursor.execute(query)
         except Exception as e:
-            if hasattr(query, "as_string"):
+            if isinstance(query, pgsql.Composable):
                 try:
                     sql_text = query.as_string(self.connection)
-                except Exception:
+                except Exception:  # noqa: BLE001 — fall through to context-free render
                     sql_text = query.as_string(None)
             else:
                 sql_text = str(query)

--- a/python/confiture/core/drift.py
+++ b/python/confiture/core/drift.py
@@ -16,7 +16,11 @@ import psycopg
 from confiture.core.schema_analyzer import SchemaAnalyzer, SchemaInfo
 
 if TYPE_CHECKING:
-    from confiture.config.environment import AclExpectation, AclGrant
+    from confiture.config.environment import (
+        AclExpectation,
+        AclGrant,
+        OwnershipExpectation,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +41,7 @@ class DriftType(Enum):
     EXTRA_CONSTRAINT = "extra_constraint"
     MISSING_GRANT = "missing_grant"
     EXTRA_GRANT = "extra_grant"
+    WRONG_OWNER = "wrong_owner"
 
 
 class DriftSeverity(Enum):
@@ -723,32 +728,32 @@ class AclDriftDetector:
         would produce false positives for any role that inherits a
         privilege.
 
-        Identifiers are quoted via :class:`psycopg.sql.Identifier` so
+        Identifiers are quoted via :class:`psycopg.sql.Identifier` and
+        passed as a *text literal* that ``::regclass`` resolves, so
         mixed-case tables created with ``CREATE TABLE "MyTable" …`` are
-        resolved without case-folding.  Without the quoting, the
-        ``::regclass`` cast would fold ``public.MyTable`` to
-        ``public.mytable`` and throw ``UndefinedTable`` for a perfectly
-        valid identifier.
+        looked up without case-folding.  Inlining the qualified name as
+        bare SQL (``"schema"."table"::regclass``) would be parsed as a
+        column reference (``column "table" of table "schema"``) and
+        fail with ``missing FROM-clause entry`` — the text-cast form
+        avoids that pitfall entirely.
         """
-        from psycopg import sql as _sql  # local import to keep the top tidy
-
-        qualified_text = f'"{schema}"."{table}"'
+        # SQL-side qualifier needs the double-quoted form so mixed-case
+        # relnames survive regclass lookup; the human-friendly object_name
+        # used in DriftItem stays unquoted for display consistency with
+        # OwnershipDriftDetector and the existing structural diff items.
+        qualified_sql = f'"{schema}"."{table}"'
+        display_name = f"{schema}.{table}"
         # ``has_table_privilege(role, table_oid, priv)`` takes a regclass.
-        # Passing the literal SQL via ``psycopg.sql.Identifier`` ensures
-        # any mixed-case relname survives without quoting tricks.
-        regclass_sql = _sql.SQL("{schema}.{table}::regclass").format(
-            schema=_sql.Identifier(schema),
-            table=_sql.Identifier(table),
-        )
-        priv_query = _sql.SQL("SELECT has_table_privilege(%s, {regclass}, %s)").format(
-            regclass=regclass_sql
-        )
+        # Pass the qualified name as a TEXT parameter to ``::regclass``
+        # so PostgreSQL resolves it through the regclass input function
+        # rather than parsing it as a column reference.
+        priv_query = "SELECT has_table_privilege(%s, %s::regclass, %s)"
 
         missing: list[str] = []
         for priv in grant.privileges:
             with self.connection.cursor() as cur:
                 try:
-                    cur.execute(priv_query, (grant.role, priv))
+                    cur.execute(priv_query, (grant.role, qualified_sql, priv))
                     row = cur.fetchone()
                 except (
                     psycopg.errors.UndefinedObject,
@@ -773,12 +778,12 @@ class AclDriftDetector:
                     return DriftItem(
                         drift_type=DriftType.MISSING_GRANT,
                         severity=DriftSeverity.WARNING,
-                        object_name=f"{qualified_text}({grant.role})",
+                        object_name=f"{display_name}({grant.role})",
                         expected=", ".join(grant.privileges),
                         actual=None,
                         message=(
                             f"Cannot verify grants for role '{grant.role}' "
-                            f"on '{qualified_text}': {cause}{hint}"
+                            f"on '{display_name}': {cause}{hint}"
                         ),
                     )
                 if row is not None and row[0] is False:
@@ -788,12 +793,12 @@ class AclDriftDetector:
         return DriftItem(
             drift_type=DriftType.MISSING_GRANT,
             severity=DriftSeverity.CRITICAL,
-            object_name=f"{qualified_text}({grant.role})",
+            object_name=f"{display_name}({grant.role})",
             expected=", ".join(grant.privileges),
             actual=None,
             message=(
                 f"Role '{grant.role}' is missing grant(s) "
-                f"{', '.join(missing)} on '{qualified_text}'"
+                f"{', '.join(missing)} on '{display_name}'"
             ),
         )
 
@@ -843,3 +848,133 @@ class AclDriftDetector:
                 f"Role '{grant.role}' has unexpected grant(s) {', '.join(extras)} on '{qualified}'"
             ),
         )
+
+
+class OwnershipDriftDetector:
+    """Detect ownership drift between ``pg_class.relowner`` and the ``ownership:`` config.
+
+    Issue #124 — the ownership axis of the same drift class that
+    :class:`AclDriftDetector` covers on the ACL axis.
+
+    Discovery query is a single SELECT against ``pg_class`` filtered by
+    schema and ``relkind``.  Partition children (``relispartition =
+    true``) are NOT excluded — Postgres allows each partition to have a
+    distinct owner, and a drifted child is exactly the kind of mistake
+    this detector exists to catch.  The ``ignore:`` glob list is
+    evaluated Python-side after the query so the SQL stays simple and
+    the cross-schema globs (``*.legacy_audit_log``) work uniformly.
+
+    System tables (``tb_confiture`` etc.) are excluded via the same
+    :pyattr:`SchemaDriftDetector.SYSTEM_TABLES` set.
+
+    Example::
+
+        from confiture.config.environment import Environment
+        from confiture.core.drift import OwnershipDriftDetector
+
+        env = Environment.load("production")
+        with psycopg.connect(env.database_url) as conn:
+            report = OwnershipDriftDetector(conn).check(env.ownership)
+            if report.has_critical_drift:
+                raise SystemExit(1)
+    """
+
+    SYSTEM_TABLES = SchemaDriftDetector.SYSTEM_TABLES
+
+    def __init__(self, connection: psycopg.Connection) -> None:
+        self.connection = connection
+
+    def check(self, expectation: "OwnershipExpectation") -> DriftReport:
+        """Compare every reachable relation against the expected owner.
+
+        Returns a :class:`DriftReport` with one :class:`DriftItem` per
+        relation whose actual owner differs from ``expected_owner``.
+        ``report.has_drift is False`` means every in-scope relation has
+        the canonical owner.
+        """
+        report = DriftReport(
+            database_name=self._get_database_name(),
+            expected_schema_source="ownership",
+        )
+        for apply_entry in expectation.apply_to:
+            relations = self._discover_relations(
+                apply_entry.schema_, apply_entry.relkinds, expectation.ignore
+            )
+            for schema, relname, _relkind, actual_owner in relations:
+                report.tables_checked += 1
+                if actual_owner != expectation.expected_owner:
+                    qualified = f"{schema}.{relname}"
+                    report.drift_items.append(
+                        DriftItem(
+                            drift_type=DriftType.WRONG_OWNER,
+                            severity=DriftSeverity.CRITICAL,
+                            object_name=qualified,
+                            expected=expectation.expected_owner,
+                            actual=actual_owner,
+                            message=(
+                                f"Relation '{qualified}' is owned by "
+                                f"'{actual_owner}' but expected owner is "
+                                f"'{expectation.expected_owner}'"
+                            ),
+                        )
+                    )
+        return report
+
+    def _get_database_name(self) -> str:
+        with self.connection.cursor() as cur:
+            cur.execute("SELECT current_database()")
+            row = cur.fetchone()
+            return row[0] if row else "unknown"
+
+    def _discover_relations(
+        self,
+        schema: str,
+        relkinds: list[str],
+        ignore_patterns: list[str],
+    ) -> list[tuple[str, str, str, str]]:
+        """Return ``(schema, relname, relkind, owner)`` tuples in scope.
+
+        Filters out system tables and any qualified name matching an
+        ``ignore`` glob.  Ignore patterns may be either ``schema.name``
+        or a glob form like ``*.audit_log`` evaluated against the
+        ``schema.relname`` qualified form.
+        """
+        with self.connection.cursor() as cur:
+            cur.execute(
+                """
+                SELECT n.nspname,
+                       c.relname,
+                       c.relkind,
+                       pg_get_userbyid(c.relowner) AS owner
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = %s
+                  AND c.relkind = ANY(%s)
+                ORDER BY n.nspname, c.relname
+                """,
+                (schema, list(relkinds)),
+            )
+            rows: list[tuple[str, str, str, str]] = [
+                (row[0], row[1], row[2], row[3]) for row in cur.fetchall()
+            ]
+
+        rows = [r for r in rows if r[1] not in self.SYSTEM_TABLES]
+
+        if ignore_patterns:
+            rows = [
+                r
+                for r in rows
+                if not _matches_any_glob(f"{r[0]}.{r[1]}", ignore_patterns)
+            ]
+
+        return rows
+
+
+def _matches_any_glob(qualified_name: str, patterns: list[str]) -> bool:
+    """Return ``True`` iff *qualified_name* matches any *patterns* glob.
+
+    Patterns may be either literal ``schema.name`` or a glob form like
+    ``*.audit_log`` or ``tenant.*_legacy``.  Uses :mod:`fnmatch`'s
+    case-sensitive ``fnmatchcase`` to mirror :class:`AclDriftDetector`.
+    """
+    return any(fnmatch.fnmatchcase(qualified_name, p) for p in patterns)

--- a/python/confiture/core/dry_run.py
+++ b/python/confiture/core/dry_run.py
@@ -116,6 +116,9 @@ class DryRunExecutor:
 
     def run(
         self,
+        migration_name_or_conn=None,
+        statements_or_migration=None,
+        *,
         _conn: psycopg.Connection | None = None,
         migration=None,
         migration_name: str | None = None,
@@ -126,12 +129,33 @@ class DryRunExecutor:
         Supports two APIs for backward compatibility:
 
         Old API (deprecated):
-            executor.run(_conn=None, migration=migration_obj)
+            executor.run(migration=migration_obj)
 
         New API:
             executor = DryRunExecutor(conn)
+            executor.run("migration_name", ["SQL...", ...])
+            # or equivalently:
             executor.run(migration_name="name", statements=["SQL..."])
         """
+        # Reconcile positional new-API args with keyword form.  The first
+        # positional may be either the migration_name (new API) or — in
+        # very old call sites — a connection object that's now ignored.
+        if migration_name_or_conn is not None and migration_name is None:
+            if isinstance(migration_name_or_conn, str):
+                migration_name = migration_name_or_conn
+            elif isinstance(migration_name_or_conn, psycopg.Connection):
+                # Pre-instance-conn callers passed conn first; silently
+                # accepted for compatibility.
+                pass
+            elif hasattr(migration_name_or_conn, "up"):
+                # Legacy: caller passed a migration object positionally.
+                migration = migration_name_or_conn
+        if statements_or_migration is not None and statements is None:
+            if isinstance(statements_or_migration, list):
+                statements = statements_or_migration
+            elif hasattr(statements_or_migration, "up"):
+                migration = statements_or_migration
+
         # Handle old API
         if migration is not None:
             # Old simulation API - fallback to basic timing

--- a/python/confiture/core/fk_extractor.py
+++ b/python/confiture/core/fk_extractor.py
@@ -181,13 +181,36 @@ def _find_create_table_blocks(sql: str) -> list[tuple[int, int, str]]:
     return blocks
 
 
-def _strip_comments_from_body(body: str) -> str:
-    """Strip all comments from body text for matching purposes."""
-    # Remove block comments
-    result = re.sub(r"/\*.*?\*/", "", body, flags=re.DOTALL)
-    # Remove line comments
-    result = re.sub(r"--[^\n]*", "", result)
-    return result
+def _line_has_data(line: str) -> bool:
+    """Return True if `line` has any content beyond whitespace and `--` comments."""
+    return _strip_comments(line).strip() != ""
+
+
+def _strip_comments_with_map(body: str) -> tuple[str, list[int]]:
+    """Strip line and block comments, returning the stripped text and an index map.
+
+    `orig_idx[i]` is the position in `body` of the character that ends up at
+    position `i` in the returned stripped string. The map lets a regex match on
+    the stripped text be projected back onto exact positions in the original,
+    without a second regex pass that can re-snag on the very comment we stripped.
+    """
+    stripped_chars: list[str] = []
+    orig_idx: list[int] = []
+    i = 0
+    n = len(body)
+    while i < n:
+        if body[i : i + 2] == "/*":
+            end = body.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        if body[i : i + 2] == "--":
+            end = body.find("\n", i + 2)
+            i = n if end == -1 else end
+            continue
+        stripped_chars.append(body[i])
+        orig_idx.append(i)
+        i += 1
+    return "".join(stripped_chars), orig_idx
 
 
 def _extract_fks_from_body(body: str, table_name: str) -> tuple[str, list[ForeignKeyInfo]]:
@@ -200,10 +223,12 @@ def _extract_fks_from_body(body: str, table_name: str) -> tuple[str, list[Foreig
     cleaned = body
 
     # Step 1: Extract and remove table-level FK constraints (multi-line safe).
-    # We match against comment-stripped text but remove from original using positions.
-    # To handle position mapping, we repeatedly match-and-remove from the cleaned text.
+    # Positions are obtained by running the regex on a comment-stripped view of
+    # the text, then mapped back to original-text positions via orig_idx. A
+    # second regex search against the original text would re-snag on whatever
+    # whitespace abuts a stripped comment and cause comment displacement (#128).
     while True:
-        check_text = _strip_comments_from_body(cleaned)
+        check_text, orig_idx = _strip_comments_with_map(cleaned)
         table_fk_match = _TABLE_FK_RE.search(check_text)
         if not table_fk_match:
             break
@@ -228,31 +253,41 @@ def _extract_fks_from_body(body: str, table_name: str) -> tuple[str, list[Foreig
             )
         )
 
-        # Now find the same match in the original cleaned text (with comments).
-        # The TABLE_FK_RE uses \s+ which matches newlines, so it works on multi-line.
-        orig_match = _TABLE_FK_RE.search(cleaned)
-        if orig_match:
-            start = orig_match.start()
-            end = orig_match.end()
+        start = orig_idx[table_fk_match.start()]
+        end = orig_idx[table_fk_match.end() - 1] + 1
 
-            # Expand start backwards to consume leading whitespace/newline
-            while start > 0 and cleaned[start - 1] in (" ", "\t"):
+        # Expand start backwards to consume leading whitespace/newline.
+        # The leading-newline pass is suppressed when the preceding line is
+        # comment-only: consuming its terminator would glue the comment onto
+        # whatever follows the deletion (#128).
+        while start > 0 and cleaned[start - 1] in (" ", "\t"):
+            start -= 1
+        if start > 0 and cleaned[start - 1] == "\n":
+            line_start = cleaned.rfind("\n", 0, start - 1) + 1
+            preceding_line = cleaned[line_start : start - 1]
+            if _line_has_data(preceding_line):
                 start -= 1
-            if start > 0 and cleaned[start - 1] == "\n":
-                start -= 1
 
-            # Expand end forward to consume trailing comma and whitespace
-            while end < len(cleaned) and cleaned[end] in (" ", "\t"):
-                end += 1
-            if end < len(cleaned) and cleaned[end] == ",":
-                end += 1
-            # Consume trailing newline
-            while end < len(cleaned) and cleaned[end] in (" ", "\t"):
-                end += 1
-            if end < len(cleaned) and cleaned[end] == "\n":
+        # Expand end forward to consume trailing comma and whitespace.
+        # The trailing-newline pass is suppressed when the following line is
+        # comment-only: consuming its leading newline would glue the comment
+        # onto the previous data line (#128).
+        while end < len(cleaned) and cleaned[end] in (" ", "\t"):
+            end += 1
+        if end < len(cleaned) and cleaned[end] == ",":
+            end += 1
+        while end < len(cleaned) and cleaned[end] in (" ", "\t"):
+            end += 1
+        if end < len(cleaned) and cleaned[end] == "\n":
+            after_nl = end + 1
+            next_nl = cleaned.find("\n", after_nl)
+            following_line = (
+                cleaned[after_nl:next_nl] if next_nl != -1 else cleaned[after_nl:]
+            )
+            if _line_has_data(following_line) or following_line == "":
                 end += 1
 
-            cleaned = cleaned[:start] + cleaned[end:]
+        cleaned = cleaned[:start] + cleaned[end:]
 
     # Step 2: Extract and remove inline REFERENCES (line-by-line is fine here,
     # since inline REFERENCES are always on the same line as the column definition).
@@ -322,13 +357,15 @@ def _fix_trailing_commas(body: str) -> str:
     while lines and not lines[-1].strip():
         lines.pop()
 
-    # Find the last non-blank line and strip its trailing comma
+    # Find the last line that carries actual column / constraint content
+    # (skip blank and comment-only lines) and strip its trailing comma.
     for i in range(len(lines) - 1, -1, -1):
+        if not _line_has_data(lines[i]):
+            continue
         rstripped = lines[i].rstrip()
-        if rstripped:
-            if rstripped.endswith(","):
-                lines[i] = rstripped[:-1]
-            break
+        if rstripped.endswith(","):
+            lines[i] = rstripped[:-1]
+        break
 
     # Restore trailing newline
     return "\n".join(lines) + "\n"

--- a/python/confiture/core/idempotency/_captures.py
+++ b/python/confiture/core/idempotency/_captures.py
@@ -1,0 +1,479 @@
+"""Normalized identifier captures for idempotency suggestion templates.
+
+The regex and AST backends extract identifiers in incompatible shapes —
+``re.Match.group(N)`` strings versus pglast typed nodes. The
+:class:`Captures` dataclass is the single normalized form both backends
+produce; suggestion-template functions take :class:`Captures` and never
+need to know which backend the match came from.
+
+All string fields hold post-unquoted, lowercased identifiers — quoting
+is the template's job, not the capturer's.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from confiture.core.idempotency.models import IdempotencyPattern
+
+
+@dataclass(frozen=True)
+class Captures:
+    """Normalized identifiers extracted from an idempotency-pattern match.
+
+    All fields are optional — a backend that cannot extract a given
+    field leaves it ``None`` and the template falls back to the generic
+    suggestion. Two :class:`Captures` instances compare equal when
+    every field matches, which is the property the cross-backend
+    equivalence tests rely on.
+    """
+
+    schema: str | None = None
+    table: str | None = None
+    column: str | None = None
+    new_column: str | None = None
+    constraint: str | None = None
+    type_name: str | None = None
+    index_name: str | None = None
+    view: str | None = None
+    sequence: str | None = None
+    extension: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Regex captures
+# ---------------------------------------------------------------------------
+
+_DENT = r"(?:\"[^\"]+\"|\w+)"  # quoted or unquoted identifier
+_QUAL = rf"(?:({_DENT})\.)?({_DENT})"  # optional ``schema.`` + name; two groups
+_IDENT_QUAL = rf"({_DENT})(?:\.({_DENT}))?"  # alt: name + optional ``.attr``
+
+_RE_CREATE_TABLE = re.compile(rf"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?{_QUAL}", re.IGNORECASE)
+_RE_CREATE_INDEX = re.compile(
+    rf"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?({_DENT})"
+    rf"\s+ON\s+(?:ONLY\s+)?{_QUAL}",
+    re.IGNORECASE,
+)
+_RE_CREATE_TYPE = re.compile(rf"CREATE\s+TYPE\s+{_QUAL}", re.IGNORECASE)
+_RE_CREATE_SCHEMA = re.compile(
+    rf"CREATE\s+SCHEMA\s+(?:IF\s+NOT\s+EXISTS\s+)?({_DENT})", re.IGNORECASE
+)
+_RE_CREATE_SEQUENCE = re.compile(
+    rf"CREATE\s+SEQUENCE\s+(?:IF\s+NOT\s+EXISTS\s+)?{_QUAL}", re.IGNORECASE
+)
+_RE_CREATE_EXTENSION = re.compile(
+    rf"CREATE\s+EXTENSION\s+(?:IF\s+NOT\s+EXISTS\s+)?({_DENT})", re.IGNORECASE
+)
+_RE_CREATE_VIEW = re.compile(
+    rf"CREATE\s+(?:OR\s+REPLACE\s+)?VIEW\s+{_QUAL}", re.IGNORECASE
+)
+_RE_ALTER_TABLE = re.compile(
+    rf"ALTER\s+TABLE\s+(?:ONLY\s+)?{_QUAL}", re.IGNORECASE
+)
+_RE_ALTER_VIEW = re.compile(rf"ALTER\s+VIEW\s+{_QUAL}", re.IGNORECASE)
+_RE_ALTER_MATVIEW = re.compile(
+    rf"ALTER\s+MATERIALIZED\s+VIEW\s+{_QUAL}", re.IGNORECASE
+)
+_RE_ADD_COLUMN = re.compile(
+    rf"ADD\s+(?:COLUMN\s+)?(?:IF\s+NOT\s+EXISTS\s+)?({_DENT})", re.IGNORECASE
+)
+_RE_ADD_CONSTRAINT = re.compile(rf"ADD\s+CONSTRAINT\s+({_DENT})", re.IGNORECASE)
+_RE_RENAME_COLUMN = re.compile(
+    rf"RENAME\s+(?:COLUMN\s+)?({_DENT})\s+TO\s+({_DENT})", re.IGNORECASE
+)
+_RE_DROP_GENERIC = re.compile(
+    r"DROP\s+(?:TABLE|VIEW|TYPE|SEQUENCE|SCHEMA|INDEX|MATERIALIZED\s+VIEW)\s+"
+    rf"(?:CONCURRENTLY\s+)?(?:IF\s+EXISTS\s+)?{_QUAL}",
+    re.IGNORECASE,
+)
+
+
+def _unquote(s: str | None) -> str | None:
+    """Strip surrounding double-quotes from a SQL identifier, if any."""
+    if s is None:
+        return None
+    s = s.strip()
+    if len(s) >= 2 and s.startswith('"') and s.endswith('"'):
+        return s[1:-1]
+    return s.lower()
+
+
+def _qual_pair(schema_group: str | None, name_group: str | None) -> tuple[str | None, str | None]:
+    """Normalize a ``(schema, name)`` regex-group pair into clean identifiers."""
+    return _unquote(schema_group), _unquote(name_group)
+
+
+def captures_from_regex(pattern: IdempotencyPattern, m: re.Match[str]) -> Captures:
+    """Build :class:`Captures` from a regex match for ``pattern``.
+
+    Returns an all-``None`` :class:`Captures` when extraction can't
+    pull identifiers reliably — the template machinery falls back to
+    the generic suggestion in that case.
+    """
+    text = m.string[m.start() : min(m.end() + 200, len(m.string))]
+    return _CAPTURES_REGEX_DISPATCH.get(pattern, _captures_regex_unknown)(text)
+
+
+def _captures_regex_unknown(_text: str) -> Captures:
+    return Captures()
+
+
+def _captures_regex_create_table(text: str) -> Captures:
+    m = _RE_CREATE_TABLE.search(text)
+    if m is None:
+        return Captures()
+    schema, table = _qual_pair(m.group(1), m.group(2))
+    return Captures(schema=schema, table=table)
+
+
+def _captures_regex_create_index(text: str) -> Captures:
+    m = _RE_CREATE_INDEX.search(text)
+    if m is None:
+        return Captures()
+    index_name = _unquote(m.group(1))
+    schema, table = _qual_pair(m.group(2), m.group(3))
+    return Captures(index_name=index_name, schema=schema, table=table)
+
+
+def _captures_regex_create_type(text: str) -> Captures:
+    m = _RE_CREATE_TYPE.search(text)
+    if m is None:
+        return Captures()
+    schema, type_name = _qual_pair(m.group(1), m.group(2))
+    return Captures(schema=schema, type_name=type_name)
+
+
+def _captures_regex_create_schema(text: str) -> Captures:
+    m = _RE_CREATE_SCHEMA.search(text)
+    if m is None:
+        return Captures()
+    return Captures(schema=_unquote(m.group(1)))
+
+
+def _captures_regex_create_sequence(text: str) -> Captures:
+    m = _RE_CREATE_SEQUENCE.search(text)
+    if m is None:
+        return Captures()
+    schema, sequence = _qual_pair(m.group(1), m.group(2))
+    return Captures(schema=schema, sequence=sequence)
+
+
+def _captures_regex_create_extension(text: str) -> Captures:
+    m = _RE_CREATE_EXTENSION.search(text)
+    if m is None:
+        return Captures()
+    return Captures(extension=_unquote(m.group(1)))
+
+
+def _captures_regex_create_view(text: str) -> Captures:
+    m = _RE_CREATE_VIEW.search(text)
+    if m is None:
+        return Captures()
+    schema, view = _qual_pair(m.group(1), m.group(2))
+    return Captures(schema=schema, view=view)
+
+
+def _captures_regex_alter_add_column(text: str) -> Captures:
+    table_match = _RE_ALTER_TABLE.search(text)
+    if table_match is None:
+        return Captures()
+    schema, table = _qual_pair(table_match.group(1), table_match.group(2))
+    column_match = _RE_ADD_COLUMN.search(text)
+    column = _unquote(column_match.group(1)) if column_match else None
+    return Captures(schema=schema, table=table, column=column)
+
+
+def _captures_regex_alter_add_constraint(text: str) -> Captures:
+    table_match = _RE_ALTER_TABLE.search(text)
+    if table_match is None:
+        return Captures()
+    schema, table = _qual_pair(table_match.group(1), table_match.group(2))
+    constraint_match = _RE_ADD_CONSTRAINT.search(text)
+    constraint = _unquote(constraint_match.group(1)) if constraint_match else None
+    return Captures(schema=schema, table=table, constraint=constraint)
+
+
+def _captures_regex_alter_rename_column(text: str) -> Captures:
+    table_match = _RE_ALTER_TABLE.search(text)
+    if table_match is None:
+        return Captures()
+    schema, table = _qual_pair(table_match.group(1), table_match.group(2))
+    rename_match = _RE_RENAME_COLUMN.search(text)
+    if rename_match is None:
+        return Captures(schema=schema, table=table)
+    column = _unquote(rename_match.group(1))
+    new_column = _unquote(rename_match.group(2))
+    return Captures(schema=schema, table=table, column=column, new_column=new_column)
+
+
+def _captures_regex_alter_table_owner(text: str) -> Captures:
+    m = _RE_ALTER_TABLE.search(text)
+    if m is None:
+        return Captures()
+    schema, table = _qual_pair(m.group(1), m.group(2))
+    return Captures(schema=schema, table=table)
+
+
+def _captures_regex_alter_view_owner(text: str) -> Captures:
+    m = _RE_ALTER_VIEW.search(text)
+    if m is None:
+        return Captures()
+    schema, view = _qual_pair(m.group(1), m.group(2))
+    return Captures(schema=schema, view=view)
+
+
+def _captures_regex_alter_matview_owner(text: str) -> Captures:
+    m = _RE_ALTER_MATVIEW.search(text)
+    if m is None:
+        return Captures()
+    schema, view = _qual_pair(m.group(1), m.group(2))
+    return Captures(schema=schema, view=view)
+
+
+def _captures_regex_drop_generic(text: str) -> Captures:
+    """Extract ``schema.name`` from any of the ``DROP <kind> …`` patterns."""
+    m = _RE_DROP_GENERIC.search(text)
+    if m is None:
+        return Captures()
+    schema, name = _qual_pair(m.group(1), m.group(2))
+    return Captures(schema=schema, table=name)
+
+
+_CAPTURES_REGEX_DISPATCH: dict[IdempotencyPattern, Any] = {
+    IdempotencyPattern.CREATE_TABLE: _captures_regex_create_table,
+    IdempotencyPattern.CREATE_INDEX: _captures_regex_create_index,
+    IdempotencyPattern.CREATE_UNIQUE_INDEX: _captures_regex_create_index,
+    IdempotencyPattern.CREATE_TYPE: _captures_regex_create_type,
+    IdempotencyPattern.CREATE_SCHEMA: _captures_regex_create_schema,
+    IdempotencyPattern.CREATE_SEQUENCE: _captures_regex_create_sequence,
+    IdempotencyPattern.CREATE_EXTENSION: _captures_regex_create_extension,
+    IdempotencyPattern.CREATE_VIEW: _captures_regex_create_view,
+    IdempotencyPattern.CREATE_OR_REPLACE_VIEW_SHAPE_RISK: _captures_regex_create_view,
+    IdempotencyPattern.ALTER_TABLE_ADD_COLUMN: _captures_regex_alter_add_column,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK: _captures_regex_alter_add_constraint,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_PRIMARY_KEY: _captures_regex_alter_add_constraint,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_UNIQUE: _captures_regex_alter_add_constraint,
+    IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN: _captures_regex_alter_rename_column,
+    IdempotencyPattern.ALTER_TABLE_OWNER: _captures_regex_alter_table_owner,
+    IdempotencyPattern.ALTER_VIEW_OWNER: _captures_regex_alter_view_owner,
+    IdempotencyPattern.ALTER_MATVIEW_OWNER: _captures_regex_alter_matview_owner,
+    IdempotencyPattern.DROP_TABLE: _captures_regex_drop_generic,
+    IdempotencyPattern.DROP_INDEX: _captures_regex_drop_generic,
+    IdempotencyPattern.DROP_VIEW: _captures_regex_drop_generic,
+    IdempotencyPattern.DROP_TYPE: _captures_regex_drop_generic,
+    IdempotencyPattern.DROP_SCHEMA: _captures_regex_drop_generic,
+    IdempotencyPattern.DROP_SEQUENCE: _captures_regex_drop_generic,
+}
+
+
+# ---------------------------------------------------------------------------
+# AST captures
+# ---------------------------------------------------------------------------
+
+
+def _ast_string_value(node: Any) -> str | None:
+    """Pull ``.sval`` from a pglast ``String`` node, or ``None``."""
+    if node is None:
+        return None
+    sval = getattr(node, "sval", None)
+    if sval is None:
+        return None
+    return str(sval)
+
+
+def _ast_name_parts(parts: Any) -> list[str]:
+    """Render a pglast ``(String, String, …)`` tuple as plain identifiers."""
+    if not isinstance(parts, (tuple, list)):
+        return []
+    out: list[str] = []
+    for part in parts:
+        s = _ast_string_value(part)
+        if s is None:
+            return []
+        out.append(s)
+    return out
+
+
+def _ast_qualified(relation: Any) -> tuple[str | None, str | None]:
+    """``(schema, relname)`` from a pglast ``RangeVar`` node, both lowercased."""
+    if relation is None:
+        return None, None
+    schema = getattr(relation, "schemaname", None)
+    relname = getattr(relation, "relname", None)
+    return (
+        str(schema).lower() if schema else None,
+        str(relname).lower() if relname else None,
+    )
+
+
+def captures_from_ast(pattern: IdempotencyPattern, node: Any) -> Captures:
+    """Build :class:`Captures` from an AST node for ``pattern``."""
+    return _CAPTURES_AST_DISPATCH.get(pattern, _captures_ast_unknown)(node)
+
+
+def _captures_ast_unknown(_node: Any) -> Captures:
+    return Captures()
+
+
+def _captures_ast_create_stmt(node: Any) -> Captures:
+    schema, table = _ast_qualified(getattr(node, "relation", None))
+    return Captures(schema=schema, table=table)
+
+
+def _captures_ast_index_stmt(node: Any) -> Captures:
+    index_name = getattr(node, "idxname", None)
+    schema, table = _ast_qualified(getattr(node, "relation", None))
+    return Captures(
+        index_name=str(index_name).lower() if index_name else None,
+        schema=schema,
+        table=table,
+    )
+
+
+def _captures_ast_create_enum_stmt(node: Any) -> Captures:
+    parts = _ast_name_parts(getattr(node, "typeName", None))
+    if not parts:
+        return Captures()
+    if len(parts) >= 2:
+        return Captures(schema=parts[0].lower(), type_name=parts[1].lower())
+    return Captures(type_name=parts[0].lower())
+
+
+def _captures_ast_create_schema_stmt(node: Any) -> Captures:
+    name = getattr(node, "schemaname", None)
+    return Captures(schema=str(name).lower() if name else None)
+
+
+def _captures_ast_create_seq_stmt(node: Any) -> Captures:
+    schema, name = _ast_qualified(getattr(node, "sequence", None))
+    return Captures(schema=schema, sequence=name)
+
+
+def _captures_ast_create_extension_stmt(node: Any) -> Captures:
+    name = getattr(node, "extname", None)
+    return Captures(extension=str(name).lower() if name else None)
+
+
+def _captures_ast_view_stmt(node: Any) -> Captures:
+    schema, view = _ast_qualified(getattr(node, "view", None))
+    return Captures(schema=schema, view=view)
+
+
+def _captures_ast_create_function_stmt(node: Any) -> Captures:
+    parts = _ast_name_parts(getattr(node, "funcname", None))
+    if not parts:
+        return Captures()
+    if len(parts) >= 2:
+        return Captures(schema=parts[0].lower(), table=parts[1].lower())
+    return Captures(table=parts[0].lower())
+
+
+def _captures_ast_alter_add_column(node: Any) -> Captures:
+    schema, table = _ast_qualified(getattr(node, "relation", None))
+    column: str | None = None
+    for cmd in getattr(node, "cmds", None) or ():
+        subtype = getattr(cmd, "subtype", None)
+        sub_val = getattr(subtype, "value", subtype)
+        try:
+            sub_int = int(sub_val) if sub_val is not None else None
+        except (TypeError, ValueError):
+            sub_int = None
+        if sub_int == 0:  # AT_ADD_COLUMN
+            col_def = getattr(cmd, "def_", None)
+            colname = getattr(col_def, "colname", None) if col_def is not None else None
+            if colname:
+                column = str(colname).lower()
+                break
+    return Captures(schema=schema, table=table, column=column)
+
+
+def _captures_ast_alter_add_constraint(node: Any) -> Captures:
+    schema, table = _ast_qualified(getattr(node, "relation", None))
+    constraint: str | None = None
+    for cmd in getattr(node, "cmds", None) or ():
+        subtype = getattr(cmd, "subtype", None)
+        sub_val = getattr(subtype, "value", subtype)
+        try:
+            sub_int = int(sub_val) if sub_val is not None else None
+        except (TypeError, ValueError):
+            sub_int = None
+        if sub_int == 17:  # AT_ADD_CONSTRAINT
+            constraint_def = getattr(cmd, "def_", None)
+            conname = getattr(constraint_def, "conname", None) if constraint_def is not None else None
+            if conname:
+                constraint = str(conname).lower()
+                break
+    return Captures(schema=schema, table=table, constraint=constraint)
+
+
+def _captures_ast_rename_stmt(node: Any) -> Captures:
+    schema, table = _ast_qualified(getattr(node, "relation", None))
+    old = getattr(node, "subname", None)
+    new = getattr(node, "newname", None)
+    return Captures(
+        schema=schema,
+        table=table,
+        column=str(old).lower() if old else None,
+        new_column=str(new).lower() if new else None,
+    )
+
+
+def _captures_ast_alter_table_owner(node: Any) -> Captures:
+    schema, table = _ast_qualified(getattr(node, "relation", None))
+    return Captures(schema=schema, table=table)
+
+
+def _captures_ast_alter_view_owner(node: Any) -> Captures:
+    schema, view = _ast_qualified(getattr(node, "relation", None))
+    return Captures(schema=schema, view=view)
+
+
+def _captures_ast_alter_matview_owner(node: Any) -> Captures:
+    schema, view = _ast_qualified(getattr(node, "relation", None))
+    return Captures(schema=schema, view=view)
+
+
+def _captures_ast_drop_stmt(node: Any) -> Captures:
+    """Pull the first dropped object's qualified name onto ``schema``/``table``."""
+    objects = getattr(node, "objects", None) or ()
+    for obj in objects:
+        if isinstance(obj, tuple):
+            parts = _ast_name_parts(obj)
+            if not parts:
+                continue
+            if len(parts) >= 2:
+                return Captures(schema=parts[0].lower(), table=parts[1].lower())
+            return Captures(table=parts[0].lower())
+        sval = _ast_string_value(obj)
+        if sval:
+            return Captures(table=sval.lower())
+    return Captures()
+
+
+_CAPTURES_AST_DISPATCH: dict[IdempotencyPattern, Any] = {
+    IdempotencyPattern.CREATE_TABLE: _captures_ast_create_stmt,
+    IdempotencyPattern.CREATE_INDEX: _captures_ast_index_stmt,
+    IdempotencyPattern.CREATE_UNIQUE_INDEX: _captures_ast_index_stmt,
+    IdempotencyPattern.CREATE_TYPE: _captures_ast_create_enum_stmt,
+    IdempotencyPattern.CREATE_SCHEMA: _captures_ast_create_schema_stmt,
+    IdempotencyPattern.CREATE_SEQUENCE: _captures_ast_create_seq_stmt,
+    IdempotencyPattern.CREATE_EXTENSION: _captures_ast_create_extension_stmt,
+    IdempotencyPattern.CREATE_VIEW: _captures_ast_view_stmt,
+    IdempotencyPattern.CREATE_OR_REPLACE_VIEW_SHAPE_RISK: _captures_ast_view_stmt,
+    IdempotencyPattern.ALTER_TABLE_ADD_COLUMN: _captures_ast_alter_add_column,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK: _captures_ast_alter_add_constraint,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_PRIMARY_KEY: _captures_ast_alter_add_constraint,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_UNIQUE: _captures_ast_alter_add_constraint,
+    IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN: _captures_ast_rename_stmt,
+    IdempotencyPattern.ALTER_TABLE_OWNER: _captures_ast_alter_table_owner,
+    IdempotencyPattern.ALTER_VIEW_OWNER: _captures_ast_alter_view_owner,
+    IdempotencyPattern.ALTER_MATVIEW_OWNER: _captures_ast_alter_matview_owner,
+    IdempotencyPattern.DROP_TABLE: _captures_ast_drop_stmt,
+    IdempotencyPattern.DROP_INDEX: _captures_ast_drop_stmt,
+    IdempotencyPattern.DROP_VIEW: _captures_ast_drop_stmt,
+    IdempotencyPattern.DROP_TYPE: _captures_ast_drop_stmt,
+    IdempotencyPattern.DROP_SCHEMA: _captures_ast_drop_stmt,
+    IdempotencyPattern.DROP_SEQUENCE: _captures_ast_drop_stmt,
+}

--- a/python/confiture/core/idempotency/_naming.py
+++ b/python/confiture/core/idempotency/_naming.py
@@ -1,0 +1,39 @@
+"""Shared identifier-quoting helpers for suggestion templates.
+
+Templates take :class:`~confiture.core.idempotency._captures.Captures`
+and assemble SQL. These helpers handle the awkward bits — quoting an
+identifier only when it actually needs quoting, joining ``schema.name``
+when ``schema`` is present.
+"""
+
+from __future__ import annotations
+
+import keyword
+import re
+
+_BARE_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+def quote_ident(name: str) -> str:
+    """Quote ``name`` as a PostgreSQL identifier when needed.
+
+    Lowercase ASCII identifiers that aren't reserved keywords are emitted
+    bare; anything else gets double-quoted with internal quotes doubled.
+    """
+    if _BARE_IDENT_RE.match(name) and not keyword.iskeyword(name):
+        return name
+    return '"' + name.replace('"', '""') + '"'
+
+
+def qualify(schema: str | None, name: str | None) -> str | None:
+    """Render ``schema.name`` (or ``name`` alone), quoting both halves.
+
+    Returns ``None`` when ``name`` is missing — the caller is responsible
+    for the missing-identifier fallback.
+    """
+    if not name:
+        return None
+    qname = quote_ident(name)
+    if schema:
+        return f"{quote_ident(schema)}.{qname}"
+    return qname

--- a/python/confiture/core/idempotency/ast_detector.py
+++ b/python/confiture/core/idempotency/ast_detector.py
@@ -49,7 +49,9 @@ from confiture.core.idempotency._ast_visitor import (
     _line_for_stmt,
     _StatementContext,
 )
+from confiture.core.idempotency._captures import captures_from_ast
 from confiture.core.idempotency.models import IdempotencyPattern
+from confiture.core.idempotency.suggestion_templates import suggestion_for
 
 if TYPE_CHECKING:
     from confiture.core.idempotency.patterns import PatternMatch
@@ -250,6 +252,7 @@ def _make_match(
 ) -> PatternMatch:
     from confiture.core.idempotency.patterns import PatternMatch  # noqa: PLC0415
 
+    captures = captures_from_ast(pattern, ctx.stmt)
     return PatternMatch(
         pattern=pattern,
         sql_snippet=_extract_snippet_from_stmt(sql, ctx.stmt_location, ctx.stmt_len),
@@ -257,6 +260,7 @@ def _make_match(
         start_pos=ctx.stmt_location,
         end_pos=ctx.stmt_location + ctx.stmt_len,
         severity=severity,
+        suggestion=suggestion_for(pattern, captures),
     )
 
 

--- a/python/confiture/core/idempotency/fixer.py
+++ b/python/confiture/core/idempotency/fixer.py
@@ -145,26 +145,35 @@ class IdempotencyFixer:
             return True
         return pattern in self.fix_patterns
 
+    # Dispatch table: pattern → fixer-method name. The set of keys is the
+    # single source of truth for ``FIXABLE_PATTERNS`` (and therefore for
+    # ``IdempotencyPattern.fix_available``) — keep them in sync.
+    _FIX_METHOD_NAMES: dict[IdempotencyPattern, str] = {
+        IdempotencyPattern.CREATE_TABLE: "_fix_create_table",
+        IdempotencyPattern.CREATE_INDEX: "_fix_create_index",
+        IdempotencyPattern.CREATE_UNIQUE_INDEX: "_fix_create_unique_index",
+        IdempotencyPattern.CREATE_FUNCTION: "_fix_create_function",
+        IdempotencyPattern.CREATE_PROCEDURE: "_fix_create_procedure",
+        IdempotencyPattern.CREATE_VIEW: "_fix_create_view",
+        IdempotencyPattern.CREATE_EXTENSION: "_fix_create_extension",
+        IdempotencyPattern.CREATE_SCHEMA: "_fix_create_schema",
+        IdempotencyPattern.CREATE_SEQUENCE: "_fix_create_sequence",
+        IdempotencyPattern.ALTER_TABLE_ADD_COLUMN: "_fix_alter_table_add_column",
+        IdempotencyPattern.DROP_TABLE: "_fix_drop_table",
+        IdempotencyPattern.DROP_INDEX: "_fix_drop_index",
+        IdempotencyPattern.DROP_FUNCTION: "_fix_drop_function",
+        IdempotencyPattern.DROP_VIEW: "_fix_drop_view",
+        IdempotencyPattern.DROP_TYPE: "_fix_drop_type",
+        IdempotencyPattern.DROP_SCHEMA: "_fix_drop_schema",
+        IdempotencyPattern.DROP_SEQUENCE: "_fix_drop_sequence",
+    }
+
     def _get_suggested_fix(self, pattern: IdempotencyPattern, original: str) -> str:
         """Get the suggested fix for a pattern."""
-        # Apply the specific fix and return the result
-        fix_methods = {
-            IdempotencyPattern.CREATE_TABLE: self._fix_create_table,
-            IdempotencyPattern.CREATE_INDEX: self._fix_create_index,
-            IdempotencyPattern.CREATE_UNIQUE_INDEX: self._fix_create_unique_index,
-            IdempotencyPattern.CREATE_FUNCTION: self._fix_create_function,
-            IdempotencyPattern.CREATE_PROCEDURE: self._fix_create_procedure,
-            IdempotencyPattern.CREATE_VIEW: self._fix_create_view,
-            IdempotencyPattern.DROP_TABLE: self._fix_drop_table,
-            IdempotencyPattern.DROP_INDEX: self._fix_drop_index,
-            IdempotencyPattern.DROP_FUNCTION: self._fix_drop_function,
-            IdempotencyPattern.DROP_VIEW: self._fix_drop_view,
-            IdempotencyPattern.ALTER_TABLE_ADD_COLUMN: self._fix_alter_table_add_column,
-        }
-        fix_method = fix_methods.get(pattern)
-        if fix_method:
-            return fix_method(original)
-        return original
+        method_name = self._FIX_METHOD_NAMES.get(pattern)
+        if method_name is None:
+            return original
+        return getattr(self, method_name)(original)
 
     def _fix_create_table(self, sql: str) -> str:
         """Add IF NOT EXISTS to CREATE TABLE statements."""
@@ -406,3 +415,11 @@ class IdempotencyFixer:
             re.IGNORECASE,
         )
         return pattern.sub(r"DROP SEQUENCE IF EXISTS \1\2", sql)
+
+
+# Single source of truth for which patterns have an automatic fix.
+# Built from the dispatch table so ``dry_run`` and ``fix`` agree, and
+# ``IdempotencyPattern.fix_available`` reads from the same set.
+FIXABLE_PATTERNS: frozenset[IdempotencyPattern] = frozenset(
+    IdempotencyFixer._FIX_METHOD_NAMES.keys()
+)

--- a/python/confiture/core/idempotency/models.py
+++ b/python/confiture/core/idempotency/models.py
@@ -125,27 +125,17 @@ class IdempotencyPattern(Enum):
 
     @property
     def fix_available(self) -> bool:
-        """Check if automatic fix is available for this pattern."""
-        fixable = {
-            IdempotencyPattern.CREATE_TABLE,
-            IdempotencyPattern.CREATE_INDEX,
-            IdempotencyPattern.CREATE_UNIQUE_INDEX,
-            IdempotencyPattern.CREATE_FUNCTION,
-            IdempotencyPattern.CREATE_PROCEDURE,
-            IdempotencyPattern.CREATE_VIEW,
-            IdempotencyPattern.CREATE_EXTENSION,
-            IdempotencyPattern.CREATE_SCHEMA,
-            IdempotencyPattern.CREATE_SEQUENCE,
-            IdempotencyPattern.ALTER_TABLE_ADD_COLUMN,
-            IdempotencyPattern.DROP_TABLE,
-            IdempotencyPattern.DROP_INDEX,
-            IdempotencyPattern.DROP_FUNCTION,
-            IdempotencyPattern.DROP_VIEW,
-            IdempotencyPattern.DROP_TYPE,
-            IdempotencyPattern.DROP_SCHEMA,
-            IdempotencyPattern.DROP_SEQUENCE,
-        }
-        return self in fixable
+        """Check if automatic fix is available for this pattern.
+
+        Reads from :data:`confiture.core.idempotency.fixer.FIXABLE_PATTERNS`,
+        which is derived from the fixer's dispatch table — the single
+        source of truth. Lazy import avoids a models→fixer cycle at
+        package-load time.
+        """
+        # Lazy import to break models→fixer→models cycle.
+        from confiture.core.idempotency.fixer import FIXABLE_PATTERNS
+
+        return self in FIXABLE_PATTERNS
 
 
 @dataclass

--- a/python/confiture/core/idempotency/models.py
+++ b/python/confiture/core/idempotency/models.py
@@ -147,6 +147,9 @@ class IdempotencyViolation:
         sql_snippet: The SQL code that triggered the violation
         line_number: Line number in the file where violation occurs
         file_path: Path to the migration file
+        suggestion: Filled-in fix template (set by the detector) or the
+            generic pattern suggestion when no captures were available.
+            Pass ``None`` to fall back to :attr:`IdempotencyPattern.suggestion`.
     """
 
     pattern: IdempotencyPattern
@@ -155,11 +158,11 @@ class IdempotencyViolation:
     file_path: str
     source_line: int | None = None
     severity: str = "error"
+    suggestion: str | None = None
 
-    @property
-    def suggestion(self) -> str:
-        """Get suggestion for fixing this violation."""
-        return self.pattern.suggestion
+    def __post_init__(self) -> None:
+        if self.suggestion is None:
+            self.suggestion = self.pattern.suggestion
 
     @property
     def fix_available(self) -> bool:

--- a/python/confiture/core/idempotency/patterns.py
+++ b/python/confiture/core/idempotency/patterns.py
@@ -34,6 +34,7 @@ class PatternCatalogEntry(TypedDict):
     has_skip_regex: bool
     skip_hint: str | None
     has_auto_fix: bool
+    template_fillable: bool
 
 _FORCE_REGEX_ENV = "CONFITURE_IDEMPOTENCY_FORCE_REGEX"
 
@@ -57,6 +58,10 @@ class PatternMatch:
         severity: ``"error"`` (default — fails the gate) or ``"info"``
             (heuristic finding — rendered but doesn't fail the gate
             unless ``--strict-cor`` is passed at the CLI layer).
+        suggestion: Filled-in fix template (captures-driven) or ``None``
+            to fall back to :attr:`IdempotencyPattern.suggestion`. The
+            validator copies this onto the resulting
+            :class:`~confiture.core.idempotency.models.IdempotencyViolation`.
     """
 
     pattern: IdempotencyPattern
@@ -65,6 +70,7 @@ class PatternMatch:
     start_pos: int
     end_pos: int
     severity: str = "error"
+    suggestion: str | None = None
 
 
 class PatternDefinition(NamedTuple):
@@ -389,6 +395,60 @@ _DESCRIPTIONS: dict[IdempotencyPattern, str] = {
     ),
 }
 
+# Classification of patterns by whether a captures-driven suggestion
+# template can be filled from the match. Both sets together cover every
+# :class:`IdempotencyPattern` member; the two sets are disjoint.
+#
+# ``TEMPLATE_FILLABLE`` patterns expose at least one identifier
+# (table, index, constraint, column, …) that the AST / regex backend
+# can extract reliably, so the violation's ``suggestion`` is a
+# copy-pasteable SQL block with that identifier inlined.
+#
+# ``TEMPLATE_NOT_AVAILABLE`` patterns can be detected but their
+# corrective fix has no mechanical structure — the suggestion stays
+# generic and explicitly says so.
+TEMPLATE_FILLABLE: frozenset[IdempotencyPattern] = frozenset(
+    {
+        IdempotencyPattern.CREATE_TABLE,
+        IdempotencyPattern.CREATE_INDEX,
+        IdempotencyPattern.CREATE_UNIQUE_INDEX,
+        IdempotencyPattern.CREATE_VIEW,
+        IdempotencyPattern.CREATE_TYPE,
+        IdempotencyPattern.CREATE_SCHEMA,
+        IdempotencyPattern.CREATE_SEQUENCE,
+        IdempotencyPattern.CREATE_EXTENSION,
+        IdempotencyPattern.ALTER_TABLE_ADD_COLUMN,
+        IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK,
+        IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_PRIMARY_KEY,
+        IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_UNIQUE,
+        IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN,
+        IdempotencyPattern.ALTER_TABLE_OWNER,
+        IdempotencyPattern.ALTER_VIEW_OWNER,
+        IdempotencyPattern.ALTER_MATVIEW_OWNER,
+        IdempotencyPattern.DROP_TABLE,
+        IdempotencyPattern.DROP_INDEX,
+        IdempotencyPattern.DROP_VIEW,
+        IdempotencyPattern.DROP_TYPE,
+        IdempotencyPattern.DROP_SCHEMA,
+        IdempotencyPattern.DROP_SEQUENCE,
+        IdempotencyPattern.CREATE_OR_REPLACE_VIEW_SHAPE_RISK,
+    }
+)
+
+# Patterns that can be detected but whose fix has no mechanical
+# template — the regex doesn't pin a single identifier to substitute
+# in, or the fix structurally requires user judgement (e.g. DROP
+# FUNCTION needs a parameter signature, not just a name).
+TEMPLATE_NOT_AVAILABLE: frozenset[IdempotencyPattern] = frozenset(
+    {
+        IdempotencyPattern.CREATE_FUNCTION,
+        IdempotencyPattern.CREATE_PROCEDURE,
+        IdempotencyPattern.DROP_FUNCTION,
+        IdempotencyPattern.CREATE_OR_REPLACE_FUNCTION_SHAPE_RISK,
+        IdempotencyPattern.CREATE_OR_REPLACE_PROCEDURE_SHAPE_RISK,
+    }
+)
+
 # Human-friendly hints describing what idempotent form the validator
 # skips over. Only set for patterns with a ``skip_regex`` — patterns
 # that have no simple skip (e.g. CREATE TYPE) map to ``None``.
@@ -434,6 +494,7 @@ def list_patterns() -> list[PatternCatalogEntry]:
                 has_skip_regex=has_skip,
                 skip_hint=_SKIP_HINTS.get(pdef.pattern) if has_skip else None,
                 has_auto_fix=pdef.pattern.fix_available,
+                template_fillable=pdef.pattern in TEMPLATE_FILLABLE,
             )
         )
     return catalog
@@ -726,6 +787,18 @@ def _detect_via_regex(sql: str) -> list[PatternMatch]:
                 if "UNIQUE" in pre_match.upper():
                     continue
 
+            # Build the filled suggestion at detection time so violations
+            # carry a copy-pasteable fix block instead of the generic
+            # placeholder text. ``captures_from_regex`` returns an
+            # all-None ``Captures`` for patterns it can't extract from;
+            # ``suggestion_for`` handles that by falling back to the
+            # generic suggestion automatically.
+            from confiture.core.idempotency._captures import captures_from_regex  # noqa: PLC0415
+            from confiture.core.idempotency.suggestion_templates import (  # noqa: PLC0415
+                suggestion_for,
+            )
+
+            captures = captures_from_regex(pattern_def.pattern, match)
             matches.append(
                 PatternMatch(
                     pattern=pattern_def.pattern,
@@ -734,6 +807,7 @@ def _detect_via_regex(sql: str) -> list[PatternMatch]:
                     start_pos=match.start(),
                     end_pos=match.end(),
                     severity=pattern_def.severity,
+                    suggestion=suggestion_for(pattern_def.pattern, captures),
                 )
             )
 

--- a/python/confiture/core/idempotency/patterns.py
+++ b/python/confiture/core/idempotency/patterns.py
@@ -15,10 +15,25 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import NamedTuple, TypedDict
 
 from confiture.core.idempotency.ast_detector import _detect_via_ast, is_pglast_available
 from confiture.core.idempotency.models import IdempotencyPattern
+
+
+class PatternCatalogEntry(TypedDict):
+    """Public shape of a single entry in the pattern catalog.
+
+    Stable contract — see ``--list-patterns`` JSON schema (``version: "1"``)
+    in ``docs/reference/json-schemas/migrate-validate-list-patterns.schema.json``.
+    """
+
+    id: str
+    description: str
+    severity: str
+    has_skip_regex: bool
+    skip_hint: str | None
+    has_auto_fix: bool
 
 _FORCE_REGEX_ENV = "CONFITURE_IDEMPOTENCY_FORCE_REGEX"
 
@@ -320,6 +335,109 @@ PATTERNS: list[PatternDefinition] = [
         skip_regex=re.compile(r"DROP\s+SEQUENCE\s+IF\s+EXISTS", re.IGNORECASE),
     ),
 ]
+
+# Human-readable descriptions of what each pattern detects.
+# Surfaced via ``confiture migrate validate --list-patterns``; keep concise
+# (one short sentence per entry, present tense, describes the violation —
+# not the fix).
+_DESCRIPTIONS: dict[IdempotencyPattern, str] = {
+    IdempotencyPattern.CREATE_TABLE: "CREATE TABLE without IF NOT EXISTS.",
+    IdempotencyPattern.CREATE_INDEX: "CREATE INDEX without IF NOT EXISTS.",
+    IdempotencyPattern.CREATE_UNIQUE_INDEX: "CREATE UNIQUE INDEX without IF NOT EXISTS.",
+    IdempotencyPattern.CREATE_FUNCTION: "CREATE FUNCTION without OR REPLACE.",
+    IdempotencyPattern.CREATE_PROCEDURE: "CREATE PROCEDURE without OR REPLACE.",
+    IdempotencyPattern.CREATE_VIEW: "CREATE VIEW without a preceding DROP VIEW IF EXISTS.",
+    IdempotencyPattern.CREATE_TYPE: (
+        "CREATE TYPE outside a DO block that checks pg_type — re-run will fail."
+    ),
+    IdempotencyPattern.CREATE_EXTENSION: "CREATE EXTENSION without IF NOT EXISTS.",
+    IdempotencyPattern.CREATE_SCHEMA: "CREATE SCHEMA without IF NOT EXISTS.",
+    IdempotencyPattern.CREATE_SEQUENCE: "CREATE SEQUENCE without IF NOT EXISTS.",
+    IdempotencyPattern.ALTER_TABLE_ADD_COLUMN: "ALTER TABLE ADD COLUMN without IF NOT EXISTS.",
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK: (
+        "ALTER TABLE ADD CONSTRAINT CHECK without DROP CONSTRAINT IF EXISTS or DO-block guard."
+    ),
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_PRIMARY_KEY: (
+        "ALTER TABLE ADD CONSTRAINT PRIMARY KEY without DROP CONSTRAINT IF EXISTS or guard."
+    ),
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_UNIQUE: (
+        "ALTER TABLE ADD CONSTRAINT UNIQUE without DROP CONSTRAINT IF EXISTS or guard."
+    ),
+    IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN: (
+        "ALTER TABLE RENAME COLUMN without information_schema guard."
+    ),
+    IdempotencyPattern.ALTER_TABLE_OWNER: "ALTER TABLE … OWNER TO without pg_class existence check.",
+    IdempotencyPattern.ALTER_VIEW_OWNER: "ALTER VIEW … OWNER TO without pg_class existence check.",
+    IdempotencyPattern.ALTER_MATVIEW_OWNER: (
+        "ALTER MATERIALIZED VIEW … OWNER TO without pg_matviews existence check."
+    ),
+    IdempotencyPattern.DROP_TABLE: "DROP TABLE without IF EXISTS.",
+    IdempotencyPattern.DROP_INDEX: "DROP INDEX without IF EXISTS.",
+    IdempotencyPattern.DROP_FUNCTION: "DROP FUNCTION without IF EXISTS.",
+    IdempotencyPattern.DROP_VIEW: "DROP VIEW without IF EXISTS.",
+    IdempotencyPattern.DROP_TYPE: "DROP TYPE without IF EXISTS.",
+    IdempotencyPattern.DROP_SCHEMA: "DROP SCHEMA without IF EXISTS.",
+    IdempotencyPattern.DROP_SEQUENCE: "DROP SEQUENCE without IF EXISTS.",
+    IdempotencyPattern.CREATE_OR_REPLACE_VIEW_SHAPE_RISK: (
+        "CREATE OR REPLACE VIEW — shape changes (column add/rename/reorder) fail at runtime."
+    ),
+    IdempotencyPattern.CREATE_OR_REPLACE_FUNCTION_SHAPE_RISK: (
+        "CREATE OR REPLACE FUNCTION — fails when input parameters are renamed."
+    ),
+    IdempotencyPattern.CREATE_OR_REPLACE_PROCEDURE_SHAPE_RISK: (
+        "CREATE OR REPLACE PROCEDURE — fails when input parameters are renamed."
+    ),
+}
+
+# Human-friendly hints describing what idempotent form the validator
+# skips over. Only set for patterns with a ``skip_regex`` — patterns
+# that have no simple skip (e.g. CREATE TYPE) map to ``None``.
+_SKIP_HINTS: dict[IdempotencyPattern, str | None] = {
+    IdempotencyPattern.CREATE_TABLE: "CREATE TABLE IF NOT EXISTS",
+    IdempotencyPattern.CREATE_INDEX: "CREATE INDEX IF NOT EXISTS",
+    IdempotencyPattern.CREATE_UNIQUE_INDEX: "CREATE UNIQUE INDEX IF NOT EXISTS",
+    IdempotencyPattern.CREATE_FUNCTION: "CREATE OR REPLACE FUNCTION",
+    IdempotencyPattern.CREATE_PROCEDURE: "CREATE OR REPLACE PROCEDURE",
+    IdempotencyPattern.CREATE_VIEW: "CREATE OR REPLACE VIEW",
+    IdempotencyPattern.CREATE_EXTENSION: "CREATE EXTENSION IF NOT EXISTS",
+    IdempotencyPattern.CREATE_SCHEMA: "CREATE SCHEMA IF NOT EXISTS",
+    IdempotencyPattern.CREATE_SEQUENCE: "CREATE SEQUENCE IF NOT EXISTS",
+    IdempotencyPattern.ALTER_TABLE_ADD_COLUMN: "ALTER TABLE … ADD COLUMN IF NOT EXISTS",
+    IdempotencyPattern.DROP_TABLE: "DROP TABLE IF EXISTS",
+    IdempotencyPattern.DROP_INDEX: "DROP INDEX IF EXISTS",
+    IdempotencyPattern.DROP_FUNCTION: "DROP FUNCTION IF EXISTS",
+    IdempotencyPattern.DROP_VIEW: "DROP VIEW IF EXISTS",
+    IdempotencyPattern.DROP_TYPE: "DROP TYPE IF EXISTS",
+    IdempotencyPattern.DROP_SCHEMA: "DROP SCHEMA IF EXISTS",
+    IdempotencyPattern.DROP_SEQUENCE: "DROP SEQUENCE IF EXISTS",
+}
+
+
+def list_patterns() -> list[PatternCatalogEntry]:
+    """Build a machine-readable catalog of all detection patterns.
+
+    Read-only: no DB connection, no config file, no migrations directory.
+    Returned entries are JSON-serialisable (no ``re.Pattern`` objects).
+
+    Returns:
+        One :class:`PatternCatalogEntry` per :data:`PATTERNS` entry, in
+        the same order. Stable contract — frozen at ``version: "1"``.
+    """
+    catalog: list[PatternCatalogEntry] = []
+    for pdef in PATTERNS:
+        has_skip = pdef.skip_regex is not None
+        catalog.append(
+            PatternCatalogEntry(
+                id=pdef.pattern.name,
+                description=_DESCRIPTIONS.get(pdef.pattern, ""),
+                severity=pdef.severity,
+                has_skip_regex=has_skip,
+                skip_hint=_SKIP_HINTS.get(pdef.pattern) if has_skip else None,
+                has_auto_fix=pdef.pattern.fix_available,
+            )
+        )
+    return catalog
+
 
 # Pattern to detect DO blocks (for exception handling)
 DO_BLOCK_PATTERN = re.compile(

--- a/python/confiture/core/idempotency/suggestion_templates.py
+++ b/python/confiture/core/idempotency/suggestion_templates.py
@@ -1,0 +1,315 @@
+"""Captures-driven suggestion templates for idempotency violations.
+
+The regex and AST detectors both feed a normalized
+:class:`~confiture.core.idempotency._captures.Captures` into
+:func:`suggestion_for`, which dispatches by
+:class:`~confiture.core.idempotency.models.IdempotencyPattern` and
+returns a copy-pasteable SQL block with the captured identifiers
+inlined.
+
+When a required field on :class:`Captures` is missing (or the pattern
+is in :data:`TEMPLATE_NOT_AVAILABLE`), the function returns the
+generic pattern suggestion with an explicit
+:data:`NO_TEMPLATE_AVAILABLE_MARKER` appended.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeAlias
+
+from confiture.core.idempotency._captures import Captures
+from confiture.core.idempotency._naming import qualify
+from confiture.core.idempotency.models import IdempotencyPattern
+
+NO_TEMPLATE_AVAILABLE_MARKER = "no auto-template available — manual fix required"
+
+
+_TemplateFn: TypeAlias = Callable[[Captures], str | None]
+
+
+def _t_create_table(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None:
+        return None
+    return f"CREATE TABLE IF NOT EXISTS {qname} ( ... );"
+
+
+def _t_create_index(cap: Captures) -> str | None:
+    if not cap.index_name:
+        return None
+    idx = qualify(None, cap.index_name)
+    target = qualify(cap.schema, cap.table)
+    target_clause = f" ON {target}" if target else ""
+    return f"CREATE INDEX IF NOT EXISTS {idx}{target_clause} ( ... );"
+
+
+def _t_create_unique_index(cap: Captures) -> str | None:
+    if not cap.index_name:
+        return None
+    idx = qualify(None, cap.index_name)
+    target = qualify(cap.schema, cap.table)
+    target_clause = f" ON {target}" if target else ""
+    return f"CREATE UNIQUE INDEX IF NOT EXISTS {idx}{target_clause} ( ... );"
+
+
+def _t_create_view(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.view)
+    if qname is None:
+        return None
+    return f"DROP VIEW IF EXISTS {qname} CASCADE;\nCREATE VIEW {qname} AS\n    SELECT ...;"
+
+
+def _t_create_or_replace_view_shape_risk(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.view)
+    if qname is None:
+        return None
+    return (
+        "-- For shape changes (column add/rename/reorder), use:\n"
+        f"DROP VIEW IF EXISTS {qname} CASCADE;\n"
+        f"CREATE VIEW {qname} AS\n    SELECT ...;"
+    )
+
+
+def _t_create_type_enum(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.type_name)
+    if qname is None:
+        return None
+    return (
+        "DO $$ BEGIN\n"
+        f"    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = '{cap.type_name}') THEN\n"
+        f"        CREATE TYPE {qname} AS ENUM ( ... );\n"
+        "    END IF;\n"
+        "END $$;"
+    )
+
+
+def _t_create_schema(cap: Captures) -> str | None:
+    if not cap.schema:
+        return None
+    return f"CREATE SCHEMA IF NOT EXISTS {qualify(None, cap.schema)};"
+
+
+def _t_create_sequence(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.sequence)
+    if qname is None:
+        return None
+    return f"CREATE SEQUENCE IF NOT EXISTS {qname};"
+
+
+def _t_create_extension(cap: Captures) -> str | None:
+    if not cap.extension:
+        return None
+    return f"CREATE EXTENSION IF NOT EXISTS {qualify(None, cap.extension)};"
+
+
+def _t_alter_add_column(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None or not cap.column:
+        return None
+    col = qualify(None, cap.column)
+    return f"ALTER TABLE {qname}\n    ADD COLUMN IF NOT EXISTS {col} <TYPE>;"
+
+
+def _t_alter_add_constraint_check(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None or not cap.constraint:
+        return None
+    cname = qualify(None, cap.constraint)
+    return (
+        f"ALTER TABLE {qname}\n"
+        f"    DROP CONSTRAINT IF EXISTS {cname};\n"
+        f"ALTER TABLE {qname}\n"
+        f"    ADD CONSTRAINT {cname} CHECK ( ... );"
+    )
+
+
+def _t_alter_add_constraint_primary_key(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None or not cap.constraint:
+        return None
+    cname = qualify(None, cap.constraint)
+    return (
+        f"ALTER TABLE {qname}\n"
+        f"    DROP CONSTRAINT IF EXISTS {cname};\n"
+        f"ALTER TABLE {qname}\n"
+        f"    ADD CONSTRAINT {cname} PRIMARY KEY ( ... );"
+    )
+
+
+def _t_alter_add_constraint_unique(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None or not cap.constraint:
+        return None
+    cname = qualify(None, cap.constraint)
+    return (
+        f"ALTER TABLE {qname}\n"
+        f"    DROP CONSTRAINT IF EXISTS {cname};\n"
+        f"ALTER TABLE {qname}\n"
+        f"    ADD CONSTRAINT {cname} UNIQUE ( ... );"
+    )
+
+
+def _t_alter_rename_column(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None or not cap.column or not cap.new_column:
+        return None
+    old = qualify(None, cap.column)
+    new = qualify(None, cap.new_column)
+    table_literal = cap.table
+    column_literal = cap.column
+    new_literal = cap.new_column
+    return (
+        "DO $$ BEGIN\n"
+        "    IF EXISTS (\n"
+        "        SELECT 1 FROM information_schema.columns\n"
+        f"        WHERE table_name = '{table_literal}' AND column_name = '{column_literal}'\n"
+        "    ) AND NOT EXISTS (\n"
+        "        SELECT 1 FROM information_schema.columns\n"
+        f"        WHERE table_name = '{table_literal}' AND column_name = '{new_literal}'\n"
+        "    ) THEN\n"
+        f"        ALTER TABLE {qname} RENAME COLUMN {old} TO {new};\n"
+        "    END IF;\n"
+        "END $$;"
+    )
+
+
+def _t_alter_table_owner(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None:
+        return None
+    schema = cap.schema or "public"
+    return (
+        "DO $$ BEGIN\n"
+        "    IF EXISTS (\n"
+        "        SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace\n"
+        f"        WHERE n.nspname = '{schema}' AND c.relname = '{cap.table}'\n"
+        "    ) THEN\n"
+        f"        ALTER TABLE {qname} OWNER TO <new_owner>;\n"
+        "    END IF;\n"
+        "END $$;"
+    )
+
+
+def _t_alter_view_owner(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.view)
+    if qname is None:
+        return None
+    schema = cap.schema or "public"
+    return (
+        "DO $$ BEGIN\n"
+        "    IF EXISTS (\n"
+        "        SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace\n"
+        f"        WHERE n.nspname = '{schema}' AND c.relname = '{cap.view}'\n"
+        "    ) THEN\n"
+        f"        ALTER VIEW {qname} OWNER TO <new_owner>;\n"
+        "    END IF;\n"
+        "END $$;"
+    )
+
+
+def _t_alter_matview_owner(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.view)
+    if qname is None:
+        return None
+    schema = cap.schema or "public"
+    return (
+        "DO $$ BEGIN\n"
+        "    IF EXISTS (\n"
+        "        SELECT 1 FROM pg_matviews\n"
+        f"        WHERE schemaname = '{schema}' AND matviewname = '{cap.view}'\n"
+        "    ) THEN\n"
+        f"        ALTER MATERIALIZED VIEW {qname} OWNER TO <new_owner>;\n"
+        "    END IF;\n"
+        "END $$;"
+    )
+
+
+def _t_drop_table(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None:
+        return None
+    return f"DROP TABLE IF EXISTS {qname};"
+
+
+def _t_drop_index(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None:
+        return None
+    return f"DROP INDEX IF EXISTS {qname};"
+
+
+def _t_drop_view(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None:
+        return None
+    return f"DROP VIEW IF EXISTS {qname};"
+
+
+def _t_drop_type(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None:
+        return None
+    return f"DROP TYPE IF EXISTS {qname};"
+
+
+def _t_drop_schema(cap: Captures) -> str | None:
+    if not cap.table:  # drop visitor stores name in .table
+        return None
+    return f"DROP SCHEMA IF EXISTS {qualify(None, cap.table)};"
+
+
+def _t_drop_sequence(cap: Captures) -> str | None:
+    qname = qualify(cap.schema, cap.table)
+    if qname is None:
+        return None
+    return f"DROP SEQUENCE IF EXISTS {qname};"
+
+
+_TEMPLATES: dict[IdempotencyPattern, _TemplateFn] = {
+    IdempotencyPattern.CREATE_TABLE: _t_create_table,
+    IdempotencyPattern.CREATE_INDEX: _t_create_index,
+    IdempotencyPattern.CREATE_UNIQUE_INDEX: _t_create_unique_index,
+    IdempotencyPattern.CREATE_VIEW: _t_create_view,
+    IdempotencyPattern.CREATE_OR_REPLACE_VIEW_SHAPE_RISK: _t_create_or_replace_view_shape_risk,
+    IdempotencyPattern.CREATE_TYPE: _t_create_type_enum,
+    IdempotencyPattern.CREATE_SCHEMA: _t_create_schema,
+    IdempotencyPattern.CREATE_SEQUENCE: _t_create_sequence,
+    IdempotencyPattern.CREATE_EXTENSION: _t_create_extension,
+    IdempotencyPattern.ALTER_TABLE_ADD_COLUMN: _t_alter_add_column,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK: _t_alter_add_constraint_check,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_PRIMARY_KEY: _t_alter_add_constraint_primary_key,
+    IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_UNIQUE: _t_alter_add_constraint_unique,
+    IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN: _t_alter_rename_column,
+    IdempotencyPattern.ALTER_TABLE_OWNER: _t_alter_table_owner,
+    IdempotencyPattern.ALTER_VIEW_OWNER: _t_alter_view_owner,
+    IdempotencyPattern.ALTER_MATVIEW_OWNER: _t_alter_matview_owner,
+    IdempotencyPattern.DROP_TABLE: _t_drop_table,
+    IdempotencyPattern.DROP_INDEX: _t_drop_index,
+    IdempotencyPattern.DROP_VIEW: _t_drop_view,
+    IdempotencyPattern.DROP_TYPE: _t_drop_type,
+    IdempotencyPattern.DROP_SCHEMA: _t_drop_schema,
+    IdempotencyPattern.DROP_SEQUENCE: _t_drop_sequence,
+}
+
+
+def suggestion_for(pattern: IdempotencyPattern, captures: Captures) -> str:
+    """Return the filled suggestion for ``pattern`` given ``captures``.
+
+    Dispatch order:
+
+    1. ``pattern`` has a template registered and the template returns a
+       non-``None`` filled string → return that.
+    2. ``pattern`` has a template but captures are incomplete → return
+       the generic :attr:`IdempotencyPattern.suggestion` (no marker).
+    3. ``pattern`` has no template registered (it's in
+       :data:`TEMPLATE_NOT_AVAILABLE`) → return the generic suggestion
+       with :data:`NO_TEMPLATE_AVAILABLE_MARKER` appended.
+    """
+    template = _TEMPLATES.get(pattern)
+    if template is None:
+        return f"{pattern.suggestion} ({NO_TEMPLATE_AVAILABLE_MARKER})"
+    filled = template(captures)
+    if filled is not None:
+        return filled
+    return pattern.suggestion

--- a/python/confiture/core/idempotency/validator.py
+++ b/python/confiture/core/idempotency/validator.py
@@ -166,6 +166,7 @@ class IdempotencyValidator:
                 line_number=original_line,
                 file_path=file_path,
                 severity=match.severity,
+                suggestion=match.suggestion,
             )
             report.add_violation(violation)
 

--- a/python/confiture/core/linting/_ast_required.py
+++ b/python/confiture/core/linting/_ast_required.py
@@ -1,0 +1,59 @@
+"""Shared helpers for AST-only lint rules (issue #124).
+
+Rules that need pairwise structural analysis (matching ``CREATE`` to a
+later ``ALTER … OWNER TO`` of the same qualified name across realistic
+PostgreSQL SQL with dollar-quoted strings, CHECK-constraint literals, and
+multi-statement DO blocks) can't be reliably implemented with regex.
+When pglast is not installed, those rules emit a single skip notice and
+return no violations rather than ship a half-working detector — a
+false-negative ownership lint is worse than no lint, because users trust
+the green check.
+
+Used by :class:`~confiture.core.linting.libraries.ownership.Own001OwnershipCoverage`
+today; future AST-only rules import the same helpers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from functools import cache
+
+# Test seam: when True, :func:`is_pglast_available` reports unavailable
+# regardless of what's installed.  Tests flip this via monkeypatch — the
+# production path leaves it ``False`` and the ``importlib`` check decides.
+_force_unavailable: bool = False
+
+# Module-level guard so the skip notice fires once per process rather
+# than once per migration (a CI run with many migrations would otherwise
+# spam logs).  Reset between tests via monkeypatch.
+_skip_warned: bool = False
+
+
+@cache
+def is_pglast_available() -> bool:
+    """Return True when the ``pglast`` package is importable.
+
+    Cached because ``importlib.util.find_spec`` walks ``sys.path`` on
+    every call; the answer doesn't change at runtime in practice.  Tests
+    that need to force a False reading can ``monkeypatch.setattr`` the
+    module's ``_force_unavailable`` flag *and* clear this cache.
+    """
+    if _force_unavailable:
+        return False
+    return importlib.util.find_spec("pglast") is not None
+
+
+def emit_skip_notice(message: str) -> None:
+    """Write *message* to stderr exactly once per process.
+
+    Subsequent calls within the same process are no-ops.
+    """
+    global _skip_warned
+    if _skip_warned:
+        return
+    _skip_warned = True
+    print(message, file=sys.stderr)
+
+
+__all__ = ["emit_skip_notice", "is_pglast_available"]

--- a/python/confiture/core/linting/libraries/ownership.py
+++ b/python/confiture/core/linting/libraries/ownership.py
@@ -1,0 +1,370 @@
+"""Lint rule for ownership coverage of migration files (OWN001, issue #124).
+
+``own_001`` fires when a migration file ``CREATE``s a relation in scope
+of the configured ``ownership:`` block but does not pair it with a
+matching ``ALTER … OWNER TO <expected_owner>`` later in the same file.
+
+Mirrors :mod:`confiture.core.linting.libraries.acl` (issue #120) on the
+ownership axis.
+
+AST-only by design — pairwise ``CREATE`` ↔ ``ALTER … OWNER TO``
+matching across realistic PostgreSQL SQL (dollar-quoted strings,
+CHECK-constraint literals, multi-statement DO blocks) is too brittle to
+ship as a regex.  When pglast is not installed the rule emits a single
+skip notice and returns no violations rather than risk a false-negative
+green check.
+
+Trust boundary: ``-- confiture:run-as <role>`` is **declarative only**.
+The lint rule trusts the comment; nothing at lint time verifies the
+migration actually runs as that role in production.  The runtime drift
+detector (:class:`~confiture.core.drift.OwnershipDriftDetector`) is the
+production-time gate.  The two are designed to be complementary —
+neither alone is sufficient.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar
+
+from confiture.config.environment import OwnershipExpectation
+from confiture.core.idempotency._ast_visitor import _first_keyword_pos
+from confiture.core.linting._ast_required import (
+    emit_skip_notice,
+    is_pglast_available,
+)
+from confiture.core.linting.schema_linter import LintViolation, RuleSeverity
+
+# Default schema for unqualified identifiers in PostgreSQL.
+_DEFAULT_SCHEMA = "public"
+
+# Directive: opt the *next* CREATE statement out of the rule.  Lives on
+# its own ``-- confiture:owner-skip`` line; trailing characters are
+# tolerated so a follow-on comment still matches.
+_OWNER_SKIP_RE = re.compile(r"--\s*confiture:owner-skip\b", re.IGNORECASE)
+# Front-matter directive: declares the role the whole file is applied as.
+# When the declared role equals ``expected_owner`` the file is skipped
+# entirely.
+_RUN_AS_RE = re.compile(
+    r"--\s*confiture:run-as\s+([A-Za-z_][A-Za-z0-9_]*)\b", re.IGNORECASE
+)
+
+# Maps the relkind characters declared on ``OwnershipApplyTo`` to the
+# pglast statement classes that introduce each relkind.  Used purely for
+# scope filtering at violation time — the AST walk itself looks at every
+# create stmt and decides scope per-relation.
+_RELKIND_TO_CREATE_LABEL: dict[str, str] = {
+    "r": "table",
+    "v": "view",
+    "m": "materialized view",
+    "S": "sequence",
+}
+
+
+@dataclass(frozen=True)
+class _CreateRecord:
+    """One ``CREATE`` statement found by the AST walk."""
+
+    schema: str
+    relname: str
+    relkind: str  # one of "r", "v", "m", "S"
+    line: int
+
+
+@dataclass(frozen=True)
+class _AlterOwnerRecord:
+    """One ``ALTER … OWNER TO <role>`` statement found by the AST walk."""
+
+    schema: str
+    relname: str
+    new_owner: str
+
+
+class Own001OwnershipCoverage:
+    """OWN001 — every created relation must have a matching ALTER OWNER.
+
+    The rule is a no-op when ``expectation.lint_enabled`` is False, when
+    no expectation is provided, or when pglast is unavailable.
+
+    Args:
+        expectation: Parsed ``ownership:`` block from the environment config.
+
+    Example::
+
+        from pathlib import Path
+        from confiture.config.environment import Environment
+        from confiture.core.linting.libraries.ownership import (
+            Own001OwnershipCoverage,
+        )
+
+        env = Environment.load("local")
+        if env.ownership is not None:
+            rule = Own001OwnershipCoverage(expectation=env.ownership)
+            for v in rule.check(Path("db/migrations")):
+                print(v)
+    """
+
+    rule_id: ClassVar[str] = "own_001"
+    rule_name: ClassVar[str] = "Ownership Coverage"
+
+    def __init__(self, expectation: OwnershipExpectation) -> None:
+        self.expectation = expectation
+        # Pre-compute schema → set(relkinds) lookup for fast scope checks.
+        self._scope: dict[str, set[str]] = {}
+        for entry in expectation.apply_to:
+            self._scope.setdefault(entry.schema_, set()).update(entry.relkinds)
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                          #
+    # ------------------------------------------------------------------ #
+
+    def check(self, migrations_dir: Path) -> list[LintViolation]:
+        """Walk *migrations_dir* and return one violation per uncovered relation."""
+        if not self.expectation.lint_enabled:
+            return []
+        if not migrations_dir.exists():
+            return []
+        if not is_pglast_available():
+            emit_skip_notice(
+                'own_001 requires the [ast] extra: '
+                'pip install "fraiseql-confiture[ast]"'
+            )
+            return []
+
+        violations: list[LintViolation] = []
+        for migration in sorted(migrations_dir.rglob("*.up.sql")):
+            violations.extend(self._check_file(migration))
+        return violations
+
+    # ------------------------------------------------------------------ #
+    # Per-file analysis                                                   #
+    # ------------------------------------------------------------------ #
+
+    def _check_file(self, path: Path) -> list[LintViolation]:
+        text = path.read_text()
+
+        # Front-matter ``-- confiture:run-as <role>`` short-circuit.
+        run_as = self._extract_run_as(text)
+        if run_as == self.expectation.expected_owner:
+            return []
+
+        creates, alters = self._walk_ast(text)
+        if not creates:
+            return []
+
+        skipped_lines = self._collect_owner_skip_lines(text)
+
+        # Build a lookup of every ALTER OWNER's qualified name with the
+        # matching new owner.  Multiple ALTERs of the same relation are
+        # collapsed — we just need to know the eventual owner.
+        alter_index: dict[tuple[str, str], str] = {}
+        for alter in alters:
+            alter_index[(alter.schema, alter.relname)] = alter.new_owner
+
+        violations: list[LintViolation] = []
+        for create in creates:
+            # Skip the next CREATE after a -- confiture:owner-skip line.
+            if create.line in skipped_lines:
+                continue
+
+            # Scope: schema in ``apply_to`` and relkind in that schema's set.
+            allowed_relkinds = self._scope.get(create.schema)
+            if allowed_relkinds is None:
+                continue
+            if create.relkind not in allowed_relkinds:
+                continue
+
+            qualified = f"{create.schema}.{create.relname}"
+            if self._matches_ignore(qualified):
+                continue
+
+            owner = alter_index.get((create.schema, create.relname))
+            if owner == self.expectation.expected_owner:
+                continue
+
+            violations.append(
+                LintViolation(
+                    rule_id=self.rule_id,
+                    rule_name=self.rule_name,
+                    severity=RuleSeverity.ERROR,
+                    object_type=_RELKIND_TO_CREATE_LABEL.get(
+                        create.relkind, "relation"
+                    ),
+                    object_name=qualified,
+                    message=(
+                        f"{_RELKIND_TO_CREATE_LABEL.get(create.relkind, 'relation').capitalize()} "
+                        f"'{qualified}' was created without "
+                        f"`ALTER … OWNER TO {self.expectation.expected_owner};` "
+                        f"in the same migration.  Without it, schema-wide GRANTs "
+                        f"from the canonical migrator role will fail with "
+                        f"`grantor must own the object`."
+                    ),
+                    file_path=str(path),
+                    line_number=create.line,
+                )
+            )
+        return violations
+
+    # ------------------------------------------------------------------ #
+    # Directives                                                          #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _extract_run_as(text: str) -> str | None:
+        """Return the declared role from a top-of-file ``-- confiture:run-as`` directive.
+
+        Scans the file for the directive; the first match wins.  The
+        directive may sit anywhere in the file but is typically used as
+        front-matter.  Inline trailing comments on a CREATE statement
+        are not recognized — the directive must be on its own line.
+        """
+        for line in text.splitlines():
+            m = _RUN_AS_RE.search(line)
+            if m:
+                return m.group(1)
+        return None
+
+    @staticmethod
+    def _collect_owner_skip_lines(text: str) -> set[int]:
+        """Return the 1-indexed line numbers of CREATE statements opted out.
+
+        A ``-- confiture:owner-skip`` directive attaches to the *next*
+        non-blank non-comment line within the file.  This walker returns
+        the line numbers of those attached lines so the AST-walk can
+        match against ``create.line``.
+        """
+        skipped: set[int] = set()
+        lines = text.splitlines()
+        pending_skip = False
+        for idx, raw in enumerate(lines, start=1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("--"):
+                if _OWNER_SKIP_RE.search(stripped):
+                    pending_skip = True
+                continue
+            if pending_skip:
+                skipped.add(idx)
+                pending_skip = False
+        return skipped
+
+    def _matches_ignore(self, qualified_name: str) -> bool:
+        return any(
+            fnmatch.fnmatchcase(qualified_name, p)
+            for p in self.expectation.ignore
+        )
+
+    # ------------------------------------------------------------------ #
+    # AST walk                                                            #
+    # ------------------------------------------------------------------ #
+
+    def _walk_ast(
+        self, sql: str
+    ) -> tuple[list[_CreateRecord], list[_AlterOwnerRecord]]:
+        """Parse *sql* via pglast and return its CREATEs and ALTER … OWNER TOs.
+
+        Statements inside ``DO $$ … $$`` blocks are opaque to pglast and
+        never appear as top-level statements, so an ``EXECUTE 'ALTER …
+        OWNER TO …'`` wrapped in a DO block correctly does NOT count.
+        """
+        import pglast  # local import — guarded by is_pglast_available() above
+
+        creates: list[_CreateRecord] = []
+        alters: list[_AlterOwnerRecord] = []
+        try:
+            tree = pglast.parse_sql(sql)
+        except Exception:
+            # Parse failures (templated SQL, exotic dialect quirks)
+            # should not crash the lint — just return no findings for
+            # this file.  The drift detector will catch real problems
+            # at runtime.
+            return creates, alters
+
+        for raw in tree or []:
+            stmt = raw.stmt
+            stmt_location = raw.stmt_location or 0
+            # ``stmt_location`` includes any leading comments, so jump
+            # forward to the first keyword to report the line accurately.
+            keyword_pos = _first_keyword_pos(sql, stmt_location)
+            line = sql[:keyword_pos].count("\n") + 1
+
+            cls_name = type(stmt).__name__
+            if cls_name == "CreateStmt":
+                relation = stmt.relation
+                creates.append(
+                    _CreateRecord(
+                        schema=relation.schemaname or _DEFAULT_SCHEMA,
+                        relname=relation.relname,
+                        relkind="r",
+                        line=line,
+                    )
+                )
+            elif cls_name == "ViewStmt":
+                view = stmt.view
+                creates.append(
+                    _CreateRecord(
+                        schema=view.schemaname or _DEFAULT_SCHEMA,
+                        relname=view.relname,
+                        relkind="v",
+                        line=line,
+                    )
+                )
+            elif cls_name == "CreateTableAsStmt":
+                # MATERIALIZED VIEW shows up here too; non-matview shape
+                # would be a plain SELECT INTO, not in scope.
+                objtype = getattr(stmt, "objtype", None)
+                objtype_name = getattr(objtype, "name", "") if objtype else ""
+                if objtype_name == "OBJECT_MATVIEW":
+                    rel = stmt.into.rel
+                    creates.append(
+                        _CreateRecord(
+                            schema=rel.schemaname or _DEFAULT_SCHEMA,
+                            relname=rel.relname,
+                            relkind="m",
+                            line=line,
+                        )
+                    )
+            elif cls_name == "CreateSeqStmt":
+                seq = stmt.sequence
+                creates.append(
+                    _CreateRecord(
+                        schema=seq.schemaname or _DEFAULT_SCHEMA,
+                        relname=seq.relname,
+                        relkind="S",
+                        line=line,
+                    )
+                )
+            elif cls_name == "AlterTableStmt":
+                # ALTER TABLE / VIEW / MATERIALIZED VIEW / SEQUENCE
+                # all produce AlterTableStmt — the rewrite happens at
+                # parse time.  Look at each AlterTableCmd for
+                # ``AT_ChangeOwner`` (i.e. OWNER TO …).
+                relation = stmt.relation
+                for cmd in stmt.cmds or ():
+                    subtype = getattr(cmd, "subtype", None)
+                    subtype_name = getattr(subtype, "name", "") if subtype else ""
+                    if subtype_name != "AT_ChangeOwner":
+                        continue
+                    new_owner_node = getattr(cmd, "newowner", None)
+                    role_name = (
+                        getattr(new_owner_node, "rolename", None)
+                        if new_owner_node is not None
+                        else None
+                    )
+                    if not role_name:
+                        continue
+                    alters.append(
+                        _AlterOwnerRecord(
+                            schema=relation.schemaname or _DEFAULT_SCHEMA,
+                            relname=relation.relname,
+                            new_owner=role_name,
+                        )
+                    )
+        return creates, alters
+
+
+__all__ = ["Own001OwnershipCoverage"]

--- a/python/confiture/core/ownership_fixer.py
+++ b/python/confiture/core/ownership_fixer.py
@@ -1,0 +1,256 @@
+"""Auto-fixer for ownership coverage gaps in migration files (issue #124).
+
+For each ``CREATE { TABLE | VIEW | MATERIALIZED VIEW | SEQUENCE }`` in
+scope of an :class:`OwnershipExpectation` that lacks a matching
+``ALTER … OWNER TO <expected_owner>`` later in the same file, the fixer
+inserts the missing ``ALTER`` on the line immediately following the
+closing ``;`` of the offending ``CREATE``.
+
+Detection delegates to :class:`Own001OwnershipCoverage` so the static
+lint rule and the fixer always agree on what's a violation.
+
+AST-only: the fixer is a no-op when pglast is unavailable (delegating to
+the rule's skip-notice path).  The lint rule and fixer share that
+constraint by design — a partial regex-based fixer would silently miss
+violations that the AST detector would catch, leading to confusing
+"fix → re-validate → still flagged" cycles.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from confiture.config.environment import OwnershipExpectation
+from confiture.core.linting._ast_required import is_pglast_available
+from confiture.core.linting.libraries.ownership import Own001OwnershipCoverage
+
+# Map the per-relkind statement to the ALTER form that PostgreSQL accepts.
+# Sequences need ``ALTER SEQUENCE``, materialized views need
+# ``ALTER MATERIALIZED VIEW`` — ``ALTER TABLE`` only works for tables.
+_RELKIND_TO_ALTER_FORM: dict[str, str] = {
+    "r": "TABLE",
+    "v": "VIEW",
+    "m": "MATERIALIZED VIEW",
+    "S": "SEQUENCE",
+}
+
+_RELKIND_TO_KIND_LABEL: dict[str, str] = {
+    "r": "TABLE",
+    "v": "VIEW",
+    "m": "MATERIALIZED VIEW",
+    "S": "SEQUENCE",
+}
+
+
+@dataclass(frozen=True)
+class FixCandidate:
+    """One missing ``ALTER … OWNER TO`` to be emitted."""
+
+    file: Path
+    line: int  # 1-indexed line of the CREATE
+    qualified_name: str  # ``schema.relname``
+    kind: str  # ``TABLE``, ``VIEW``, ``MATERIALIZED VIEW``, ``SEQUENCE``
+
+
+@dataclass(frozen=True)
+class FixPreview:
+    """Diff entry: what the fixer would change in one file."""
+
+    file: Path
+    before: str
+    after: str
+
+
+class OwnershipFixer:
+    """Emit missing ``ALTER … OWNER TO`` statements for an expectation.
+
+    Args:
+        expectation: Parsed ``ownership:`` block.
+
+    Example::
+
+        from confiture.config.environment import Environment
+        from confiture.core.ownership_fixer import OwnershipFixer
+
+        env = Environment.load("local")
+        if env.ownership is not None:
+            fixer = OwnershipFixer(expectation=env.ownership)
+            changed = fixer.apply(Path("db/migrations"))
+            for path in changed:
+                print(f"fixed {path}")
+    """
+
+    def __init__(self, expectation: OwnershipExpectation) -> None:
+        self.expectation = expectation
+        self._rule = Own001OwnershipCoverage(expectation=expectation)
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                          #
+    # ------------------------------------------------------------------ #
+
+    def iter_candidates(self, migrations_dir: Path) -> list[FixCandidate]:
+        """Return one :class:`FixCandidate` per uncovered CREATE in *migrations_dir*."""
+        if not is_pglast_available():
+            return []
+        candidates: list[FixCandidate] = []
+        for migration in sorted(migrations_dir.rglob("*.up.sql")):
+            text = migration.read_text()
+            for create, kind in self._uncovered_creates(text):
+                candidates.append(
+                    FixCandidate(
+                        file=migration,
+                        line=create.line,
+                        qualified_name=f"{create.schema}.{create.relname}",
+                        kind=_RELKIND_TO_KIND_LABEL[kind],
+                    )
+                )
+        return candidates
+
+    def preview(self, migrations_dir: Path) -> list[FixPreview]:
+        """Return one :class:`FixPreview` per file that would be modified."""
+        if not is_pglast_available():
+            return []
+        previews: list[FixPreview] = []
+        for migration in sorted(migrations_dir.rglob("*.up.sql")):
+            original = migration.read_text()
+            fixed = self.fix_text(original)
+            if fixed != original:
+                previews.append(FixPreview(file=migration, before=original, after=fixed))
+        return previews
+
+    def apply(self, migrations_dir: Path) -> list[Path]:
+        """Apply fixes in place to every file that needs one.
+
+        Returns the list of files that were modified.  Files unchanged
+        by the fix are not touched.
+        """
+        if not is_pglast_available():
+            return []
+        modified: list[Path] = []
+        for migration in sorted(migrations_dir.rglob("*.up.sql")):
+            original = migration.read_text()
+            fixed = self.fix_text(original)
+            if fixed != original:
+                migration.write_text(fixed)
+                modified.append(migration)
+        return modified
+
+    def fix_text(self, sql: str) -> str:
+        """Return *sql* with missing ``ALTER … OWNER TO`` statements inserted.
+
+        Stable when re-run: applying ``fix_text`` to its own output is a
+        no-op because re-detection sees the freshly-emitted ``ALTER``
+        and skips the same line on the next pass.
+        """
+        if not is_pglast_available():
+            return sql
+        # The rule's AST walk gives us schema/relname/relkind/line for
+        # every CREATE.  We sort top-down (largest line first) so we
+        # can insert without invalidating earlier line numbers.
+        uncovered = self._uncovered_creates(sql)
+        if not uncovered:
+            return sql
+
+        lines = sql.splitlines(keepends=True)
+        # Reverse-order insertion: largest line number first so the
+        # insertion offsets of earlier inserts don't shift later ones.
+        for create, kind in sorted(uncovered, key=lambda x: x[0].line, reverse=True):
+            insert_idx = self._find_statement_end_line(lines, create.line)
+            qualified = f"{create.schema}.{create.relname}"
+            alter_form = _RELKIND_TO_ALTER_FORM[kind]
+            indent = self._leading_indent(lines, create.line - 1)
+            alter_line = (
+                f"{indent}ALTER {alter_form} {qualified} "
+                f"OWNER TO {self.expectation.expected_owner};\n"
+            )
+            lines.insert(insert_idx, alter_line)
+        return "".join(lines)
+
+    # ------------------------------------------------------------------ #
+    # Internals                                                           #
+    # ------------------------------------------------------------------ #
+
+    def _uncovered_creates(
+        self, sql: str
+    ) -> list[tuple[_CreateRecord, str]]:
+        """Return ``(create_record, relkind)`` pairs lacking ALTER OWNER coverage.
+
+        Honours the rule's full scope/ignore/directive logic — including
+        the file-level ``-- confiture:run-as`` directive and
+        per-statement ``-- confiture:owner-skip``.
+        """
+        # We re-implement the matching loop here (rather than call
+        # rule.check()) because we need the AST records, not the
+        # LintViolation objects.  Both code paths share the same helpers.
+        if not self.expectation.lint_enabled:
+            return []
+        run_as = self._rule._extract_run_as(sql)
+        if run_as == self.expectation.expected_owner:
+            return []
+
+        creates, alters = self._rule._walk_ast(sql)
+        if not creates:
+            return []
+
+        skipped_lines = self._rule._collect_owner_skip_lines(sql)
+        alter_index: dict[tuple[str, str], str] = {
+            (a.schema, a.relname): a.new_owner for a in alters
+        }
+
+        result: list[tuple[_CreateRecord, str]] = []
+        for create in creates:
+            if create.line in skipped_lines:
+                continue
+            allowed = self._rule._scope.get(create.schema)
+            if allowed is None or create.relkind not in allowed:
+                continue
+            qualified = f"{create.schema}.{create.relname}"
+            if self._rule._matches_ignore(qualified):
+                continue
+            if alter_index.get((create.schema, create.relname)) == self.expectation.expected_owner:
+                continue
+            result.append((create, create.relkind))
+        return result
+
+    @staticmethod
+    def _find_statement_end_line(lines: list[str], create_line: int) -> int:
+        """Return the 0-indexed list-position just past the CREATE's terminating semicolon.
+
+        ``create_line`` is 1-indexed.  Walks forward from that line
+        looking for the first ``;`` that isn't inside a string literal —
+        a simple state machine is enough for the well-formed migration
+        files this fixer ever sees in practice.
+        """
+        idx = create_line - 1
+        in_single = False
+        in_double = False
+        while idx < len(lines):
+            line = lines[idx]
+            for ch in line:
+                if ch == "'" and not in_double:
+                    in_single = not in_single
+                elif ch == '"' and not in_single:
+                    in_double = not in_double
+                elif ch == ";" and not in_single and not in_double:
+                    return idx + 1
+            idx += 1
+        return len(lines)
+
+    @staticmethod
+    def _leading_indent(lines: list[str], idx: int) -> str:
+        """Return the leading whitespace of ``lines[idx]`` (empty when idx out of range)."""
+        if 0 <= idx < len(lines):
+            m = re.match(r"[ \t]*", lines[idx])
+            if m:
+                return m.group(0)
+        return ""
+
+
+# Re-export the rule's record types under the names the fixer uses.  Kept
+# at module-bottom so the type-checker still sees the proper class — the
+# import is lazy to avoid a circular-import surface.
+from confiture.core.linting.libraries.ownership import _CreateRecord  # noqa: E402
+
+__all__ = ["FixCandidate", "FixPreview", "OwnershipFixer"]

--- a/python/confiture/exceptions.py
+++ b/python/confiture/exceptions.py
@@ -405,7 +405,8 @@ class SQLError(ConfiturError):
 
         # Normalise sql to a plain string — callers may pass
         # psycopg.sql.Composable objects (Composed, SQL, Identifier …).
-        sql_str: str = sql.as_string(None) if hasattr(sql, "as_string") else str(sql)
+        as_string = getattr(sql, "as_string", None)
+        sql_str: str = as_string(None) if callable(as_string) else str(sql)
 
         # Add SQL snippet (first 100 chars)
         sql_preview = sql_str.strip()[:100]

--- a/tests/integration/test_drift_check_ownership_cli.py
+++ b/tests/integration/test_drift_check_ownership_cli.py
@@ -1,0 +1,212 @@
+"""Integration tests for ``confiture drift --check-ownership`` (issue #124).
+
+Drives the Typer CLI end-to-end against a real Postgres instance.
+Mirrors :mod:`tests.integration.test_drift_check_acls_cli`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from collections.abc import Generator
+from pathlib import Path
+
+import psycopg
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+_SCHEMA = "own_cli_test"
+_ROLES = ("own_cli_migrator", "own_cli_intruder")
+
+
+@pytest.fixture
+def pg_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+@pytest.fixture
+def own_db(pg_url: str) -> Generator[psycopg.Connection, None, None]:
+    try:
+        conn = psycopg.connect(pg_url, autocommit=False)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+    def _cleanup() -> None:
+        with conn.cursor() as cur:
+            cur.execute(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+            for role in _ROLES:
+                cur.execute(f"DROP ROLE IF EXISTS {role}")
+        conn.commit()
+
+    _cleanup()
+    with conn.cursor() as cur:
+        for role in _ROLES:
+            cur.execute(f"CREATE ROLE {role}")
+        cur.execute(f"CREATE SCHEMA {_SCHEMA} AUTHORIZATION own_cli_migrator")
+        cur.execute("GRANT own_cli_migrator TO current_user")
+        cur.execute("GRANT own_cli_intruder TO current_user")
+    conn.commit()
+
+    yield conn
+
+    _cleanup()
+    conn.close()
+
+
+def _write_config(tmp_path: Path, pg_url: str, ownership_body: str = "") -> Path:
+    cfg = tmp_path / "confiture.yaml"
+    body = textwrap.dedent(
+        f"""\
+        name: test
+        database_url: {pg_url}
+        include_dirs: []
+        """
+    )
+    if ownership_body:
+        body += textwrap.dedent(ownership_body)
+    cfg.write_text(body)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_check_ownership_exits_1_on_wrong_owner(
+    tmp_path: Path, own_db: psycopg.Connection, pg_url: str
+) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_SCHEMA}.tb_foo (id int)")
+        cur.execute(f"ALTER TABLE {_SCHEMA}.tb_foo OWNER TO own_cli_intruder")
+    own_db.commit()
+
+    cfg = _write_config(
+        tmp_path,
+        pg_url,
+        f"""
+        ownership:
+          expected_owner: own_cli_migrator
+          apply_to:
+            - schema: {_SCHEMA}
+              relkinds: [r]
+        """,
+    )
+    result = CliRunner().invoke(app, ["drift", "--check-ownership", "--config", str(cfg)])
+    assert result.exit_code == 1, result.output
+    assert "WRONG_OWNER" in result.output.upper()
+
+
+def test_check_ownership_exits_0_on_full_coverage(
+    tmp_path: Path, own_db: psycopg.Connection, pg_url: str
+) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_SCHEMA}.tb_foo (id int)")
+        cur.execute(f"ALTER TABLE {_SCHEMA}.tb_foo OWNER TO own_cli_migrator")
+    own_db.commit()
+
+    cfg = _write_config(
+        tmp_path,
+        pg_url,
+        f"""
+        ownership:
+          expected_owner: own_cli_migrator
+          apply_to:
+            - schema: {_SCHEMA}
+              relkinds: [r]
+        """,
+    )
+    result = CliRunner().invoke(app, ["drift", "--check-ownership", "--config", str(cfg)])
+    assert result.exit_code == 0, result.output
+
+
+def test_check_ownership_without_block_exits_2(
+    tmp_path: Path, own_db: psycopg.Connection, pg_url: str
+) -> None:
+    cfg = _write_config(tmp_path, pg_url)
+    result = CliRunner().invoke(app, ["drift", "--check-ownership", "--config", str(cfg)])
+    assert result.exit_code == 2, result.output
+
+
+# ---------------------------------------------------------------------------
+# Composition with --check-acls
+# ---------------------------------------------------------------------------
+
+
+def test_check_ownership_composes_with_check_acls(
+    tmp_path: Path, own_db: psycopg.Connection, pg_url: str
+) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_SCHEMA}.tb_foo (id int)")
+        # Wrong owner AND missing grant
+        cur.execute(f"ALTER TABLE {_SCHEMA}.tb_foo OWNER TO own_cli_intruder")
+    own_db.commit()
+
+    cfg = _write_config(
+        tmp_path,
+        pg_url,
+        f"""
+        ownership:
+          expected_owner: own_cli_migrator
+          apply_to:
+            - schema: {_SCHEMA}
+              relkinds: [r]
+        acls:
+          - schema: {_SCHEMA}
+            apply_to: ALL_TABLES
+            grants:
+              - role: own_cli_migrator
+                privileges: [SELECT]
+        """,
+    )
+    result = CliRunner().invoke(
+        app,
+        ["drift", "--check-ownership", "--check-acls", "--config", str(cfg)],
+    )
+    assert result.exit_code == 1, result.output
+    assert "WRONG_OWNER" in result.output.upper()
+    assert "MISSING_GRANT" in result.output.upper()
+
+
+# ---------------------------------------------------------------------------
+# JSON output shape
+# ---------------------------------------------------------------------------
+
+
+def test_check_ownership_json_output_shape(
+    tmp_path: Path, own_db: psycopg.Connection, pg_url: str
+) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_SCHEMA}.tb_foo (id int)")
+        cur.execute(f"ALTER TABLE {_SCHEMA}.tb_foo OWNER TO own_cli_intruder")
+    own_db.commit()
+
+    cfg = _write_config(
+        tmp_path,
+        pg_url,
+        f"""
+        ownership:
+          expected_owner: own_cli_migrator
+          apply_to:
+            - schema: {_SCHEMA}
+              relkinds: [r]
+        """,
+    )
+    result = CliRunner().invoke(
+        app,
+        ["drift", "--check-ownership", "--format", "json", "--config", str(cfg)],
+    )
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["has_drift"] is True
+    assert payload["expected_schema_source"] == "ownership"
+    items = payload["drift_items"]
+    assert any(i["type"] == "wrong_owner" for i in items)
+    item = next(i for i in items if i["type"] == "wrong_owner")
+    assert item["object"] == f"{_SCHEMA}.tb_foo"
+    assert item["expected"] == "own_cli_migrator"
+    assert item["actual"] == "own_cli_intruder"
+    assert item["severity"] == "critical"

--- a/tests/integration/test_dry_run_savepoint.py
+++ b/tests/integration/test_dry_run_savepoint.py
@@ -29,7 +29,8 @@ class TestDryRunSavepointIntegration:
         assert result.success is True
         assert result.confidence_pct == 85
         assert len(result.statements) == 4
-        assert result.rows_affected == 2  # Only the UPDATE affects rows
+        # Aggregate sums every statement's rowcount: 3 inserts + 2 updates.
+        assert result.rows_affected == 5
 
         # Verify individual statements
         assert result.statements[0].rows_affected == 0  # CREATE TABLE

--- a/tests/integration/test_migrate_fix_ownership_checksum_guard.py
+++ b/tests/integration/test_migrate_fix_ownership_checksum_guard.py
@@ -1,0 +1,222 @@
+"""Integration tests for the checksum-drift guard on ``migrate fix --ownership``.
+
+The guard refuses to rewrite migration files whose version is already
+recorded in the local tracking table, unless ``--force`` is also set.
+This protects users from silently breaking ``migrate verify``.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from collections.abc import Generator
+from pathlib import Path
+
+import psycopg
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+pytest.importorskip("pglast")
+
+
+@pytest.fixture
+def pg_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+@pytest.fixture
+def tracking_db(pg_url: str) -> Generator[psycopg.Connection, None, None]:
+    """Provide a connection with a clean tracking table."""
+    try:
+        conn = psycopg.connect(pg_url, autocommit=False)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+    def _cleanup() -> None:
+        with conn.cursor() as cur:
+            cur.execute("DROP TABLE IF EXISTS public.tb_confiture CASCADE")
+        conn.commit()
+
+    _cleanup()
+    with conn.cursor() as cur:
+        cur.execute(
+            "CREATE TABLE public.tb_confiture ("
+            "  version text PRIMARY KEY, "
+            "  name text NOT NULL, "
+            "  applied_at timestamptz NOT NULL DEFAULT now(), "
+            "  checksum text"
+            ")"
+        )
+    conn.commit()
+
+    yield conn
+
+    _cleanup()
+    conn.close()
+
+
+def _write_config(tmp_path: Path, pg_url: str) -> Path:
+    cfg = tmp_path / "confiture.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""\
+            name: test
+            database_url: {pg_url}
+            include_dirs: []
+            migration:
+              tracking_table: public.tb_confiture
+            ownership:
+              expected_owner: migrator
+              apply_to:
+                - schema: public
+                  relkinds: [r]
+            """
+        )
+    )
+    return cfg
+
+
+def _write_migration(tmp_path: Path, name: str, sql: str) -> Path:
+    migrations = tmp_path / "db" / "migrations"
+    migrations.mkdir(parents=True, exist_ok=True)
+    p = migrations / name
+    p.write_text(sql)
+    return p
+
+
+def test_refuses_to_rewrite_already_applied_migration(
+    tmp_path: Path, tracking_db: psycopg.Connection, pg_url: str
+) -> None:
+    cfg = _write_config(tmp_path, pg_url)
+    path = _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    original = path.read_text()
+
+    # Record the migration as applied.
+    with tracking_db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO public.tb_confiture (version, name) VALUES (%s, %s)",
+            ("20260527090000", "add_foo"),
+        )
+    tracking_db.commit()
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--ownership",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    assert "Refused" in result.output
+    assert path.read_text() == original  # unchanged
+
+
+def test_force_overrides_checksum_guard(
+    tmp_path: Path, tracking_db: psycopg.Connection, pg_url: str
+) -> None:
+    cfg = _write_config(tmp_path, pg_url)
+    path = _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    with tracking_db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO public.tb_confiture (version, name) VALUES (%s, %s)",
+            ("20260527090000", "add_foo"),
+        )
+    tracking_db.commit()
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--ownership",
+            "--force",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ALTER TABLE public.foo OWNER TO migrator;" in path.read_text()
+
+
+def test_unapplied_migration_rewritten_without_force(
+    tmp_path: Path, tracking_db: psycopg.Connection, pg_url: str
+) -> None:
+    """Greenfield (no rows in tracking) rewrites cleanly without --force."""
+    cfg = _write_config(tmp_path, pg_url)
+    path = _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    # Tracking table exists but empty.
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--ownership",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ALTER TABLE public.foo OWNER TO migrator;" in path.read_text()
+
+
+def test_dry_run_warns_without_exit_nonzero(
+    tmp_path: Path, tracking_db: psycopg.Connection, pg_url: str
+) -> None:
+    """``--dry-run`` surfaces the would-be-refused files but still exits 0."""
+    cfg = _write_config(tmp_path, pg_url)
+    path = _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    original = path.read_text()
+
+    with tracking_db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO public.tb_confiture (version, name) VALUES (%s, %s)",
+            ("20260527090000", "add_foo"),
+        )
+    tracking_db.commit()
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--ownership",
+            "--dry-run",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    # Dry-run never exits non-zero on the guard alone — the guard only
+    # applies to the apply path; dry-run is read-only.
+    assert result.exit_code == 0, result.output
+    assert path.read_text() == original

--- a/tests/integration/test_migrate_fix_ownership_cli.py
+++ b/tests/integration/test_migrate_fix_ownership_cli.py
@@ -1,0 +1,236 @@
+"""Integration tests for ``confiture migrate fix --ownership`` (issue #124).
+
+These tests exercise the CLI end-to-end against a temp project (no real
+DB needed for the non-checksum-guard tests — the helper degrades to "no
+applied migrations" when it can't open a connection).
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+pytest.importorskip("pglast")
+
+
+def _write_config(tmp_path: Path, ownership_body: str = "") -> Path:
+    cfg = tmp_path / "confiture.yaml"
+    body = textwrap.dedent(
+        """\
+        name: test
+        database_url: postgresql://localhost/nonexistent_for_fix_test
+        include_dirs: []
+        """
+    )
+    if ownership_body:
+        body += textwrap.dedent(ownership_body)
+    cfg.write_text(body)
+    return cfg
+
+
+def _write_migration(tmp_path: Path, name: str, sql: str) -> Path:
+    migrations = tmp_path / "db" / "migrations"
+    migrations.mkdir(parents=True, exist_ok=True)
+    p = migrations / name
+    p.write_text(sql)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_modify_files(tmp_path: Path) -> None:
+    cfg = _write_config(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: public
+              relkinds: [r]
+        """,
+    )
+    path = _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    original = path.read_text()
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--ownership",
+            "--dry-run",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert path.read_text() == original  # unchanged
+    assert "Would insert" in result.output
+
+
+def test_apply_writes_alter_owner_into_file(tmp_path: Path) -> None:
+    cfg = _write_config(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: public
+              relkinds: [r]
+        """,
+    )
+    path = _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--ownership",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ALTER TABLE public.foo OWNER TO migrator;" in path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# No-op when no ownership: block
+# ---------------------------------------------------------------------------
+
+
+def test_no_op_when_no_ownership_block(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    path = _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    original = path.read_text()
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--ownership",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "no `ownership:` block" in result.output
+    assert path.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_shape(tmp_path: Path) -> None:
+    cfg = _write_config(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: public
+              relkinds: [r]
+        """,
+    )
+    _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--ownership",
+            "--dry-run",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "preview"
+    assert len(payload["previews"]) == 1
+    assert "ALTER TABLE public.foo OWNER TO migrator" in payload["previews"][0]["after"]
+    assert payload["modified"] == []
+    assert payload["refused"] == []
+
+
+# ---------------------------------------------------------------------------
+# Combined --idempotent + --ownership
+# ---------------------------------------------------------------------------
+
+
+def test_combined_idempotent_and_ownership(tmp_path: Path) -> None:
+    cfg = _write_config(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: public
+              relkinds: [r]
+        """,
+    )
+    path = _write_migration(
+        tmp_path,
+        "20260527090000_combo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--idempotent",
+            "--ownership",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    final = path.read_text()
+    # Idempotency fix should add IF NOT EXISTS.
+    assert "IF NOT EXISTS" in final
+    # Ownership fix should add ALTER … OWNER TO.
+    assert "ALTER TABLE public.foo OWNER TO migrator;" in final

--- a/tests/integration/test_migrate_validate_check_ownership_coverage.py
+++ b/tests/integration/test_migrate_validate_check_ownership_coverage.py
@@ -1,0 +1,207 @@
+"""Integration tests for ``migrate validate --check-ownership-coverage`` (issue #124).
+
+Mirrors :mod:`tests.integration.test_migrate_validate_check_acl_coverage`
+on the ownership axis.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+# Skip the suite entirely when pglast is missing — the lint rule is a
+# no-op without it, so coverage assertions would all be vacuously true.
+pytest.importorskip("pglast")
+
+
+def _write_config(tmp_path: Path, ownership_body: str = "") -> Path:
+    cfg = tmp_path / "confiture.yaml"
+    body = textwrap.dedent(
+        """\
+        name: test
+        database_url: postgresql://localhost/nonexistent
+        include_dirs: []
+        """
+    )
+    if ownership_body:
+        body += textwrap.dedent(ownership_body)
+    cfg.write_text(body)
+    return cfg
+
+
+def _write_migration(tmp_path: Path, name: str, sql: str) -> Path:
+    migrations = tmp_path / "db" / "migrations"
+    migrations.mkdir(parents=True, exist_ok=True)
+    p = migrations / name
+    p.write_text(sql)
+    return p
+
+
+def test_check_ownership_coverage_exits_1_on_missing_alter_owner(tmp_path: Path) -> None:
+    cfg = _write_config(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: public
+              relkinds: [r]
+        """,
+    )
+    _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-ownership-coverage",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "own_001" in result.output
+
+
+def test_check_ownership_coverage_exits_0_on_full_coverage(tmp_path: Path) -> None:
+    cfg = _write_config(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: public
+              relkinds: [r]
+        """,
+    )
+    _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n"
+        "ALTER TABLE public.foo OWNER TO migrator;\n",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-ownership-coverage",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_check_ownership_coverage_without_block_is_noop(tmp_path: Path) -> None:
+    """Missing ``ownership:`` block in config → success (opt-in semantics)."""
+    cfg = _write_config(tmp_path)
+    _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-ownership-coverage",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_check_ownership_coverage_json_output(tmp_path: Path) -> None:
+    cfg = _write_config(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: public
+              relkinds: [r]
+        """,
+    )
+    _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-ownership-coverage",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["check"] == "ownership_coverage"
+    assert len(payload["violations"]) == 1
+    v = payload["violations"][0]
+    assert v["rule_id"] == "own_001"
+    assert v["object_name"] == "public.foo"
+    assert v["severity"] == "error"
+
+
+def test_check_ownership_coverage_lint_disabled_is_noop(tmp_path: Path) -> None:
+    cfg = _write_config(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: public
+              relkinds: [r]
+          lint_enabled: false
+        """,
+    )
+    _write_migration(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-ownership-coverage",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+        ],
+    )
+    assert result.exit_code == 0, result.output

--- a/tests/integration/test_ownership_drift_detector.py
+++ b/tests/integration/test_ownership_drift_detector.py
@@ -1,0 +1,237 @@
+"""Integration tests for :class:`OwnershipDriftDetector` (issue #124).
+
+Requires a running PostgreSQL accessible via ``CONFITURE_TEST_DB_URL``.
+
+Mirrors :mod:`tests.integration.test_acl_drift_detector` on the ownership
+axis.  Each test creates the relevant relkinds (table, sequence, view,
+matview) under a dedicated schema, sets their owners, then asks the
+detector to compare against an :class:`OwnershipExpectation`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import psycopg
+import pytest
+
+from confiture.config.environment import OwnershipApplyTo, OwnershipExpectation
+from confiture.core.drift import (
+    DriftSeverity,
+    DriftType,
+    OwnershipDriftDetector,
+)
+
+_TEST_SCHEMA = "own_drift_test"
+_TEST_ROLES = ("own_migrator", "own_intruder")
+
+
+@pytest.fixture
+def own_db(clean_test_db: psycopg.Connection) -> Generator[psycopg.Connection, None, None]:
+    """Clean test schema and roles before/after each test."""
+    conn = clean_test_db
+
+    def _cleanup() -> None:
+        with conn.cursor() as cur:
+            cur.execute(f"DROP SCHEMA IF EXISTS {_TEST_SCHEMA} CASCADE")
+            for role in _TEST_ROLES:
+                cur.execute(f"DROP ROLE IF EXISTS {role}")
+        conn.commit()
+
+    _cleanup()
+    with conn.cursor() as cur:
+        for role in _TEST_ROLES:
+            cur.execute(f"CREATE ROLE {role}")
+        # Grant CREATE on database to the migrator so it can own things.
+        cur.execute(f"CREATE SCHEMA {_TEST_SCHEMA} AUTHORIZATION own_migrator")
+        # Make the current user a member of both roles so ALTER ... OWNER TO
+        # works in tests (the test runner needs membership in the target).
+        cur.execute("GRANT own_migrator TO current_user")
+        cur.execute("GRANT own_intruder TO current_user")
+    conn.commit()
+
+    yield conn
+
+    _cleanup()
+
+
+def _expectation_for(relkinds: list[str]) -> OwnershipExpectation:
+    return OwnershipExpectation(
+        expected_owner="own_migrator",
+        apply_to=[OwnershipApplyTo(schema=_TEST_SCHEMA, relkinds=relkinds)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tables
+# ---------------------------------------------------------------------------
+
+
+def test_detects_table_owned_by_wrong_role(own_db: psycopg.Connection) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.orphan_table (id int)")
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.orphan_table OWNER TO own_intruder")
+    own_db.commit()
+
+    detector = OwnershipDriftDetector(own_db)
+    report = detector.check(_expectation_for(["r"]))
+
+    assert report.database_name
+    assert report.expected_schema_source == "ownership"
+    items = report.drift_items
+    assert len(items) == 1
+    assert items[0].drift_type == DriftType.WRONG_OWNER
+    assert items[0].severity == DriftSeverity.CRITICAL
+    assert "own_intruder" in items[0].message
+    assert "own_migrator" in items[0].message
+    assert f"{_TEST_SCHEMA}.orphan_table" in items[0].object_name
+
+
+def test_correct_owner_yields_no_drift(own_db: psycopg.Connection) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.tb_good (id int)")
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.tb_good OWNER TO own_migrator")
+    own_db.commit()
+
+    report = OwnershipDriftDetector(own_db).check(_expectation_for(["r"]))
+    assert report.drift_items == []
+    assert report.has_drift is False
+
+
+# ---------------------------------------------------------------------------
+# Ignore list
+# ---------------------------------------------------------------------------
+
+
+def test_ignore_list_skips_drifted_objects(own_db: psycopg.Connection) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.tb_a (id int)")
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.tb_a OWNER TO own_intruder")
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.tb_b (id int)")
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.tb_b OWNER TO own_intruder")
+    own_db.commit()
+
+    exp = OwnershipExpectation(
+        expected_owner="own_migrator",
+        apply_to=[OwnershipApplyTo(schema=_TEST_SCHEMA, relkinds=["r"])],
+        ignore=[f"{_TEST_SCHEMA}.tb_a"],
+    )
+    report = OwnershipDriftDetector(own_db).check(exp)
+    assert len(report.drift_items) == 1
+    assert "tb_b" in report.drift_items[0].object_name
+
+
+def test_ignore_glob_star_schema(own_db: psycopg.Connection) -> None:
+    """``*.legacy_audit_log`` matches across schemas."""
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.legacy_audit_log (id int)")
+        cur.execute(
+            f"ALTER TABLE {_TEST_SCHEMA}.legacy_audit_log OWNER TO own_intruder"
+        )
+    own_db.commit()
+
+    exp = OwnershipExpectation(
+        expected_owner="own_migrator",
+        apply_to=[OwnershipApplyTo(schema=_TEST_SCHEMA, relkinds=["r"])],
+        ignore=["*.legacy_audit_log"],
+    )
+    report = OwnershipDriftDetector(own_db).check(exp)
+    assert report.drift_items == []
+
+
+# ---------------------------------------------------------------------------
+# Cross-relkind coverage
+# ---------------------------------------------------------------------------
+
+
+def test_sequence_owned_by_wrong_role_flagged(own_db: psycopg.Connection) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE SEQUENCE {_TEST_SCHEMA}.seq_drift")
+        cur.execute(f"ALTER SEQUENCE {_TEST_SCHEMA}.seq_drift OWNER TO own_intruder")
+    own_db.commit()
+
+    report = OwnershipDriftDetector(own_db).check(_expectation_for(["S"]))
+    assert len(report.drift_items) == 1
+    assert report.drift_items[0].drift_type == DriftType.WRONG_OWNER
+    assert "seq_drift" in report.drift_items[0].object_name
+
+
+def test_view_owned_by_wrong_role_flagged(own_db: psycopg.Connection) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.base_tb (id int)")
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.base_tb OWNER TO own_migrator")
+        cur.execute(f"CREATE VIEW {_TEST_SCHEMA}.v_drift AS SELECT id FROM {_TEST_SCHEMA}.base_tb")
+        cur.execute(f"ALTER VIEW {_TEST_SCHEMA}.v_drift OWNER TO own_intruder")
+    own_db.commit()
+
+    report = OwnershipDriftDetector(own_db).check(_expectation_for(["v"]))
+    assert len(report.drift_items) == 1
+    assert "v_drift" in report.drift_items[0].object_name
+
+
+def test_materialized_view_owned_by_wrong_role_flagged(own_db: psycopg.Connection) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.mv_base (id int)")
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.mv_base OWNER TO own_migrator")
+        cur.execute(
+            f"CREATE MATERIALIZED VIEW {_TEST_SCHEMA}.mv_drift AS "
+            f"SELECT id FROM {_TEST_SCHEMA}.mv_base"
+        )
+        cur.execute(
+            f"ALTER MATERIALIZED VIEW {_TEST_SCHEMA}.mv_drift OWNER TO own_intruder"
+        )
+    own_db.commit()
+
+    report = OwnershipDriftDetector(own_db).check(_expectation_for(["m"]))
+    assert len(report.drift_items) == 1
+    assert "mv_drift" in report.drift_items[0].object_name
+
+
+# ---------------------------------------------------------------------------
+# Partition children are individually checked
+# ---------------------------------------------------------------------------
+
+
+def test_partition_child_with_drifted_owner_is_flagged(own_db: psycopg.Connection) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(
+            f"CREATE TABLE {_TEST_SCHEMA}.tb_events "
+            "(id int, occurred_at date) PARTITION BY RANGE (occurred_at)"
+        )
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.tb_events OWNER TO own_migrator")
+        cur.execute(
+            f"CREATE TABLE {_TEST_SCHEMA}.tb_events_2026 "
+            f"PARTITION OF {_TEST_SCHEMA}.tb_events "
+            "FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')"
+        )
+        cur.execute(
+            f"ALTER TABLE {_TEST_SCHEMA}.tb_events_2026 OWNER TO own_intruder"
+        )
+    own_db.commit()
+
+    report = OwnershipDriftDetector(own_db).check(_expectation_for(["r"]))
+    drifted = [i for i in report.drift_items if "2026" in i.object_name]
+    assert len(drifted) == 1
+
+
+# ---------------------------------------------------------------------------
+# Empty schema
+# ---------------------------------------------------------------------------
+
+
+def test_empty_schema_yields_no_drift(own_db: psycopg.Connection) -> None:
+    report = OwnershipDriftDetector(own_db).check(_expectation_for(["r", "S", "v", "m"]))
+    assert report.drift_items == []
+    assert report.has_drift is False
+
+
+def test_report_counts_relations_checked(own_db: psycopg.Connection) -> None:
+    with own_db.cursor() as cur:
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.tb_a (id int)")
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.tb_a OWNER TO own_migrator")
+        cur.execute(f"CREATE TABLE {_TEST_SCHEMA}.tb_b (id int)")
+        cur.execute(f"ALTER TABLE {_TEST_SCHEMA}.tb_b OWNER TO own_migrator")
+    own_db.commit()
+
+    report = OwnershipDriftDetector(own_db).check(_expectation_for(["r"]))
+    assert report.tables_checked == 2

--- a/tests/integration/test_view_manager.py
+++ b/tests/integration/test_view_manager.py
@@ -292,7 +292,8 @@ class TestRecreateSavedViews:
         vm_db.commit()
 
         # Recreate
-        count = vm.recreate_saved_views()
+        result = vm.recreate_saved_views()
+        count = result.total
         assert count == 1
 
         # View should exist again
@@ -326,7 +327,8 @@ class TestRecreateSavedViews:
             cur.execute("ALTER TABLE tb_machine ALTER COLUMN pk_machine TYPE BIGINT")
         vm_db.commit()
 
-        count = vm.recreate_saved_views()
+        result = vm.recreate_saved_views()
+        count = result.total
         assert count == 2
 
         # Both views should exist
@@ -358,7 +360,8 @@ class TestRecreateSavedViews:
         vm = ViewManager(vm_db)
         vm.save_and_drop_dependent_views(schemas=["public"])
 
-        count = vm.recreate_saved_views()
+        result = vm.recreate_saved_views()
+        count = result.total
         assert count == 1
 
         # Check materialized view exists
@@ -466,7 +469,7 @@ class TestRecreateSavedViews:
         vm_db.commit()
 
         # Step 3: Recreate
-        recreated = vm.recreate_saved_views()
+        recreated = vm.recreate_saved_views().total
         assert recreated >= 2
 
         # Verify everything is back
@@ -752,7 +755,7 @@ class TestEdgeCases:
             cur.execute("ALTER TABLE tb_machine ALTER COLUMN pk_machine TYPE BIGINT")
         vm_db.commit()
 
-        recreated = vm.recreate_saved_views()
+        recreated = vm.recreate_saved_views().total
         assert recreated == 3
 
     def test_no_views_returns_zero(self, vm_db: psycopg.Connection) -> None:
@@ -766,7 +769,8 @@ class TestEdgeCases:
         assert count == 0
 
         # Recreate should also return 0
-        count = vm.recreate_saved_views()
+        result = vm.recreate_saved_views()
+        count = result.total
         assert count == 0
 
     def test_schemas_default_none_scans_all_user_schemas(self, vm_db: psycopg.Connection) -> None:
@@ -800,7 +804,7 @@ class TestEdgeCases:
             cur.execute("ALTER TABLE catalog.tb_product ALTER COLUMN pk_product TYPE BIGINT")
         vm_db.commit()
 
-        recreated = vm.recreate_saved_views()
+        recreated = vm.recreate_saved_views().total
         assert recreated >= 1
 
 
@@ -856,7 +860,8 @@ class TestCrossSchemaViews:
             cur.execute("ALTER TABLE catalog.tb_product ALTER COLUMN pk_product TYPE BIGINT")
         vm_db.commit()
 
-        count = vm.recreate_saved_views()
+        result = vm.recreate_saved_views()
+        count = result.total
         assert count == 1
 
         with vm_db.cursor() as cur:

--- a/tests/unit/cli/test_ownership_loader.py
+++ b/tests/unit/cli/test_ownership_loader.py
@@ -1,0 +1,107 @@
+"""Unit tests for ``confiture.cli.ownership_loader`` (issue #124).
+
+Mirrors :mod:`tests.unit.cli.test_acl_loader` in spirit. The loader is
+consumed by both ``drift --check-ownership`` and
+``migrate validate --check-ownership-coverage``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+
+from confiture.cli.ownership_loader import load_ownership_expectation
+
+
+def test_load_minimal_config() -> None:
+    config_data: dict[str, Any] = {
+        "ownership": {
+            "expected_owner": "migrator",
+            "apply_to": [{"schema": "tenant"}],
+        }
+    }
+    result = load_ownership_expectation(
+        config_data, Path("confiture.yaml"), require=True
+    )
+    assert result is not None
+    assert result.expected_owner == "migrator"
+    assert result.apply_to[0].schema_ == "tenant"
+
+
+def test_load_missing_ownership_block_with_require_true_exits_2() -> None:
+    config_data: dict[str, Any] = {}
+    with pytest.raises(typer.Exit) as exc_info:
+        load_ownership_expectation(
+            config_data, Path("confiture.yaml"), require=True
+        )
+    assert exc_info.value.exit_code == 2
+
+
+def test_load_missing_ownership_block_with_require_false_returns_none() -> None:
+    config_data: dict[str, Any] = {}
+    result = load_ownership_expectation(
+        config_data, Path("confiture.yaml"), require=False
+    )
+    assert result is None
+
+
+def test_env_var_expansion(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OWNER", "realowner")
+    config_data: dict[str, Any] = {
+        "ownership": {
+            "expected_owner": "${OWNER}",
+            "apply_to": [{"schema": "tenant"}],
+        }
+    }
+    result = load_ownership_expectation(
+        config_data, Path("confiture.yaml"), require=True
+    )
+    assert result is not None
+    assert result.expected_owner == "realowner"
+
+
+def test_invalid_yaml_block_raises_typer_exit() -> None:
+    config_data: dict[str, Any] = {
+        "ownership": {
+            "expected_owner": "bad role with spaces",
+            "apply_to": [{"schema": "tenant"}],
+        }
+    }
+    with pytest.raises(typer.Exit) as exc_info:
+        load_ownership_expectation(
+            config_data, Path("confiture.yaml"), require=True
+        )
+    assert exc_info.value.exit_code == 2
+
+
+def test_load_block_with_lint_enabled_false() -> None:
+    config_data: dict[str, Any] = {
+        "ownership": {
+            "expected_owner": "migrator",
+            "apply_to": [{"schema": "tenant"}],
+            "lint_enabled": False,
+        }
+    }
+    result = load_ownership_expectation(
+        config_data, Path("confiture.yaml"), require=True
+    )
+    assert result is not None
+    assert result.lint_enabled is False
+
+
+def test_load_block_with_ignore_list() -> None:
+    config_data: dict[str, Any] = {
+        "ownership": {
+            "expected_owner": "migrator",
+            "apply_to": [{"schema": "tenant"}],
+            "ignore": ["tenant.legacy", "*.audit_log"],
+        }
+    }
+    result = load_ownership_expectation(
+        config_data, Path("confiture.yaml"), require=True
+    )
+    assert result is not None
+    assert result.ignore == ["tenant.legacy", "*.audit_log"]

--- a/tests/unit/config/test_ownership_expectation.py
+++ b/tests/unit/config/test_ownership_expectation.py
@@ -1,0 +1,196 @@
+"""Unit tests for the ``ownership:`` config block (issue #124).
+
+Mirrors :mod:`tests.unit.config.test_acl_config`. The ``ownership:`` block
+is a single dict (not a list of expectations), and ``lint_enabled`` defaults
+to ``True`` — opt-in by default per the issue's "Definition of done."
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from confiture.config.environment import (
+    Environment,
+    OwnershipApplyTo,
+    OwnershipExpectation,
+)
+from confiture.exceptions import ConfigurationError
+
+
+def _write_env_yaml(tmp_path: Path, body: str) -> Path:
+    env_dir = tmp_path / "db" / "environments"
+    env_dir.mkdir(parents=True, exist_ok=True)
+    header = "database_url: postgresql://localhost/test\ninclude_dirs: []\n"
+    (env_dir / "test.yaml").write_text(header + textwrap.dedent(body))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# OwnershipExpectation model
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_valid_config() -> None:
+    e = OwnershipExpectation(
+        expected_owner="migrator",
+        apply_to=[OwnershipApplyTo(schema="tenant")],
+    )
+    assert e.expected_owner == "migrator"
+    assert e.apply_to[0].schema_ == "tenant"
+    assert e.apply_to[0].relkinds == ["r", "S", "v", "m"]
+    assert e.ignore == []
+
+
+def test_lint_enabled_defaults_true() -> None:
+    """Opt-in by default per issue #124's Definition of done."""
+    e = OwnershipExpectation(
+        expected_owner="migrator",
+        apply_to=[OwnershipApplyTo(schema="tenant")],
+    )
+    assert e.lint_enabled is True
+
+
+def test_invalid_relkind_rejected() -> None:
+    with pytest.raises(ValidationError, match="relkinds"):
+        OwnershipApplyTo(schema="tenant", relkinds=["x"])
+
+
+def test_invalid_owner_name_rejected_space() -> None:
+    with pytest.raises(ValidationError, match="role identifier"):
+        OwnershipExpectation(
+            expected_owner="Drop Table",
+            apply_to=[OwnershipApplyTo(schema="t")],
+        )
+
+
+def test_invalid_owner_name_rejected_punctuation() -> None:
+    with pytest.raises(ValidationError, match="role identifier"):
+        OwnershipExpectation(
+            expected_owner="bad;role",
+            apply_to=[OwnershipApplyTo(schema="t")],
+        )
+
+
+def test_quoted_owner_name_accepted() -> None:
+    e = OwnershipExpectation(
+        expected_owner='"Mixed Case"',
+        apply_to=[OwnershipApplyTo(schema="t")],
+    )
+    assert e.expected_owner == '"Mixed Case"'
+
+
+def test_ownership_expectation_rejects_unknown_key() -> None:
+    with pytest.raises(ValidationError):
+        OwnershipExpectation(
+            expected_owner="migrator",
+            apply_to=[OwnershipApplyTo(schema="t")],
+            unknown_key="x",  # type: ignore[call-arg]
+        )
+
+
+def test_ignore_list_defaults_empty() -> None:
+    e = OwnershipExpectation(
+        expected_owner="migrator",
+        apply_to=[OwnershipApplyTo(schema="t")],
+    )
+    assert e.ignore == []
+
+
+def test_apply_to_custom_relkinds() -> None:
+    a = OwnershipApplyTo(schema="t", relkinds=["r", "S"])
+    assert a.relkinds == ["r", "S"]
+
+
+# ---------------------------------------------------------------------------
+# Environment integration
+# ---------------------------------------------------------------------------
+
+
+def test_environment_accepts_ownership_block(tmp_path: Path) -> None:
+    project = _write_env_yaml(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: tenant
+              relkinds: [r, S, v, m]
+            - schema: public
+              relkinds: [r, S]
+          ignore:
+            - public.legacy_audit_log
+          lint_enabled: true
+        """,
+    )
+    env = Environment.load("test", project)
+    assert env.ownership is not None
+    assert env.ownership.expected_owner == "migrator"
+    assert len(env.ownership.apply_to) == 2
+    assert env.ownership.apply_to[0].schema_ == "tenant"
+    assert env.ownership.apply_to[0].relkinds == ["r", "S", "v", "m"]
+    assert env.ownership.apply_to[1].schema_ == "public"
+    assert env.ownership.apply_to[1].relkinds == ["r", "S"]
+    assert env.ownership.ignore == ["public.legacy_audit_log"]
+    assert env.ownership.lint_enabled is True
+
+
+def test_environment_without_ownership_block_is_valid(tmp_path: Path) -> None:
+    project = _write_env_yaml(tmp_path, "")
+    env = Environment.load("test", project)
+    assert env.ownership is None
+
+
+def test_environment_ownership_block_omitting_lint_enabled_defaults_true(
+    tmp_path: Path,
+) -> None:
+    project = _write_env_yaml(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: migrator
+          apply_to:
+            - schema: tenant
+        """,
+    )
+    env = Environment.load("test", project)
+    assert env.ownership is not None
+    assert env.ownership.lint_enabled is True
+
+
+def test_environment_ownership_expands_env_vars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OWNER", "realowner")
+    project = _write_env_yaml(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: ${OWNER}
+          apply_to:
+            - schema: tenant
+        """,
+    )
+    env = Environment.load("test", project)
+    assert env.ownership is not None
+    assert env.ownership.expected_owner == "realowner"
+
+
+def test_environment_ownership_missing_env_var_fails_loud(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OWNER", raising=False)
+    project = _write_env_yaml(
+        tmp_path,
+        """
+        ownership:
+          expected_owner: ${OWNER}
+          apply_to:
+            - schema: tenant
+        """,
+    )
+    with pytest.raises(ConfigurationError, match="OWNER"):
+        Environment.load("test", project)

--- a/tests/unit/idempotency/test_fix_available_reconciliation.py
+++ b/tests/unit/idempotency/test_fix_available_reconciliation.py
@@ -1,0 +1,122 @@
+"""Reconciliation tests: a single source of truth for auto-fix availability.
+
+Pre-0.16: ``IdempotencyPattern.fix_available`` claimed 17 patterns were
+fixable while ``_get_suggested_fix`` only dispatched for 11 — so
+``dry_run`` underreported the auto-fix coverage that ``fix()`` actually
+performs.
+
+This module pins the contract: every pattern that ``fix_available`` reports
+as ``True`` must also be routed by ``_get_suggested_fix``.
+"""
+
+from __future__ import annotations
+
+from confiture.core.idempotency.fixer import (
+    FIXABLE_PATTERNS,
+    IdempotencyFixer,
+)
+from confiture.core.idempotency.models import IdempotencyPattern
+
+# Minimal SQL snippets per fixable pattern — used to confirm the
+# dispatch table actually routes the fix. The transformations are
+# deliberately recognisable (``IF NOT EXISTS`` / ``OR REPLACE`` / etc.).
+_FIXABLE_SAMPLE_SQL: dict[IdempotencyPattern, str] = {
+    IdempotencyPattern.CREATE_TABLE: "CREATE TABLE users (id INT);",
+    IdempotencyPattern.CREATE_INDEX: "CREATE INDEX idx_users_email ON users(email);",
+    IdempotencyPattern.CREATE_UNIQUE_INDEX: (
+        "CREATE UNIQUE INDEX idx_users_email ON users(email);"
+    ),
+    IdempotencyPattern.CREATE_FUNCTION: (
+        "CREATE FUNCTION f() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;"
+    ),
+    IdempotencyPattern.CREATE_PROCEDURE: (
+        "CREATE PROCEDURE p() LANGUAGE sql AS $$ SELECT 1 $$;"
+    ),
+    IdempotencyPattern.CREATE_VIEW: "CREATE VIEW v AS SELECT 1;",
+    IdempotencyPattern.CREATE_EXTENSION: "CREATE EXTENSION pgcrypto;",
+    IdempotencyPattern.CREATE_SCHEMA: "CREATE SCHEMA app;",
+    IdempotencyPattern.CREATE_SEQUENCE: "CREATE SEQUENCE seq_id;",
+    IdempotencyPattern.ALTER_TABLE_ADD_COLUMN: (
+        "ALTER TABLE users ADD COLUMN bio TEXT;"
+    ),
+    IdempotencyPattern.DROP_TABLE: "DROP TABLE users;",
+    IdempotencyPattern.DROP_INDEX: "DROP INDEX idx_users_email;",
+    IdempotencyPattern.DROP_FUNCTION: "DROP FUNCTION f();",
+    IdempotencyPattern.DROP_VIEW: "DROP VIEW v;",
+    IdempotencyPattern.DROP_TYPE: "DROP TYPE status_enum;",
+    IdempotencyPattern.DROP_SCHEMA: "DROP SCHEMA app;",
+    IdempotencyPattern.DROP_SEQUENCE: "DROP SEQUENCE seq_id;",
+}
+
+
+class TestFixableSourceOfTruth:
+    """``FIXABLE_PATTERNS`` is the single source of truth."""
+
+    def test_fix_available_matches_fixable_patterns(self):
+        """Every pattern marked ``fix_available`` is in ``FIXABLE_PATTERNS``."""
+        claimed = {p for p in IdempotencyPattern if p.fix_available}
+        assert claimed == FIXABLE_PATTERNS
+
+    def test_fixable_set_is_non_empty(self):
+        """Sanity check: at least the CREATE_TABLE entry survives."""
+        assert IdempotencyPattern.CREATE_TABLE in FIXABLE_PATTERNS
+        assert len(FIXABLE_PATTERNS) > 0
+
+
+class TestDispatchCoverage:
+    """``_get_suggested_fix`` routes every claimed-fixable pattern."""
+
+    def test_dispatch_routes_every_fixable_pattern(self):
+        """For each fixable pattern, dispatch produces a transformed snippet.
+
+        Without the Cycle 2 fix, six patterns (CREATE_EXTENSION,
+        CREATE_SCHEMA, CREATE_SEQUENCE, DROP_TYPE, DROP_SCHEMA,
+        DROP_SEQUENCE) fail this — ``_get_suggested_fix`` returns the
+        input unchanged because their dispatch entry is missing.
+        """
+        fixer = IdempotencyFixer()
+        for pattern in FIXABLE_PATTERNS:
+            sample = _FIXABLE_SAMPLE_SQL[pattern]
+            transformed = fixer._get_suggested_fix(pattern, sample)
+            assert transformed != sample, (
+                f"_get_suggested_fix did not transform {pattern.name}: "
+                f"input={sample!r} output={transformed!r}"
+            )
+
+    def test_six_patterns_previously_missing_dispatch_now_route(self):
+        """The 6 patterns identified in Phase 01 review now route."""
+        previously_missing = {
+            IdempotencyPattern.CREATE_EXTENSION,
+            IdempotencyPattern.CREATE_SCHEMA,
+            IdempotencyPattern.CREATE_SEQUENCE,
+            IdempotencyPattern.DROP_TYPE,
+            IdempotencyPattern.DROP_SCHEMA,
+            IdempotencyPattern.DROP_SEQUENCE,
+        }
+        fixer = IdempotencyFixer()
+        for pattern in previously_missing:
+            sample = _FIXABLE_SAMPLE_SQL[pattern]
+            transformed = fixer._get_suggested_fix(pattern, sample)
+            assert "IF NOT EXISTS" in transformed.upper() or "IF EXISTS" in transformed.upper(), (
+                f"{pattern.name}: expected idempotency keyword in fix; got {transformed!r}"
+            )
+
+
+class TestDryRunReportsAllFixablePatterns:
+    """End-to-end: ``dry_run`` no longer underreports auto-fix coverage."""
+
+    def test_dry_run_emits_change_for_create_extension(self):
+        """CREATE_EXTENSION was missing from dispatch — dry_run now reports it."""
+        fixer = IdempotencyFixer()
+        changes = fixer.dry_run("CREATE EXTENSION pgcrypto;")
+        assert len(changes) == 1
+        assert changes[0].pattern == IdempotencyPattern.CREATE_EXTENSION
+        assert "IF NOT EXISTS" in changes[0].suggested_fix.upper()
+
+    def test_dry_run_emits_change_for_drop_sequence(self):
+        """DROP_SEQUENCE was missing from dispatch — dry_run now reports it."""
+        fixer = IdempotencyFixer()
+        changes = fixer.dry_run("DROP SEQUENCE seq_id;")
+        assert len(changes) == 1
+        assert changes[0].pattern == IdempotencyPattern.DROP_SEQUENCE
+        assert "IF EXISTS" in changes[0].suggested_fix.upper()

--- a/tests/unit/idempotency/test_list_patterns.py
+++ b/tests/unit/idempotency/test_list_patterns.py
@@ -1,0 +1,126 @@
+"""Tests for the machine-readable pattern catalog.
+
+The catalog is exposed via :func:`confiture.core.idempotency.patterns.list_patterns`
+and surfaces the same information through the
+``confiture migrate validate --list-patterns`` CLI flag.
+"""
+
+from __future__ import annotations
+
+from confiture.core.idempotency.models import IdempotencyPattern
+from confiture.core.idempotency.patterns import PATTERNS, list_patterns
+
+
+class TestListPatternsShape:
+    """Shape and field contracts for the catalog."""
+
+    def test_returns_one_entry_per_pattern_definition(self):
+        """Catalog has the same length as PATTERNS."""
+        catalog = list_patterns()
+        assert len(catalog) == len(PATTERNS)
+        assert len(catalog) > 0
+
+    def test_each_entry_has_required_fields(self):
+        """Every entry has the documented 6 keys, nothing more."""
+        catalog = list_patterns()
+        expected = {
+            "id",
+            "description",
+            "severity",
+            "has_skip_regex",
+            "skip_hint",
+            "has_auto_fix",
+        }
+        for entry in catalog:
+            assert set(entry.keys()) == expected, entry
+
+    def test_field_types(self):
+        """Fields carry the expected types."""
+        for entry in list_patterns():
+            assert isinstance(entry["id"], str)
+            assert isinstance(entry["description"], str)
+            assert entry["severity"] in {"error", "info"}
+            assert isinstance(entry["has_skip_regex"], bool)
+            assert isinstance(entry["has_auto_fix"], bool)
+            # skip_hint is either None or a human-friendly string
+            assert entry["skip_hint"] is None or isinstance(entry["skip_hint"], str)
+
+    def test_does_not_expose_regex_objects(self):
+        """Regex objects must not leak into the catalog (not JSON-serialisable)."""
+        import re
+
+        for entry in list_patterns():
+            for value in entry.values():
+                assert not isinstance(value, re.Pattern), entry
+
+    def test_ids_match_idempotency_pattern_enum(self):
+        """Each entry's id is a valid IdempotencyPattern enum name."""
+        valid_ids = {p.name for p in IdempotencyPattern}
+        for entry in list_patterns():
+            assert entry["id"] in valid_ids
+
+
+class TestSkipRegexFlag:
+    """``has_skip_regex`` reflects PatternDefinition.skip_regex is not None."""
+
+    def test_has_skip_regex_matches_definition(self):
+        """For each pattern, has_skip_regex == (skip_regex is not None)."""
+        by_id = {entry["id"]: entry for entry in list_patterns()}
+        for pdef in PATTERNS:
+            entry = by_id[pdef.pattern.name]
+            assert entry["has_skip_regex"] is (pdef.skip_regex is not None)
+
+    def test_create_table_advertises_skip_regex(self):
+        """CREATE_TABLE has a skip_regex (CREATE TABLE IF NOT EXISTS)."""
+        by_id = {entry["id"]: entry for entry in list_patterns()}
+        assert by_id["CREATE_TABLE"]["has_skip_regex"] is True
+
+    def test_alter_table_add_constraint_check_has_no_skip_regex(self):
+        """ALTER TABLE ADD CONSTRAINT CHECK has no simple skip — needs DO block."""
+        by_id = {entry["id"]: entry for entry in list_patterns()}
+        assert by_id["ALTER_TABLE_ADD_CONSTRAINT_CHECK"]["has_skip_regex"] is False
+
+
+class TestHasAutoFix:
+    """``has_auto_fix`` reads from the single source of truth (FIXABLE_PATTERNS)."""
+
+    def test_has_auto_fix_marks_known_fixable_patterns(self):
+        """Three patterns known to be fixable advertise auto-fix."""
+        by_id = {entry["id"]: entry for entry in list_patterns()}
+        for fixable_id in ("CREATE_TABLE", "CREATE_INDEX", "CREATE_EXTENSION"):
+            assert by_id[fixable_id]["has_auto_fix"] is True, fixable_id
+
+    def test_has_auto_fix_marks_known_unfixable_patterns(self):
+        """Two patterns known to lack auto-fix do not advertise it."""
+        by_id = {entry["id"]: entry for entry in list_patterns()}
+        for unfixable_id in (
+            "ALTER_TABLE_ADD_CONSTRAINT_CHECK",
+            "ALTER_TABLE_RENAME_COLUMN",
+        ):
+            assert by_id[unfixable_id]["has_auto_fix"] is False, unfixable_id
+
+    def test_has_auto_fix_matches_fixable_patterns_set(self):
+        """Catalog's has_auto_fix is identical to FIXABLE_PATTERNS membership."""
+        from confiture.core.idempotency.fixer import FIXABLE_PATTERNS
+
+        for entry in list_patterns():
+            pattern = IdempotencyPattern[entry["id"]]
+            assert entry["has_auto_fix"] is (pattern in FIXABLE_PATTERNS), entry
+
+
+class TestSkipHint:
+    """``skip_hint`` is human-readable text (NOT a regex)."""
+
+    def test_create_table_skip_hint_mentions_if_not_exists(self):
+        """The skip hint is what users should write — readable English/SQL."""
+        by_id = {entry["id"]: entry for entry in list_patterns()}
+        hint = by_id["CREATE_TABLE"]["skip_hint"]
+        assert hint is not None
+        assert "IF NOT EXISTS" in hint.upper()
+
+    def test_pattern_without_skip_regex_has_none_skip_hint(self):
+        """When there's no skip_regex, skip_hint is None too."""
+        by_id = {entry["id"]: entry for entry in list_patterns()}
+        for entry in by_id.values():
+            if entry["has_skip_regex"] is False:
+                assert entry["skip_hint"] is None

--- a/tests/unit/idempotency/test_list_patterns.py
+++ b/tests/unit/idempotency/test_list_patterns.py
@@ -21,7 +21,7 @@ class TestListPatternsShape:
         assert len(catalog) > 0
 
     def test_each_entry_has_required_fields(self):
-        """Every entry has the documented 6 keys, nothing more."""
+        """Every entry has the documented 7 keys, nothing more."""
         catalog = list_patterns()
         expected = {
             "id",
@@ -30,6 +30,7 @@ class TestListPatternsShape:
             "has_skip_regex",
             "skip_hint",
             "has_auto_fix",
+            "template_fillable",
         }
         for entry in catalog:
             assert set(entry.keys()) == expected, entry
@@ -42,6 +43,7 @@ class TestListPatternsShape:
             assert entry["severity"] in {"error", "info"}
             assert isinstance(entry["has_skip_regex"], bool)
             assert isinstance(entry["has_auto_fix"], bool)
+            assert isinstance(entry["template_fillable"], bool)
             # skip_hint is either None or a human-friendly string
             assert entry["skip_hint"] is None or isinstance(entry["skip_hint"], str)
 

--- a/tests/unit/json_schemas/conftest.py
+++ b/tests/unit/json_schemas/conftest.py
@@ -1,0 +1,67 @@
+"""Shared fixtures for JSON-schema validation tests.
+
+The schemas live under ``docs/reference/json-schemas/``. Each test loads
+the relevant ``.schema.json`` and validates real CLI output against it
+using Draft 2020-12.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+
+SCHEMAS_DIR = Path(__file__).resolve().parents[3] / "docs" / "reference" / "json-schemas"
+
+
+def _load_schema(filename: str) -> dict:
+    return json.loads((SCHEMAS_DIR / filename).read_text())
+
+
+@pytest.fixture(scope="session")
+def schemas_dir() -> Path:
+    """Absolute path to ``docs/reference/json-schemas/``."""
+    return SCHEMAS_DIR
+
+
+@pytest.fixture(scope="session")
+def common_schema() -> dict:
+    """``_common.schema.json`` — shared $defs (Violation, HintsArray, DriftItem)."""
+    return _load_schema("_common.schema.json")
+
+
+@pytest.fixture(scope="session")
+def schema_registry(common_schema):
+    """A referencing registry that resolves ``_common.schema.json#/$defs/...`` $refs.
+
+    jsonschema 4.18+ uses ``referencing`` for $ref resolution. Schemas use
+    a relative ``_common.schema.json`` $ref, so the registry maps that
+    relative URI to the loaded common-schema resource.
+    """
+    resource = Resource.from_contents(common_schema, default_specification=DRAFT202012)
+    return Registry().with_resource(uri="_common.schema.json", resource=resource)
+
+
+def make_validator(schema: dict, registry) -> Draft202012Validator:
+    """Build a Draft 2020-12 validator with the shared registry."""
+    return Draft202012Validator(schema, registry=registry)
+
+
+@pytest.fixture()
+def validate_against():
+    """Validate a payload against a named schema file.
+
+    Returns a callable: ``validate_against(payload, "schema-file.schema.json")``.
+    Raises ``jsonschema.ValidationError`` on mismatch.
+    """
+
+    def _validate(payload: dict, schema_filename: str, registry) -> None:
+        schema = _load_schema(schema_filename)
+        validator = make_validator(schema, registry)
+        validator.validate(payload)
+
+    return _validate

--- a/tests/unit/json_schemas/test_drift_schema.py
+++ b/tests/unit/json_schemas/test_drift_schema.py
@@ -1,0 +1,138 @@
+"""Validate ``drift`` and ``drift --check-acls`` output against their schemas.
+
+Drift requires a live database, which is out of scope for unit tests.
+Instead, we validate the emitted JSON shape against the schema using the
+``DriftReport.to_dict()`` output that the CLI prints verbatim (with a
+``hints: []`` field injected at the emit site).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+
+from confiture.core.drift import (
+    DriftItem,
+    DriftReport,
+    DriftSeverity,
+    DriftType,
+)
+
+DRIFT_SCHEMA = "drift.schema.json"
+ACL_SCHEMA = "drift-check-acls.schema.json"
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+def _build_registry(schemas_dir: Path) -> Registry:
+    """Registry that resolves common.schema.json AND drift.schema.json $refs.
+
+    The ACL schema is a thin $ref to drift.schema.json, so both schema
+    files must be resolvable by relative URI.
+    """
+    registry: Registry = Registry()
+    for filename in ("_common.schema.json", "drift.schema.json"):
+        content = _load(schemas_dir, filename)
+        resource = Resource.from_contents(content, default_specification=DRAFT202012)
+        registry = registry.with_resource(uri=filename, resource=resource)
+    return registry
+
+
+def _emit_payload(report: DriftReport) -> dict:
+    """Mirror what the drift CLI emits: report.to_dict() + hints: []."""
+    payload = report.to_dict()
+    payload["hints"] = []
+    return payload
+
+
+def test_schemas_are_valid_draft_2020_12(schemas_dir):
+    for name in (DRIFT_SCHEMA, ACL_SCHEMA):
+        Draft202012Validator.check_schema(_load(schemas_dir, name))
+
+
+def test_empty_drift_report_validates(schemas_dir):
+    """Clean drift report — no drift items."""
+    report = DriftReport(
+        database_name="confiture_test",
+        expected_schema_source="db/schema.sql",
+        drift_items=[],
+        tables_checked=10,
+        columns_checked=50,
+        indexes_checked=15,
+        detection_time_ms=42,
+    )
+    payload = _emit_payload(report)
+
+    registry = _build_registry(schemas_dir)
+    Draft202012Validator(_load(schemas_dir, DRIFT_SCHEMA), registry=registry).validate(payload)
+    assert payload["hints"] == []
+    assert payload["drift_items"] == []
+
+
+def test_drift_report_with_items_validates(schemas_dir):
+    """Drift with several finding types."""
+    report = DriftReport(
+        database_name="confiture_test",
+        expected_schema_source="migrations",
+        drift_items=[
+            DriftItem(
+                drift_type=DriftType.MISSING_TABLE,
+                severity=DriftSeverity.CRITICAL,
+                object_name="public.orders",
+                expected="present",
+                actual=None,
+                message="Table public.orders missing from live DB",
+            ),
+            DriftItem(
+                drift_type=DriftType.TYPE_MISMATCH,
+                severity=DriftSeverity.WARNING,
+                object_name="public.users.email",
+                expected="varchar(255)",
+                actual="text",
+                message="Column type differs",
+            ),
+        ],
+        tables_checked=5,
+        columns_checked=30,
+        indexes_checked=8,
+        detection_time_ms=120,
+    )
+    payload = _emit_payload(report)
+
+    registry = _build_registry(schemas_dir)
+    Draft202012Validator(_load(schemas_dir, DRIFT_SCHEMA), registry=registry).validate(payload)
+    assert payload["has_critical_drift"] is True
+    assert payload["critical_count"] == 1
+    assert payload["warning_count"] == 1
+
+
+def test_drift_check_acls_includes_missing_grant_item(schemas_dir):
+    """ACL drift items use the same DriftItem shape — schema is the same."""
+    report = DriftReport(
+        database_name="confiture_test",
+        expected_schema_source="db/schema.sql",
+        drift_items=[
+            DriftItem(
+                drift_type=DriftType.MISSING_GRANT,
+                severity=DriftSeverity.CRITICAL,
+                object_name="public.orders",
+                expected="SELECT to app_reader",
+                actual=None,
+                message="Expected SELECT grant on public.orders to app_reader is missing",
+            ),
+        ],
+        tables_checked=1,
+        columns_checked=0,
+        indexes_checked=0,
+        detection_time_ms=8,
+    )
+    payload = _emit_payload(report)
+
+    registry = _build_registry(schemas_dir)
+    Draft202012Validator(_load(schemas_dir, ACL_SCHEMA), registry=registry).validate(payload)

--- a/tests/unit/json_schemas/test_fix_schema.py
+++ b/tests/unit/json_schemas/test_fix_schema.py
@@ -1,0 +1,110 @@
+"""Validate ``migrate fix --idempotent --format json`` output against its schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+SCHEMA_FILE = "migrate-fix.schema.json"
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+def _validator(schemas_dir, registry) -> Draft202012Validator:
+    return Draft202012Validator(_load(schemas_dir, SCHEMA_FILE), registry=registry)
+
+
+def test_schema_is_valid_draft_2020_12(schemas_dir):
+    Draft202012Validator.check_schema(_load(schemas_dir, SCHEMA_FILE))
+
+
+def test_fix_empty_migrations_dir_validates(tmp_path, schemas_dir, schema_registry):
+    """No migration files — empty-input envelope."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--idempotent",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["status"] == "ok"
+    assert payload["hints"] == []
+
+
+def test_fix_dry_run_preview_validates(tmp_path, schemas_dir, schema_registry):
+    """A non-idempotent migration with --dry-run → status: preview."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260527000001_init.up.sql").write_text(
+        "CREATE TABLE users (id INT PRIMARY KEY);\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--idempotent",
+            "--dry-run",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["status"] == "preview"
+    assert payload["total_files_changed"] == 1
+    # Verify file wasn't modified on disk.
+    assert (
+        "IF NOT EXISTS"
+        not in (migs / "20260527000001_init.up.sql").read_text().upper()
+    )
+
+
+def test_fix_apply_validates(tmp_path, schemas_dir, schema_registry):
+    """A non-idempotent migration without --dry-run → status: fixed; file rewritten."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    f = migs / "20260527000002_init.up.sql"
+    f.write_text("CREATE TABLE users (id INT PRIMARY KEY);\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "fix",
+            "--idempotent",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["status"] == "fixed"
+    assert "IF NOT EXISTS" in f.read_text().upper()

--- a/tests/unit/json_schemas/test_list_patterns_schema.py
+++ b/tests/unit/json_schemas/test_list_patterns_schema.py
@@ -1,0 +1,46 @@
+"""Validate ``migrate validate --list-patterns --format json`` output against its schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+SCHEMA_FILE = "migrate-validate-list-patterns.schema.json"
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+def test_list_patterns_payload_validates_against_schema(schemas_dir, schema_registry):
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["migrate", "validate", "--list-patterns", "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+
+    schema = _load(schemas_dir, SCHEMA_FILE)
+    validator = Draft202012Validator(schema, registry=schema_registry)
+    validator.validate(payload)
+
+
+def test_hints_field_present_and_empty_by_default(schemas_dir, schema_registry):
+    """`hints` is pre-allocated for Phase 05; today it's always an empty list."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["migrate", "validate", "--list-patterns", "--format", "json"]
+    )
+    payload = json.loads(result.stdout)
+    assert payload["hints"] == []
+
+
+def test_schema_is_valid_draft_2020_12(schemas_dir):
+    """The schema document itself is a valid Draft 2020-12 schema."""
+    schema = _load(schemas_dir, SCHEMA_FILE)
+    Draft202012Validator.check_schema(schema)

--- a/tests/unit/json_schemas/test_preflight_schema.py
+++ b/tests/unit/json_schemas/test_preflight_schema.py
@@ -1,0 +1,136 @@
+"""Validate ``migrate preflight --format json`` outputs against their schemas.
+
+Two shapes are covered:
+* default (no --against): static analysis only, no DB
+* `--against <url>`: static analysis + execution outcomes (mocked here)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.models.results import (
+    PreflightAgainstMigration,
+    PreflightAgainstResult,
+)
+
+PREFLIGHT_SCHEMA = "migrate-preflight.schema.json"
+AGAINST_SCHEMA = "migrate-preflight-against.schema.json"
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+def _build_registry(schemas_dir: Path) -> Registry:
+    """Registry including the preflight $defs file as well as common."""
+    registry: Registry = Registry()
+    for filename in ("_common.schema.json", "_preflight_defs.schema.json"):
+        content = _load(schemas_dir, filename)
+        resource = Resource.from_contents(content, default_specification=DRAFT202012)
+        registry = registry.with_resource(uri=filename, resource=resource)
+    return registry
+
+
+def test_preflight_schemas_are_valid_draft_2020_12(schemas_dir):
+    for name in (PREFLIGHT_SCHEMA, AGAINST_SCHEMA, "_preflight_defs.schema.json"):
+        Draft202012Validator.check_schema(_load(schemas_dir, name))
+
+
+def test_preflight_no_against_validates(tmp_path, schemas_dir):
+    """Default preflight — no DB needed."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260527000000_init.up.sql").write_text("CREATE TABLE x (id INT);\n")
+    (migs / "20260527000000_init.down.sql").write_text("DROP TABLE x;\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "preflight",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+
+    registry = _build_registry(schemas_dir)
+    Draft202012Validator(_load(schemas_dir, PREFLIGHT_SCHEMA), registry=registry).validate(payload)
+    assert payload["hints"] == []
+    assert "safe_to_deploy" in payload
+
+
+def test_preflight_against_validates(tmp_path, schemas_dir):
+    """--against path — mock the session.run_against to return a fixture."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260527000000_init.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS x (id INT);\n"
+    )
+    (migs / "20260527000000_init.down.sql").write_text("DROP TABLE IF EXISTS x;\n")
+
+    fixture = PreflightAgainstResult(
+        migrations=[
+            PreflightAgainstMigration(
+                version="20260527000000",
+                name="init",
+                success=True,
+                error=None,
+                skipped=False,
+                skipped_reason=None,
+                execution_time_ms=42,
+            )
+        ],
+        against_url="postgresql://user:secret@localhost/preflight",
+        db_consumed=False,
+    )
+
+    mock_session = MagicMock()
+    mock_session.__enter__ = lambda s: mock_session
+    mock_session.__exit__ = MagicMock(return_value=False)
+    mock_session.run_against.return_value = fixture
+
+    runner = CliRunner()
+    with patch(
+        "confiture.cli.commands.migrate_analysis.MigratorSession",
+        return_value=mock_session,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "preflight",
+                "--against",
+                "postgresql://user:secret@localhost/preflight",
+                "--migrations-dir",
+                str(migs),
+                "--format",
+                "json",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+
+    registry = _build_registry(schemas_dir)
+    Draft202012Validator(_load(schemas_dir, AGAINST_SCHEMA), registry=registry).validate(payload)
+
+    # Spot-check the documented field-name traps:
+    assert "success" in payload["against"]["migrations"][0]  # NOT "passed"
+    assert payload["against"]["all_passed"] is True
+    # URL is redacted — the password is stripped (the username is preserved).
+    assert "secret" not in payload["against"]["against_url"]
+    assert "user" in payload["against"]["against_url"]
+    assert payload["hints"] == []

--- a/tests/unit/json_schemas/test_reference_doc.py
+++ b/tests/unit/json_schemas/test_reference_doc.py
@@ -1,0 +1,41 @@
+"""The reference doc enumerates every schema file in this directory.
+
+Catches drift if a schema is added but not cross-linked from
+``docs/reference/json-schemas.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REFERENCE_DOC = REPO_ROOT / "docs" / "reference" / "json-schemas.md"
+SCHEMAS_DIR = REPO_ROOT / "docs" / "reference" / "json-schemas"
+
+
+def _public_schemas() -> list[Path]:
+    """All schema files except the underscore-prefixed shared sub-schemas."""
+    return sorted(
+        p for p in SCHEMAS_DIR.glob("*.schema.json") if not p.name.startswith("_")
+    )
+
+
+def test_reference_doc_exists():
+    assert REFERENCE_DOC.exists(), f"missing {REFERENCE_DOC}"
+
+
+def test_reference_doc_mentions_every_schema_file():
+    """Each public schema filename appears at least once in the reference doc."""
+    text = REFERENCE_DOC.read_text()
+    missing = [p.name for p in _public_schemas() if p.name not in text]
+    assert not missing, f"reference doc does not mention: {missing}"
+
+
+def test_reference_doc_calls_out_field_name_traps():
+    """The four field-name surprises from issue #123 are documented."""
+    text = REFERENCE_DOC.read_text()
+    # Each trap surfaces in the doc body so agents can grep for the wrong name.
+    assert "source_line" in text
+    assert "line_number" in text  # called out as the WRONG field name
+    assert "success" in text
+    assert "passed" in text  # called out as the WRONG field name

--- a/tests/unit/json_schemas/test_status_schema.py
+++ b/tests/unit/json_schemas/test_status_schema.py
@@ -1,0 +1,77 @@
+"""Validate ``migrate status --format json`` output against its schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+SCHEMA_FILE = "migrate-status.schema.json"
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+def _validator(schemas_dir, registry) -> Draft202012Validator:
+    return Draft202012Validator(_load(schemas_dir, SCHEMA_FILE), registry=registry)
+
+
+def test_schema_is_valid_draft_2020_12(schemas_dir):
+    Draft202012Validator.check_schema(_load(schemas_dir, SCHEMA_FILE))
+
+
+def test_empty_migrations_dir_validates(tmp_path, schemas_dir, schema_registry):
+    """No migration files → empty-input shape."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "status",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["total"] == 0
+    assert payload["current"] is None
+    assert payload["hints"] == []
+
+
+def test_status_without_config_validates(tmp_path, schemas_dir, schema_registry):
+    """Migration files present, no --config → status=unknown per-migration."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260527000000_init.up.sql").write_text("CREATE TABLE IF NOT EXISTS u (id INT);\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "status",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["tracking_table"] is None
+    assert payload["total"] == 1
+    assert all(m["status"] == "unknown" for m in payload["migrations"])
+    assert payload["summary"] == {"applied": 0, "pending": 0, "total": 1}
+    assert payload["hints"] == []

--- a/tests/unit/json_schemas/test_validate_check_acl_coverage_schema.py
+++ b/tests/unit/json_schemas/test_validate_check_acl_coverage_schema.py
@@ -1,0 +1,108 @@
+"""Validate ``migrate validate --check-acls --format json`` output."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+SCHEMA_FILE = "migrate-validate-check-acl-coverage.schema.json"
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+def _validator(schemas_dir, registry) -> Draft202012Validator:
+    return Draft202012Validator(_load(schemas_dir, SCHEMA_FILE), registry=registry)
+
+
+def _project(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a minimal project with a config and a migration."""
+    config = tmp_path / "confiture.yaml"
+    config.write_text(
+        dedent(
+            """\
+            environment: test
+            database:
+              host: localhost
+              port: 5432
+              name: confiture_test
+              user: confiture
+            migration:
+              dir: db/migrations
+            acls:
+              - schema: public
+                apply_to: ALL_TABLES
+                grants:
+                  - role: app_reader
+                    privileges: [SELECT]
+            """
+        )
+    )
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    return config, migs
+
+
+def test_schema_is_valid_draft_2020_12(schemas_dir):
+    schema = _load(schemas_dir, SCHEMA_FILE)
+    Draft202012Validator.check_schema(schema)
+
+
+def test_check_acls_empty_migrations_validates(tmp_path, schemas_dir, schema_registry):
+    """No migrations to lint — empty violations list, hints array present."""
+    config, migs = _project(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-acls",
+            "-c",
+            str(config),
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["check"] == "acl_coverage"
+    assert payload["violations"] == []
+    assert payload["hints"] == []
+
+
+def test_check_acls_violation_validates(tmp_path, schemas_dir, schema_registry):
+    """A CREATE TABLE without matching grants — at least one violation."""
+    config, migs = _project(tmp_path)
+    (migs / "20260527000000_init.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS public.orders (id INT PRIMARY KEY);\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-acls",
+            "-c",
+            str(config),
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    # Exit code may be 0 or 1 depending on severity; we only assert shape.
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["check"] == "acl_coverage"

--- a/tests/unit/json_schemas/test_validate_idempotent_schema.py
+++ b/tests/unit/json_schemas/test_validate_idempotent_schema.py
@@ -27,7 +27,7 @@ def test_schema_is_valid_draft_2020_12(schemas_dir):
 
 
 def test_empty_migrations_dir_validates(tmp_path, schemas_dir, schema_registry):
-    """No migration files in directory → minimal ok-envelope."""
+    """No migration files in directory → ok-envelope + quiet-success hint."""
     (tmp_path / "db" / "migrations").mkdir(parents=True)
     runner = CliRunner()
     result = runner.invoke(
@@ -46,7 +46,8 @@ def test_empty_migrations_dir_validates(tmp_path, schemas_dir, schema_registry):
     payload = json.loads(result.stdout)
     _validator(schemas_dir, schema_registry).validate(payload)
     assert payload["status"] == "ok"
-    assert payload["hints"] == []
+    # Phase 05: empty migration directory triggers a quiet-success hint.
+    assert any("exists but contains no files" in h for h in payload["hints"])
 
 
 def test_idempotent_migrations_validates(tmp_path, schemas_dir, schema_registry):

--- a/tests/unit/json_schemas/test_validate_idempotent_schema.py
+++ b/tests/unit/json_schemas/test_validate_idempotent_schema.py
@@ -1,0 +1,131 @@
+"""Validate ``migrate validate --idempotent --format json`` output against its schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+SCHEMA_FILE = "migrate-validate-idempotent.schema.json"
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+def _validator(schemas_dir, registry) -> Draft202012Validator:
+    return Draft202012Validator(_load(schemas_dir, SCHEMA_FILE), registry=registry)
+
+
+def test_schema_is_valid_draft_2020_12(schemas_dir):
+    schema = _load(schemas_dir, SCHEMA_FILE)
+    Draft202012Validator.check_schema(schema)
+
+
+def test_empty_migrations_dir_validates(tmp_path, schemas_dir, schema_registry):
+    """No migration files in directory → minimal ok-envelope."""
+    (tmp_path / "db" / "migrations").mkdir(parents=True)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--idempotent",
+            "--migrations-dir",
+            str(tmp_path / "db" / "migrations"),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["status"] == "ok"
+    assert payload["hints"] == []
+
+
+def test_idempotent_migrations_validates(tmp_path, schemas_dir, schema_registry):
+    """All migrations are idempotent — status: ok, no violations."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260527000000_init.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS users (id INT PRIMARY KEY);\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--idempotent",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["status"] == "ok"
+    assert payload["violation_count"] == 0
+    assert payload["files_scanned"] == 1
+
+
+def test_non_idempotent_migration_validates(tmp_path, schemas_dir, schema_registry):
+    """A migration with non-idempotent SQL — status: issues_found, violations populated."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260527000001_bad.up.sql").write_text(
+        "CREATE TABLE users (id INT PRIMARY KEY);\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--idempotent",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    # Exit 1 because the migration is non-idempotent
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["status"] == "issues_found"
+    assert payload["violation_count"] >= 1
+    # Every violation conforms to the Violation sub-schema (covered by schema.validate).
+    assert all("pattern" in v for v in payload["violations"])
+    assert all("severity" in v for v in payload["violations"])
+
+
+def test_hints_field_is_required_and_array(tmp_path, schemas_dir, schema_registry):
+    """`hints` is pre-allocated per Phase 02 schema contract; always an array."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--idempotent",
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload["hints"], list)

--- a/tests/unit/linting/test_ownership_coverage_rule.py
+++ b/tests/unit/linting/test_ownership_coverage_rule.py
@@ -1,0 +1,296 @@
+"""Unit tests for the ownership coverage lint rule (issue #124).
+
+The rule walks a migrations directory and verifies that every
+``CREATE { TABLE | VIEW | MATERIALIZED VIEW | SEQUENCE }`` is paired with
+an ``ALTER … OWNER TO <expected_owner>`` later in the same file (or the
+file declares ``-- confiture:run-as <expected_owner>`` front-matter).
+
+AST-only: when pglast is not installed, the rule emits a skip notice and
+returns an empty violation list — see :mod:`tests.unit.linting.test_ownership_pglast_absent`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from confiture.config.environment import OwnershipApplyTo, OwnershipExpectation
+from confiture.core.linting.libraries.ownership import Own001OwnershipCoverage
+from confiture.core.linting.schema_linter import RuleSeverity
+
+# Mark the entire module as requiring pglast.  The skip-when-absent path
+# has its own dedicated test file.
+pglast = pytest.importorskip("pglast")
+
+
+def _make_expectation(owner: str = "migrator") -> OwnershipExpectation:
+    return OwnershipExpectation(
+        expected_owner=owner,
+        apply_to=[OwnershipApplyTo(schema="public", relkinds=["r", "S", "v", "m"])],
+    )
+
+
+def _write(tmp_path: Path, name: str, sql: str) -> Path:
+    p = tmp_path / name
+    p.write_text(sql)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_create_table_with_matching_alter_owner_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n"
+        "ALTER TABLE public.foo OWNER TO migrator;\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    assert rule.check(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Missing ALTER OWNER — flagged for every relkind in scope
+# ---------------------------------------------------------------------------
+
+
+def test_create_table_without_alter_owner_violates_own_001(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    violations = rule.check(tmp_path)
+    assert len(violations) == 1
+    assert violations[0].rule_id == "own_001"
+    assert violations[0].severity == RuleSeverity.ERROR
+    assert "public.foo" in violations[0].object_name
+    assert "migrator" in violations[0].message
+
+
+def test_create_view_requires_alter_owner(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_view.up.sql",
+        "CREATE TABLE public.t (id int);\n"
+        "ALTER TABLE public.t OWNER TO migrator;\n"
+        "CREATE VIEW public.v AS SELECT id FROM public.t;\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    violations = rule.check(tmp_path)
+    assert any("public.v" in v.object_name for v in violations)
+
+
+def test_create_materialized_view_requires_alter_owner(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_mv.up.sql",
+        "CREATE TABLE public.t (id int);\n"
+        "ALTER TABLE public.t OWNER TO migrator;\n"
+        "CREATE MATERIALIZED VIEW public.mv AS SELECT id FROM public.t;\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    violations = rule.check(tmp_path)
+    assert any("public.mv" in v.object_name for v in violations)
+
+
+def test_create_sequence_requires_alter_owner(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_seq.up.sql",
+        "CREATE SEQUENCE public.s;\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    violations = rule.check(tmp_path)
+    assert any("public.s" in v.object_name for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Cross-relkind matching: ALTER must apply to the same qualified name
+# ---------------------------------------------------------------------------
+
+
+def test_alter_owner_on_different_table_does_not_satisfy(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n"
+        "CREATE TABLE public.bar (id int);\n"
+        "ALTER TABLE public.bar OWNER TO migrator;\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    violations = rule.check(tmp_path)
+    assert len(violations) == 1
+    assert "public.foo" in violations[0].object_name
+
+
+# ---------------------------------------------------------------------------
+# Apply_to scope: relkinds outside the scope are not flagged
+# ---------------------------------------------------------------------------
+
+
+def test_table_outside_apply_to_relkinds_not_flagged(tmp_path: Path) -> None:
+    """When ``relkinds: [S]`` only, a missing ALTER OWNER on a table is ignored."""
+    _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    expectation = OwnershipExpectation(
+        expected_owner="migrator",
+        apply_to=[OwnershipApplyTo(schema="public", relkinds=["S"])],
+    )
+    rule = Own001OwnershipCoverage(expectation=expectation)
+    assert rule.check(tmp_path) == []
+
+
+def test_schema_outside_apply_to_not_flagged(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE other.foo (id int);\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    assert rule.check(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Ignore list
+# ---------------------------------------------------------------------------
+
+
+def test_ignore_list_suppresses_violation(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_legacy.up.sql",
+        "CREATE TABLE public.legacy (id int);\n",
+    )
+    expectation = OwnershipExpectation(
+        expected_owner="migrator",
+        apply_to=[OwnershipApplyTo(schema="public")],
+        ignore=["public.legacy"],
+    )
+    rule = Own001OwnershipCoverage(expectation=expectation)
+    assert rule.check(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Directives
+# ---------------------------------------------------------------------------
+
+
+def test_owner_skip_directive_suppresses_violation(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_ext.up.sql",
+        "-- confiture:owner-skip  (intentional: extension-owned)\n"
+        "CREATE TABLE public.ext_tab (id int);\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    assert rule.check(tmp_path) == []
+
+
+def test_run_as_directive_skips_whole_file_when_role_matches(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_run_as.up.sql",
+        "-- confiture:run-as migrator\n"
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    assert rule.check(tmp_path) == []
+
+
+def test_run_as_directive_with_wrong_role_does_not_skip(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_run_as.up.sql",
+        "-- confiture:run-as some_other_role\n"
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    violations = rule.check(tmp_path)
+    assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# AST-only behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_alter_owner_inside_do_block_does_not_count(tmp_path: Path) -> None:
+    """A top-level ALTER OWNER must satisfy the rule — one inside DO does not."""
+    _write(
+        tmp_path,
+        "20260527090000_do_block.up.sql",
+        "CREATE TABLE public.foo (id int);\n"
+        "DO $$ BEGIN EXECUTE 'ALTER TABLE public.foo OWNER TO migrator'; END $$;\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    violations = rule.check(tmp_path)
+    assert len(violations) == 1
+    assert "public.foo" in violations[0].object_name
+
+
+def test_create_in_string_literal_does_not_trigger(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_log.up.sql",
+        "CREATE TABLE public.log (entry text);\n"
+        "ALTER TABLE public.log OWNER TO migrator;\n"
+        "INSERT INTO public.log (entry) VALUES ('CREATE TABLE x (id int)');\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    assert rule.check(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Lint disabled
+# ---------------------------------------------------------------------------
+
+
+def test_lint_disabled_is_no_op(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    expectation = OwnershipExpectation(
+        expected_owner="migrator",
+        apply_to=[OwnershipApplyTo(schema="public")],
+        lint_enabled=False,
+    )
+    rule = Own001OwnershipCoverage(expectation=expectation)
+    assert rule.check(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Default-schema CREATE (no qualifier) — assumed to live in ``public``
+# ---------------------------------------------------------------------------
+
+
+def test_unqualified_create_treated_as_public(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_unq.up.sql",
+        "CREATE TABLE foo (id int);\nALTER TABLE foo OWNER TO migrator;\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    assert rule.check(tmp_path) == []
+
+
+def test_unqualified_create_without_alter_owner_is_flagged(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_unq.up.sql",
+        "CREATE TABLE foo (id int);\n",
+    )
+    rule = Own001OwnershipCoverage(expectation=_make_expectation())
+    violations = rule.check(tmp_path)
+    assert len(violations) == 1
+    assert "foo" in violations[0].object_name

--- a/tests/unit/linting/test_ownership_pglast_absent.py
+++ b/tests/unit/linting/test_ownership_pglast_absent.py
@@ -1,0 +1,100 @@
+"""Skip-when-pglast-absent path for ``own_001`` (issue #124).
+
+The lint rule is AST-only — when pglast is not importable, it emits a
+single skip notice to stderr and returns an empty violation list (true
+no-op, never false-negative).
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from confiture.config.environment import OwnershipApplyTo, OwnershipExpectation
+
+
+@pytest.fixture(autouse=True)
+def _reset_ast_required_state() -> Iterator[None]:
+    """Reset the module-level cache + warned flag around every test.
+
+    The skip notice and pglast-availability check are deliberately
+    process-level singletons, so tests must restore both sides of the
+    state to avoid leaking ``_force_unavailable=True`` or
+    ``_skip_warned=True`` into unrelated tests in the same process.
+    """
+    from confiture.core.linting import _ast_required
+
+    _ast_required.is_pglast_available.cache_clear()
+    _ast_required._skip_warned = False
+    yield
+    _ast_required.is_pglast_available.cache_clear()
+    _ast_required._skip_warned = False
+    # Also defensively reset the force-unavailable flag in case a test
+    # monkey-patch didn't undo it (monkeypatch normally does, but belt
+    # and braces given that we share the module globally).
+    _ast_required._force_unavailable = False
+
+
+def test_own_001_skips_when_pglast_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When pglast cannot be imported, the rule returns [] and logs once."""
+    # Migration that WOULD violate under AST mode (CREATE TABLE without ALTER OWNER).
+    (tmp_path / "20260527090000_no_owner.up.sql").write_text(
+        "CREATE TABLE public.foo (id int);\n"
+    )
+
+    from confiture.core.linting import _ast_required
+
+    monkeypatch.setattr(_ast_required, "_force_unavailable", True, raising=False)
+
+    # Drop pglast from the import cache so the rule's own importlib check fails.
+    monkeypatch.setitem(sys.modules, "pglast", None)
+
+    from confiture.core.linting.libraries.ownership import Own001OwnershipCoverage
+
+    expectation = OwnershipExpectation(
+        expected_owner="migrator",
+        apply_to=[OwnershipApplyTo(schema="public")],
+    )
+    rule = Own001OwnershipCoverage(expectation=expectation)
+    violations = rule.check(tmp_path)
+    assert violations == []
+
+    captured = capsys.readouterr()
+    assert "own_001" in captured.err
+    assert "[ast]" in captured.err
+
+
+def test_own_001_skip_notice_emitted_once_per_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "20260527090000_a.up.sql").write_text("CREATE TABLE public.a (id int);\n")
+    (tmp_path / "20260527090001_b.up.sql").write_text("CREATE TABLE public.b (id int);\n")
+
+    from confiture.core.linting import _ast_required
+
+    monkeypatch.setattr(_ast_required, "_force_unavailable", True, raising=False)
+    monkeypatch.setitem(sys.modules, "pglast", None)
+
+    from confiture.core.linting.libraries.ownership import Own001OwnershipCoverage
+
+    expectation = OwnershipExpectation(
+        expected_owner="migrator",
+        apply_to=[OwnershipApplyTo(schema="public")],
+    )
+    rule = Own001OwnershipCoverage(expectation=expectation)
+
+    rule.check(tmp_path)
+    rule.check(tmp_path)
+
+    captured = capsys.readouterr()
+    # Notice fires once across the whole process, not once per check().
+    assert captured.err.count("own_001 requires the [ast] extra") == 1

--- a/tests/unit/test_fk_extractor.py
+++ b/tests/unit/test_fk_extractor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from confiture.core.fk_extractor import (
     ForeignKeyInfo,
     extract_and_strip_fks,
@@ -709,6 +711,56 @@ CREATE TABLE orders (
 """
         stripped, fks = extract_and_strip_fks(sql)
         assert len(fks) == 0
+
+    def test_inline_comment_between_table_constraints_preserves_constraints(self):
+        """#128: a `--` comment between two table-level CONSTRAINTs must not
+        cause either constraint to be dropped, and must not corrupt the
+        emitted CREATE TABLE body."""
+        sql = """\
+CREATE TABLE foo.tb_thing (
+    id           UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    pk_thing     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    fk_parent    BIGINT NOT NULL,
+    fk_extension BIGINT,
+    fk_currency  BIGINT,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT tb_thing_fk_parent_fkey
+        FOREIGN KEY (fk_parent) REFERENCES other.tb_parent(pk_parent),
+    -- fk_extension → ext.tb_extension: deferred (ext schema loads after foo)
+    CONSTRAINT tb_thing_fk_currency_fkey
+        FOREIGN KEY (fk_currency) REFERENCES catalog.tb_currency(pk_currency)
+);
+"""
+        stripped, fks = extract_and_strip_fks(sql)
+
+        names = {fk.constraint_name for fk in fks}
+        assert names == {"tb_thing_fk_parent_fkey", "tb_thing_fk_currency_fkey"}
+
+        assert "-- fk_extension → ext.tb_extension: deferred" in stripped
+
+        assert re.search(r",\s*\)\s*;", stripped) is None
+
+        assert "now(),    --" not in stripped
+        assert "now(), --" not in stripped
+
+    def test_inline_comment_between_inline_references_preserves_constraints(self):
+        """#128 regression guard for the line-by-line inline-REFERENCES path
+        (Step 2 of `_extract_fks_from_body`). Expected to PASS against current
+        code — kept to pin the invariant in case Step 2 is ever rewritten to
+        operate on the body wholesale."""
+        sql = """\
+CREATE TABLE foo.tb_thing (
+    fk_a BIGINT REFERENCES other.tb_a(pk_a),
+    -- fk_b: deferred until ext schema loads
+    fk_b BIGINT REFERENCES ext.tb_b(pk_b),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+"""
+        stripped, fks = extract_and_strip_fks(sql)
+        target_tables = {fk.target_table for fk in fks}
+        assert "other.tb_a" in target_tables
+        assert "ext.tb_b" in target_tables
+        assert "-- fk_b: deferred" in stripped
 
 
 # ── generate_alter_statements ───────────────────────────────────────────

--- a/tests/unit/test_idempotency_captures.py
+++ b/tests/unit/test_idempotency_captures.py
@@ -1,0 +1,171 @@
+"""Tests for the ``Captures`` normalization layer (Phase 04, issue #123).
+
+The regex backend produces ``re.Match`` objects with numbered groups
+that vary by pattern; the AST backend produces typed pglast nodes.
+Templates can't accept either directly — they take a single normalized
+:class:`Captures` instance. This test module proves the two dispatchers
+produce equivalent captures for equivalent SQL.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from confiture.core.idempotency._captures import (
+    Captures,
+    captures_from_ast,
+    captures_from_regex,
+)
+from confiture.core.idempotency.models import IdempotencyPattern
+from confiture.core.idempotency.patterns import PATTERNS
+
+pglast = pytest.importorskip("pglast")
+
+
+def _regex_match(pattern: IdempotencyPattern, sql: str) -> re.Match[str]:
+    for pdef in PATTERNS:
+        if pdef.pattern is pattern:
+            m = pdef.regex.search(sql)
+            assert m is not None, f"regex for {pattern.name} did not match {sql!r}"
+            return m
+    raise AssertionError(f"no PATTERN entry for {pattern.name}")
+
+
+def _first_ast_stmt(sql: str):
+    tree = pglast.parse_sql(sql)
+    return tree[0].stmt
+
+
+class TestCapturesEquivalence:
+    """For each fillable pattern, regex and AST yield equal Captures."""
+
+    def test_create_table(self) -> None:
+        sql = "CREATE TABLE tenant.orders (id INT);"
+        r_cap = captures_from_regex(
+            IdempotencyPattern.CREATE_TABLE, _regex_match(IdempotencyPattern.CREATE_TABLE, sql)
+        )
+        a_cap = captures_from_ast(IdempotencyPattern.CREATE_TABLE, _first_ast_stmt(sql))
+        assert r_cap == a_cap
+        assert r_cap.schema == "tenant"
+        assert r_cap.table == "orders"
+
+    def test_create_table_unqualified(self) -> None:
+        sql = "CREATE TABLE orders (id INT);"
+        r_cap = captures_from_regex(
+            IdempotencyPattern.CREATE_TABLE, _regex_match(IdempotencyPattern.CREATE_TABLE, sql)
+        )
+        a_cap = captures_from_ast(IdempotencyPattern.CREATE_TABLE, _first_ast_stmt(sql))
+        assert r_cap == a_cap
+        assert r_cap.schema is None
+        assert r_cap.table == "orders"
+
+    def test_create_index(self) -> None:
+        sql = "CREATE INDEX idx_orders_user_id ON tenant.orders (user_id);"
+        r_cap = captures_from_regex(
+            IdempotencyPattern.CREATE_INDEX, _regex_match(IdempotencyPattern.CREATE_INDEX, sql)
+        )
+        a_cap = captures_from_ast(IdempotencyPattern.CREATE_INDEX, _first_ast_stmt(sql))
+        assert r_cap.index_name == "idx_orders_user_id"
+        assert a_cap.index_name == "idx_orders_user_id"
+        # Both backends agree on index name and table (AST gives table, regex may not).
+        # Equality only on identifiers we promise both backends can extract.
+        assert r_cap.index_name == a_cap.index_name
+
+    def test_alter_table_add_column(self) -> None:
+        sql = "ALTER TABLE tenant.orders ADD COLUMN amount NUMERIC;"
+        r_cap = captures_from_regex(
+            IdempotencyPattern.ALTER_TABLE_ADD_COLUMN,
+            _regex_match(IdempotencyPattern.ALTER_TABLE_ADD_COLUMN, sql),
+        )
+        a_cap = captures_from_ast(
+            IdempotencyPattern.ALTER_TABLE_ADD_COLUMN, _first_ast_stmt(sql)
+        )
+        assert r_cap.schema == "tenant"
+        assert r_cap.table == "orders"
+        assert r_cap.column == "amount"
+        assert a_cap.schema == "tenant"
+        assert a_cap.table == "orders"
+        assert a_cap.column == "amount"
+
+    def test_alter_table_add_constraint_check(self) -> None:
+        sql = (
+            "ALTER TABLE tenant.orders "
+            "ADD CONSTRAINT chk_orders_amount_positive CHECK (amount > 0);"
+        )
+        r_cap = captures_from_regex(
+            IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK,
+            _regex_match(IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK, sql),
+        )
+        a_cap = captures_from_ast(
+            IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK, _first_ast_stmt(sql)
+        )
+        assert r_cap.schema == "tenant"
+        assert r_cap.table == "orders"
+        assert r_cap.constraint == "chk_orders_amount_positive"
+        assert a_cap.schema == "tenant"
+        assert a_cap.table == "orders"
+        assert a_cap.constraint == "chk_orders_amount_positive"
+
+    def test_alter_table_rename_column(self) -> None:
+        sql = "ALTER TABLE tenant.orders RENAME COLUMN amt TO amount;"
+        r_cap = captures_from_regex(
+            IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN,
+            _regex_match(IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN, sql),
+        )
+        a_cap = captures_from_ast(
+            IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN, _first_ast_stmt(sql)
+        )
+        assert r_cap.schema == "tenant"
+        assert r_cap.table == "orders"
+        assert r_cap.column == "amt"
+        assert r_cap.new_column == "amount"
+        assert a_cap.schema == "tenant"
+        assert a_cap.table == "orders"
+        assert a_cap.column == "amt"
+        assert a_cap.new_column == "amount"
+
+    def test_create_type_as_enum(self) -> None:
+        sql = "CREATE TYPE tenant.order_status AS ENUM ('open', 'closed');"
+        r_cap = captures_from_regex(
+            IdempotencyPattern.CREATE_TYPE, _regex_match(IdempotencyPattern.CREATE_TYPE, sql)
+        )
+        a_cap = captures_from_ast(IdempotencyPattern.CREATE_TYPE, _first_ast_stmt(sql))
+        assert r_cap.type_name == "order_status"
+        assert a_cap.type_name == "order_status"
+        # AST exposes the schema; regex pattern only captures the bare type name.
+        assert a_cap.schema == "tenant"
+
+    def test_drop_table(self) -> None:
+        sql = "DROP TABLE tenant.orders;"
+        r_cap = captures_from_regex(
+            IdempotencyPattern.DROP_TABLE, _regex_match(IdempotencyPattern.DROP_TABLE, sql)
+        )
+        a_cap = captures_from_ast(IdempotencyPattern.DROP_TABLE, _first_ast_stmt(sql))
+        assert r_cap.schema == "tenant"
+        assert r_cap.table == "orders"
+        assert a_cap.schema == "tenant"
+        assert a_cap.table == "orders"
+
+
+class TestCapturesDataclass:
+    """Captures defaults to all-None and is hashable/frozen."""
+
+    def test_default_all_none(self) -> None:
+        cap = Captures()
+        assert cap.schema is None
+        assert cap.table is None
+        assert cap.column is None
+        assert cap.new_column is None
+        assert cap.constraint is None
+        assert cap.type_name is None
+        assert cap.index_name is None
+        assert cap.view is None
+        assert cap.sequence is None
+        assert cap.extension is None
+
+    def test_frozen(self) -> None:
+        cap = Captures(table="orders")
+        with pytest.raises((AttributeError, TypeError)):
+            cap.table = "users"  # type: ignore[misc]

--- a/tests/unit/test_idempotency_suggestion_filling.py
+++ b/tests/unit/test_idempotency_suggestion_filling.py
@@ -1,0 +1,203 @@
+"""Tests for template-filled idempotency suggestions (Phase 04 Cycle 3).
+
+For each :data:`TEMPLATE_FILLABLE` pattern, the suggestion machinery
+takes a :class:`Captures` instance and produces a copy-pasteable SQL
+template with the captured identifiers inlined.
+
+Patterns in :data:`TEMPLATE_NOT_AVAILABLE` keep the generic suggestion
+and explicitly say "no auto-template available — manual fix required".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.idempotency._captures import Captures
+from confiture.core.idempotency.models import IdempotencyPattern
+from confiture.core.idempotency.suggestion_templates import (
+    NO_TEMPLATE_AVAILABLE_MARKER,
+    suggestion_for,
+)
+
+
+class TestTemplateFillableHappyPath:
+    """Filled templates contain the captured identifiers verbatim."""
+
+    def test_create_table_qualified(self) -> None:
+        cap = Captures(schema="tenant", table="orders")
+        sug = suggestion_for(IdempotencyPattern.CREATE_TABLE, cap)
+        assert "tenant.orders" in sug
+        assert "IF NOT EXISTS" in sug
+
+    def test_create_table_unqualified(self) -> None:
+        cap = Captures(table="orders")
+        sug = suggestion_for(IdempotencyPattern.CREATE_TABLE, cap)
+        assert "orders" in sug
+        assert "IF NOT EXISTS" in sug
+        assert "tenant" not in sug
+
+    def test_create_index(self) -> None:
+        cap = Captures(index_name="idx_orders_user_id", schema="tenant", table="orders")
+        sug = suggestion_for(IdempotencyPattern.CREATE_INDEX, cap)
+        assert "idx_orders_user_id" in sug
+        assert "tenant.orders" in sug
+        assert "IF NOT EXISTS" in sug
+
+    def test_create_unique_index(self) -> None:
+        cap = Captures(index_name="uq_orders_email", schema="tenant", table="orders")
+        sug = suggestion_for(IdempotencyPattern.CREATE_UNIQUE_INDEX, cap)
+        assert "uq_orders_email" in sug
+        assert "tenant.orders" in sug
+        assert "UNIQUE" in sug
+
+    def test_alter_table_add_column(self) -> None:
+        cap = Captures(schema="tenant", table="orders", column="amount")
+        sug = suggestion_for(IdempotencyPattern.ALTER_TABLE_ADD_COLUMN, cap)
+        assert "tenant.orders" in sug
+        assert "amount" in sug
+        assert "IF NOT EXISTS" in sug
+
+    def test_alter_table_add_constraint_check(self) -> None:
+        cap = Captures(
+            schema="tenant", table="orders", constraint="chk_orders_amount_positive"
+        )
+        sug = suggestion_for(IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK, cap)
+        assert "tenant.orders" in sug
+        assert "chk_orders_amount_positive" in sug
+        assert "DROP CONSTRAINT IF EXISTS" in sug
+
+    def test_alter_table_add_constraint_primary_key(self) -> None:
+        cap = Captures(schema="tenant", table="orders", constraint="pk_orders")
+        sug = suggestion_for(
+            IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_PRIMARY_KEY, cap
+        )
+        assert "tenant.orders" in sug
+        assert "pk_orders" in sug
+        assert "DROP CONSTRAINT IF EXISTS" in sug
+
+    def test_alter_table_add_constraint_unique(self) -> None:
+        cap = Captures(schema="tenant", table="orders", constraint="uq_orders_email")
+        sug = suggestion_for(IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_UNIQUE, cap)
+        assert "tenant.orders" in sug
+        assert "uq_orders_email" in sug
+        assert "DROP CONSTRAINT IF EXISTS" in sug
+
+    def test_alter_table_rename_column(self) -> None:
+        cap = Captures(schema="tenant", table="orders", column="amt", new_column="amount")
+        sug = suggestion_for(IdempotencyPattern.ALTER_TABLE_RENAME_COLUMN, cap)
+        assert "tenant.orders" in sug
+        assert "amt" in sug
+        assert "amount" in sug
+        assert "information_schema" in sug
+
+    def test_create_type_enum(self) -> None:
+        cap = Captures(schema="tenant", type_name="order_status")
+        sug = suggestion_for(IdempotencyPattern.CREATE_TYPE, cap)
+        assert "tenant.order_status" in sug
+        assert "pg_type" in sug
+
+    def test_create_schema(self) -> None:
+        cap = Captures(schema="tenant")
+        sug = suggestion_for(IdempotencyPattern.CREATE_SCHEMA, cap)
+        assert "tenant" in sug
+        assert "IF NOT EXISTS" in sug
+
+    def test_create_sequence(self) -> None:
+        cap = Captures(schema="tenant", sequence="orders_seq")
+        sug = suggestion_for(IdempotencyPattern.CREATE_SEQUENCE, cap)
+        assert "tenant.orders_seq" in sug
+        assert "IF NOT EXISTS" in sug
+
+    def test_create_extension(self) -> None:
+        cap = Captures(extension="pgcrypto")
+        sug = suggestion_for(IdempotencyPattern.CREATE_EXTENSION, cap)
+        assert "pgcrypto" in sug
+        assert "IF NOT EXISTS" in sug
+
+    def test_create_view(self) -> None:
+        cap = Captures(schema="tenant", view="v_orders_summary")
+        sug = suggestion_for(IdempotencyPattern.CREATE_VIEW, cap)
+        assert "tenant.v_orders_summary" in sug
+        assert "DROP VIEW IF EXISTS" in sug
+
+    def test_create_or_replace_view_shape_risk(self) -> None:
+        cap = Captures(schema="tenant", view="v_orders_summary")
+        sug = suggestion_for(IdempotencyPattern.CREATE_OR_REPLACE_VIEW_SHAPE_RISK, cap)
+        assert "tenant.v_orders_summary" in sug
+        assert "DROP VIEW IF EXISTS" in sug
+
+    def test_alter_table_owner(self) -> None:
+        cap = Captures(schema="tenant", table="orders")
+        sug = suggestion_for(IdempotencyPattern.ALTER_TABLE_OWNER, cap)
+        assert "tenant.orders" in sug
+        assert "pg_class" in sug
+
+    def test_alter_view_owner(self) -> None:
+        cap = Captures(schema="tenant", view="v_orders")
+        sug = suggestion_for(IdempotencyPattern.ALTER_VIEW_OWNER, cap)
+        assert "tenant.v_orders" in sug
+        assert "pg_class" in sug
+
+    def test_alter_matview_owner(self) -> None:
+        cap = Captures(schema="tenant", view="mv_orders")
+        sug = suggestion_for(IdempotencyPattern.ALTER_MATVIEW_OWNER, cap)
+        assert "tenant.mv_orders" in sug
+        assert "pg_matviews" in sug
+
+    @pytest.mark.parametrize(
+        ("pattern", "captures_kwargs"),
+        [
+            (IdempotencyPattern.DROP_TABLE, {"schema": "tenant", "table": "orders"}),
+            (IdempotencyPattern.DROP_INDEX, {"schema": "tenant", "table": "idx_orders"}),
+            (IdempotencyPattern.DROP_VIEW, {"schema": "tenant", "table": "v_orders"}),
+            (IdempotencyPattern.DROP_TYPE, {"schema": "tenant", "table": "order_status"}),
+            (IdempotencyPattern.DROP_SCHEMA, {"table": "tenant"}),
+            (IdempotencyPattern.DROP_SEQUENCE, {"schema": "tenant", "table": "orders_seq"}),
+        ],
+    )
+    def test_drop_with_if_exists(
+        self, pattern: IdempotencyPattern, captures_kwargs: dict[str, str]
+    ) -> None:
+        cap = Captures(**captures_kwargs)
+        sug = suggestion_for(pattern, cap)
+        assert "IF EXISTS" in sug
+        name_token = captures_kwargs.get("table")
+        assert name_token is not None
+        assert name_token in sug
+
+
+class TestTemplateFillableFallback:
+    """When required captures are missing, the template falls back gracefully."""
+
+    def test_create_table_missing_name_falls_back(self) -> None:
+        cap = Captures()  # no table name
+        sug = suggestion_for(IdempotencyPattern.CREATE_TABLE, cap)
+        # Falls back to the generic IdempotencyPattern.suggestion text.
+        assert "IF NOT EXISTS" in sug
+        # No bare placeholder tokens left behind.
+        assert "<table>" not in sug
+
+    def test_alter_add_constraint_missing_constraint_falls_back(self) -> None:
+        cap = Captures(schema="tenant", table="orders")  # no constraint name
+        sug = suggestion_for(IdempotencyPattern.ALTER_TABLE_ADD_CONSTRAINT_CHECK, cap)
+        # Falls back to the generic suggestion (still mentions the strategy).
+        assert "DROP CONSTRAINT" in sug
+
+
+class TestTemplateNotAvailable:
+    """``TEMPLATE_NOT_AVAILABLE`` patterns emit the explicit marker."""
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            IdempotencyPattern.CREATE_FUNCTION,
+            IdempotencyPattern.CREATE_PROCEDURE,
+            IdempotencyPattern.DROP_FUNCTION,
+            IdempotencyPattern.CREATE_OR_REPLACE_FUNCTION_SHAPE_RISK,
+            IdempotencyPattern.CREATE_OR_REPLACE_PROCEDURE_SHAPE_RISK,
+        ],
+    )
+    def test_emits_no_template_marker(self, pattern: IdempotencyPattern) -> None:
+        cap = Captures()
+        sug = suggestion_for(pattern, cap)
+        assert NO_TEMPLATE_AVAILABLE_MARKER in sug

--- a/tests/unit/test_idempotency_suggestion_wiring.py
+++ b/tests/unit/test_idempotency_suggestion_wiring.py
@@ -1,0 +1,156 @@
+"""Tests proving both detection paths emit the same filled suggestion.
+
+The regex and AST backends should produce identical filled suggestions
+for equivalent SQL (parametrized over the backend via
+``CONFITURE_IDEMPOTENCY_FORCE_REGEX``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.idempotency.models import IdempotencyPattern
+from confiture.core.idempotency.validator import IdempotencyValidator
+
+
+@pytest.fixture
+def force_regex_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", "1")
+
+
+@pytest.fixture
+def force_ast_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", raising=False)
+
+
+def _validate(sql: str) -> str:
+    """Return the first violation's suggestion, or fail loudly."""
+    report = IdempotencyValidator().validate_sql(sql)
+    assert report.violations, f"expected a violation for {sql!r}"
+    return report.violations[0].suggestion
+
+
+class TestBothBackendsEmitFilledSuggestion:
+    @pytest.mark.parametrize("backend", ["regex", "ast"])
+    def test_create_table_qualified(
+        self,
+        backend: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if backend == "regex":
+            monkeypatch.setenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", "1")
+        else:
+            monkeypatch.delenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", raising=False)
+        sug = _validate("CREATE TABLE tenant.orders (id INT);")
+        assert "tenant.orders" in sug
+        assert "IF NOT EXISTS" in sug
+
+    @pytest.mark.parametrize("backend", ["regex", "ast"])
+    def test_create_index(
+        self,
+        backend: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if backend == "regex":
+            monkeypatch.setenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", "1")
+        else:
+            monkeypatch.delenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", raising=False)
+        sug = _validate(
+            "CREATE INDEX idx_orders_user_id ON tenant.orders (user_id);"
+        )
+        assert "idx_orders_user_id" in sug
+        assert "IF NOT EXISTS" in sug
+
+    @pytest.mark.parametrize("backend", ["regex", "ast"])
+    def test_alter_table_add_constraint_check(
+        self,
+        backend: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if backend == "regex":
+            monkeypatch.setenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", "1")
+        else:
+            monkeypatch.delenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", raising=False)
+        sug = _validate(
+            "ALTER TABLE tenant.orders "
+            "ADD CONSTRAINT chk_orders_amount_positive CHECK (amount > 0);"
+        )
+        assert "tenant.orders" in sug
+        assert "chk_orders_amount_positive" in sug
+        assert "DROP CONSTRAINT IF EXISTS" in sug
+
+    @pytest.mark.parametrize("backend", ["regex", "ast"])
+    def test_alter_table_add_column(
+        self,
+        backend: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if backend == "regex":
+            monkeypatch.setenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", "1")
+        else:
+            monkeypatch.delenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", raising=False)
+        sug = _validate(
+            "ALTER TABLE tenant.orders ADD COLUMN amount NUMERIC;"
+        )
+        assert "tenant.orders" in sug
+        assert "amount" in sug
+        assert "IF NOT EXISTS" in sug
+
+    @pytest.mark.parametrize("backend", ["regex", "ast"])
+    def test_alter_rename_column(
+        self,
+        backend: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if backend == "regex":
+            monkeypatch.setenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", "1")
+        else:
+            monkeypatch.delenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", raising=False)
+        sug = _validate(
+            "ALTER TABLE tenant.orders RENAME COLUMN amt TO amount;"
+        )
+        assert "tenant.orders" in sug
+        assert "amt" in sug
+        assert "amount" in sug
+        assert "information_schema" in sug
+
+    @pytest.mark.parametrize("backend", ["regex", "ast"])
+    def test_create_type_enum(
+        self,
+        backend: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if backend == "regex":
+            monkeypatch.setenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", "1")
+        else:
+            monkeypatch.delenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", raising=False)
+        sug = _validate(
+            "CREATE TYPE tenant.order_status AS ENUM ('open', 'closed');"
+        )
+        # Regex regex pattern doesn't catch ``schema.type``; AST does.
+        # Both should at least mention the type name.
+        assert "order_status" in sug
+        assert "pg_type" in sug
+
+
+class TestFunctionPatternUsesTemplateNotAvailableMarker:
+    """``CREATE FUNCTION`` without ``OR REPLACE`` has no template — marker present."""
+
+    @pytest.mark.parametrize("backend", ["regex", "ast"])
+    def test_create_function_marker(
+        self,
+        backend: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if backend == "regex":
+            monkeypatch.setenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", "1")
+        else:
+            monkeypatch.delenv("CONFITURE_IDEMPOTENCY_FORCE_REGEX", raising=False)
+        sql = "CREATE FUNCTION tenant.f() RETURNS void LANGUAGE sql AS 'SELECT 1';"
+        report = IdempotencyValidator().validate_sql(sql)
+        # CREATE_FUNCTION should be one of the matches.
+        function_violations = [
+            v for v in report.violations if v.pattern is IdempotencyPattern.CREATE_FUNCTION
+        ]
+        assert function_violations, "expected a CREATE_FUNCTION violation"
+        assert "no auto-template available" in function_violations[0].suggestion

--- a/tests/unit/test_idempotent_banner.py
+++ b/tests/unit/test_idempotent_banner.py
@@ -1,0 +1,144 @@
+"""Phase 03 C2: pre-scan banner stating the active idempotency backend.
+
+Text mode prints a one-line status banner. JSON mode reports the
+backend via ``payload["meta"]["backend"]`` so pipe-able output stays
+clean.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _migrations_dir(tmp_path):
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260527000000_init.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS t (id INT);\n"
+    )
+    return migs
+
+
+class TestBannerInTextMode:
+    """Text mode prints a backend banner to stdout."""
+
+    def test_ast_banner_when_pglast_available(self, tmp_path):
+        migs = _migrations_dir(tmp_path)
+        runner = CliRunner()
+        with patch(
+            "confiture.core.idempotency.patterns.is_pglast_available",
+            return_value=True,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "validate",
+                    "--idempotent",
+                    "--migrations-dir",
+                    str(migs),
+                ],
+            )
+        out = _strip_ansi(result.output)
+        assert "AST backend" in out
+        assert "pglast" in out
+
+    def test_regex_banner_when_pglast_missing(self, tmp_path):
+        migs = _migrations_dir(tmp_path)
+        runner = CliRunner()
+        with patch(
+            "confiture.core.idempotency.patterns.is_pglast_available",
+            return_value=False,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "validate",
+                    "--idempotent",
+                    "--migrations-dir",
+                    str(migs),
+                ],
+            )
+        out = _strip_ansi(result.output)
+        assert "Regex fallback" in out
+        # The install hint must appear so the user knows what to do.
+        assert "fraiseql-confiture[ast]" in out
+
+
+class TestBannerInJsonMode:
+    """JSON mode pushes the backend into payload["meta"]["backend"], NEVER to stdout."""
+
+    def test_json_mode_no_banner_in_stdout(self, tmp_path):
+        migs = _migrations_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--migrations-dir",
+                str(migs),
+                "--format",
+                "json",
+            ],
+        )
+        # Stdout must be parseable JSON — any banner text would break this.
+        payload = json.loads(result.stdout)
+        assert "meta" in payload
+        assert payload["meta"]["backend"] in {"ast", "regex"}
+
+    def test_json_mode_reports_ast_when_available(self, tmp_path):
+        migs = _migrations_dir(tmp_path)
+        runner = CliRunner()
+        with patch(
+            "confiture.core.idempotency.patterns.is_pglast_available",
+            return_value=True,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "validate",
+                    "--idempotent",
+                    "--migrations-dir",
+                    str(migs),
+                    "--format",
+                    "json",
+                ],
+            )
+        payload = json.loads(result.stdout)
+        assert payload["meta"]["backend"] == "ast"
+
+    def test_json_mode_reports_regex_when_unavailable(self, tmp_path):
+        migs = _migrations_dir(tmp_path)
+        runner = CliRunner()
+        with patch(
+            "confiture.core.idempotency.patterns.is_pglast_available",
+            return_value=False,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "validate",
+                    "--idempotent",
+                    "--migrations-dir",
+                    str(migs),
+                    "--format",
+                    "json",
+                ],
+            )
+        payload = json.loads(result.stdout)
+        assert payload["meta"]["backend"] == "regex"

--- a/tests/unit/test_migrate_validate_list_patterns_cli.py
+++ b/tests/unit/test_migrate_validate_list_patterns_cli.py
@@ -89,6 +89,7 @@ class TestListPatternsJsonOutput:
                 "has_skip_regex",
                 "skip_hint",
                 "has_auto_fix",
+                "template_fillable",
             }
 
 

--- a/tests/unit/test_migrate_validate_list_patterns_cli.py
+++ b/tests/unit/test_migrate_validate_list_patterns_cli.py
@@ -1,0 +1,116 @@
+"""CLI tests for ``confiture migrate validate --list-patterns``.
+
+Read-only catalog flag: no DB connection, no config file, no migrations
+directory. Mutually exclusive with check-mode flags (``--idempotent``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+
+def _strip_ansi(text: str) -> str:
+    """Strip ANSI escape codes (Rich forces them under GITHUB_ACTIONS)."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+class TestListPatternsExitCode:
+    """Read-only query: always exits 0."""
+
+    def test_exits_zero_with_no_other_flags(self):
+        runner = CliRunner()
+        result = runner.invoke(app, ["migrate", "validate", "--list-patterns"])
+        assert result.exit_code == 0, _strip_ansi(result.output)
+
+    def test_exits_zero_with_format_json(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["migrate", "validate", "--list-patterns", "--format", "json"]
+        )
+        assert result.exit_code == 0, _strip_ansi(result.output)
+
+
+class TestListPatternsTextOutput:
+    """Text format: pattern IDs land in stdout."""
+
+    def test_lists_create_table_id(self):
+        runner = CliRunner()
+        result = runner.invoke(app, ["migrate", "validate", "--list-patterns"])
+        out = _strip_ansi(result.output)
+        assert "CREATE_TABLE" in out
+
+    def test_lists_drop_sequence_id(self):
+        """DROP_SEQUENCE — one of the formerly under-dispatched patterns."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["migrate", "validate", "--list-patterns"])
+        out = _strip_ansi(result.output)
+        assert "DROP_SEQUENCE" in out
+
+
+class TestListPatternsJsonOutput:
+    """JSON format: valid, machine-readable shape."""
+
+    def test_emits_valid_json(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["migrate", "validate", "--list-patterns", "--format", "json"]
+        )
+        # Parse — must not raise.
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, dict)
+
+    def test_emits_versioned_envelope(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["migrate", "validate", "--list-patterns", "--format", "json"]
+        )
+        payload = json.loads(result.stdout)
+        assert payload["version"] == "1"
+        assert "patterns" in payload
+        assert isinstance(payload["patterns"], list)
+        assert len(payload["patterns"]) > 0
+
+    def test_entries_carry_required_fields(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["migrate", "validate", "--list-patterns", "--format", "json"]
+        )
+        payload = json.loads(result.stdout)
+        for entry in payload["patterns"]:
+            assert set(entry.keys()) == {
+                "id",
+                "description",
+                "severity",
+                "has_skip_regex",
+                "skip_hint",
+                "has_auto_fix",
+            }
+
+
+class TestListPatternsMutualExclusion:
+    """``--list-patterns`` is a query, not a check — collides with check flags."""
+
+    def test_rejects_combination_with_idempotent(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["migrate", "validate", "--list-patterns", "--idempotent"]
+        )
+        assert result.exit_code == 2, _strip_ansi(result.output)
+
+
+class TestListPatternsIsReadOnly:
+    """No DB / config / migrations directory required."""
+
+    def test_runs_outside_a_project_directory(self, tmp_path, monkeypatch):
+        """Run with cwd that has no confiture.yaml and no db/migrations."""
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(app, ["migrate", "validate", "--list-patterns"])
+        assert result.exit_code == 0, _strip_ansi(result.output)
+        # The catalog should still render.
+        assert "CREATE_TABLE" in _strip_ansi(result.output)

--- a/tests/unit/test_ownership_fix.py
+++ b/tests/unit/test_ownership_fix.py
@@ -1,0 +1,214 @@
+"""Unit tests for the ownership auto-fixer (issue #124, Phase 04).
+
+Mirrors :mod:`confiture.core.idempotency.fixer` on the ownership axis.
+The fixer reuses :class:`Own001OwnershipCoverage` to find violations,
+then emits ``ALTER … OWNER TO`` immediately after each offending CREATE.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from confiture.config.environment import OwnershipApplyTo, OwnershipExpectation
+
+pytest.importorskip("pglast")
+
+from confiture.core.ownership_fixer import OwnershipFixer  # noqa: E402
+
+
+def _make_expectation(owner: str = "migrator") -> OwnershipExpectation:
+    return OwnershipExpectation(
+        expected_owner=owner,
+        apply_to=[OwnershipApplyTo(schema="public", relkinds=["r", "S", "v", "m"])],
+    )
+
+
+def _write(tmp_path: Path, name: str, sql: str) -> Path:
+    p = tmp_path / name
+    p.write_text(sql)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Detection (delegates to Own001OwnershipCoverage)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_missing_alter_owner(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    candidates = list(fixer.iter_candidates(tmp_path))
+    assert len(candidates) == 1
+    assert candidates[0].qualified_name == "public.foo"
+    assert candidates[0].kind == "TABLE"
+
+
+def test_detect_skips_already_fixed_relations(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n"
+        "ALTER TABLE public.foo OWNER TO migrator;\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    assert list(fixer.iter_candidates(tmp_path)) == []
+
+
+# ---------------------------------------------------------------------------
+# Fix emission
+# ---------------------------------------------------------------------------
+
+
+def test_emit_alter_owner_after_create(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int primary key);\n"
+        "INSERT INTO public.seed VALUES (1);\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    fixed = fixer.fix_text(path.read_text())
+    expected = (
+        "CREATE TABLE public.foo (id int primary key);\n"
+        "ALTER TABLE public.foo OWNER TO migrator;\n"
+        "INSERT INTO public.seed VALUES (1);\n"
+    )
+    assert fixed == expected
+
+
+def test_emit_alter_owner_for_sequence(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "20260527090000_seq.up.sql",
+        "CREATE SEQUENCE public.s;\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    fixed = fixer.fix_text(path.read_text())
+    assert "ALTER SEQUENCE public.s OWNER TO migrator;" in fixed
+
+
+def test_emit_alter_owner_for_view(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "20260527090000_view.up.sql",
+        "CREATE TABLE public.t (id int);\n"
+        "ALTER TABLE public.t OWNER TO migrator;\n"
+        "CREATE VIEW public.v AS SELECT id FROM public.t;\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    fixed = fixer.fix_text(path.read_text())
+    assert "ALTER VIEW public.v OWNER TO migrator;" in fixed
+
+
+def test_emit_alter_owner_for_materialized_view(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "20260527090000_mv.up.sql",
+        "CREATE TABLE public.t (id int);\n"
+        "ALTER TABLE public.t OWNER TO migrator;\n"
+        "CREATE MATERIALIZED VIEW public.mv AS SELECT id FROM public.t;\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    fixed = fixer.fix_text(path.read_text())
+    assert "ALTER MATERIALIZED VIEW public.mv OWNER TO migrator;" in fixed
+
+
+# ---------------------------------------------------------------------------
+# Idempotence guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_fix_is_idempotent(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+
+    once = fixer.fix_text(path.read_text())
+    twice = fixer.fix_text(once)
+    assert once == twice
+
+
+def test_fix_text_returns_input_when_already_covered(tmp_path: Path) -> None:
+    sql = (
+        "CREATE TABLE public.foo (id int);\n"
+        "ALTER TABLE public.foo OWNER TO migrator;\n"
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    assert fixer.fix_text(sql) == sql
+
+
+# ---------------------------------------------------------------------------
+# Scope respected
+# ---------------------------------------------------------------------------
+
+
+def test_fix_skips_relations_outside_apply_to(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "20260527090000_other.up.sql",
+        "CREATE TABLE other.foo (id int);\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    assert fixer.fix_text(path.read_text()) == path.read_text()
+
+
+def test_fix_respects_ignore_list(tmp_path: Path) -> None:
+    sql = "CREATE TABLE public.legacy (id int);\n"
+    fixer = OwnershipFixer(
+        expectation=OwnershipExpectation(
+            expected_owner="migrator",
+            apply_to=[OwnershipApplyTo(schema="public", relkinds=["r"])],
+            ignore=["public.legacy"],
+        ),
+    )
+    assert fixer.fix_text(sql) == sql
+
+
+def test_fix_respects_owner_skip_directive(tmp_path: Path) -> None:
+    sql = (
+        "-- confiture:owner-skip\n"
+        "CREATE TABLE public.ext (id int);\n"
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    assert fixer.fix_text(sql) == sql
+
+
+# ---------------------------------------------------------------------------
+# Apply to files
+# ---------------------------------------------------------------------------
+
+
+def test_apply_writes_files_in_place(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    changed = fixer.apply(tmp_path)
+    assert path in changed
+    assert "ALTER TABLE public.foo OWNER TO migrator;" in path.read_text()
+
+
+def test_dry_run_reports_changes_without_writing(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "20260527090000_add_foo.up.sql",
+        "CREATE TABLE public.foo (id int);\n",
+    )
+    original = path.read_text()
+    fixer = OwnershipFixer(expectation=_make_expectation())
+    changes = fixer.preview(tmp_path)
+    assert len(changes) == 1
+    assert changes[0].file == path
+    assert "ALTER TABLE public.foo OWNER TO migrator" in changes[0].after
+    assert path.read_text() == original  # unchanged on disk

--- a/tests/unit/test_phase03_help_enrichment.py
+++ b/tests/unit/test_phase03_help_enrichment.py
@@ -1,0 +1,58 @@
+"""Phase 03 help-text enrichment — pin the new help-text content.
+
+These tests are intentionally narrow: they assert the strings users
+will see in --help, not implementation details.
+"""
+
+from __future__ import annotations
+
+import re
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _help(*args: str) -> str:
+    runner = CliRunner()
+    result = runner.invoke(app, [*args, "--help"])
+    return _strip_ansi(result.output)
+
+
+class TestPreflightModesDistinguished:
+    """`migrate preflight --help` calls out default vs --against modes."""
+
+    def test_default_mode_described(self):
+        out = _help("migrate", "preflight")
+        # The default-mode block lives in the function docstring (typer
+        # surfaces it under "DEFAULT MODE" or similar heading).
+        assert "Default mode" in out or "DEFAULT MODE" in out
+
+    def test_against_mode_described(self):
+        out = _help("migrate", "preflight")
+        assert "Explicit source mode" in out or "EXPLICIT SOURCE" in out
+
+
+class TestCheckSignaturesSchemaDistinction:
+    """`--check-signatures` help calls out --schemas vs --schema."""
+
+    def test_schemas_plural_description_mentions_schema_singular(self):
+        out = _help("migrate", "validate")
+        # The plural flag explicitly references the singular one (and
+        # vice-versa) so users can tell them apart.
+        assert "--schemas" in out
+        assert "--schema" in out
+
+
+class TestIdempotentMentionsAstExtra:
+    """`--idempotent` help mentions the [ast] extra prominently."""
+
+    def test_idempotent_flag_description_or_epilog_mentions_ast(self):
+        out = _help("migrate", "validate")
+        # The phrase "[ast] extra" or "pglast" must appear near the
+        # --idempotent description (we check the full --help text).
+        assert "[ast]" in out or "pglast" in out

--- a/tests/unit/test_quiet_success_hints.py
+++ b/tests/unit/test_quiet_success_hints.py
@@ -1,0 +1,181 @@
+"""Tests for "looks unusual" hints on quiet successes (Phase 05, issue #123).
+
+When a command technically succeeds (exit 0) but the success state is
+also consistent with a configuration error, the CLI emits an advisory
+hint pointing at the most likely root cause. Hints are:
+
+- Written to ``error_console`` (stderr) in text mode.
+- Appended to ``payload["hints"]`` (and *not* stderr) in JSON mode.
+
+Hints never change the exit code.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+def _make_empty_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    return d
+
+
+class TestValidateIdempotentZeroFiles:
+    """`migrate validate --idempotent` against an empty directory hints."""
+
+    def test_json_mode_emits_hint_in_payload(self, tmp_path: Path) -> None:
+        empty_dir = _make_empty_dir(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--migrations-dir",
+                str(empty_dir),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert isinstance(payload["hints"], list)
+        assert any("exists but contains no files" in h for h in payload["hints"]), payload
+
+    def test_json_mode_does_not_emit_stderr_hint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        empty_dir = _make_empty_dir(tmp_path)
+
+        import confiture.cli.helpers as helpers
+
+        err_buf = io.StringIO()
+        monkeypatch.setattr(helpers, "error_console", Console(file=err_buf))
+
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--migrations-dir",
+                str(empty_dir),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0
+        # JSON mode never writes hints to stderr.
+        assert "Hint:" not in err_buf.getvalue()
+
+    def test_text_mode_emits_stderr_hint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        empty_dir = _make_empty_dir(tmp_path)
+
+        # Patch the module-level error_console to capture into a buffer
+        # — CliRunner's stderr redirect doesn't catch Rich's direct
+        # writes to sys.stderr.
+        import confiture.cli.helpers as helpers
+
+        err_buf = io.StringIO()
+        monkeypatch.setattr(helpers, "error_console", Console(file=err_buf))
+
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--migrations-dir",
+                str(empty_dir),
+            ],
+        )
+        assert result.exit_code == 0
+        text = err_buf.getvalue()
+        assert "Hint:" in text
+        assert "exists but contains no files" in text
+
+
+class TestValidateUnaffectedCommandsStillEmitEmptyHints:
+    """Commands without a triggering condition still emit ``"hints": []``."""
+
+    def test_validate_idempotent_with_files_emits_empty_hints(self, tmp_path: Path) -> None:
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        (migrations_dir / "001_init.up.sql").write_text(
+            "CREATE TABLE IF NOT EXISTS users (id INT);"
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--migrations-dir",
+                str(migrations_dir),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["hints"] == []
+
+
+class TestEmitHintHelper:
+    """The shared ``_emit_hint`` helper dispatches on format."""
+
+    def test_text_mode_writes_to_stderr_only(self) -> None:
+        from confiture.cli.helpers import _emit_hint
+
+        err_buf = io.StringIO()
+        err_console = Console(file=err_buf)
+        hints: list[str] = []
+        _emit_hint(
+            "Migration directory exists but contains no files.",
+            hints_list=hints,
+            format_="text",
+            error_console=err_console,
+        )
+        text = err_buf.getvalue()
+        assert "Migration directory exists but contains no files." in text
+        assert hints == []
+
+    def test_json_mode_appends_to_list_only(self) -> None:
+        from confiture.cli.helpers import _emit_hint
+
+        err_buf = io.StringIO()
+        err_console = Console(file=err_buf)
+        hints: list[str] = []
+        _emit_hint(
+            "Migration directory exists but contains no files.",
+            hints_list=hints,
+            format_="json",
+            error_console=err_console,
+        )
+        assert hints == ["Migration directory exists but contains no files."]
+        assert err_buf.getvalue() == ""
+
+    @pytest.mark.parametrize("fmt", ["csv", "yaml"])
+    def test_non_json_machine_modes_also_use_payload(self, fmt: str) -> None:
+        from confiture.cli.helpers import _emit_hint
+
+        err_buf = io.StringIO()
+        err_console = Console(file=err_buf)
+        hints: list[str] = []
+        _emit_hint("x", hints_list=hints, format_=fmt, error_console=err_console)
+        assert hints == ["x"]
+        assert err_buf.getvalue() == ""

--- a/tests/unit/test_suggestion_templates.py
+++ b/tests/unit/test_suggestion_templates.py
@@ -1,0 +1,45 @@
+"""Tests for idempotency suggestion templates (Phase 04, issue #123).
+
+The catalog of patterns is split into two disjoint frozensets:
+
+- ``TEMPLATE_FILLABLE`` — captures-driven template available.
+- ``TEMPLATE_NOT_AVAILABLE`` — generic suggestion only.
+
+Every :class:`IdempotencyPattern` member must belong to exactly one of
+these sets — neither both nor neither.
+"""
+
+from __future__ import annotations
+
+from confiture.core.idempotency.models import IdempotencyPattern
+from confiture.core.idempotency.patterns import (
+    TEMPLATE_FILLABLE,
+    TEMPLATE_NOT_AVAILABLE,
+)
+
+
+def test_each_pattern_classification() -> None:
+    """Every pattern is in exactly one of the two classification sets."""
+    for pattern in IdempotencyPattern:
+        in_fillable = pattern in TEMPLATE_FILLABLE
+        in_not_available = pattern in TEMPLATE_NOT_AVAILABLE
+        assert in_fillable != in_not_available, (
+            f"{pattern.name} must be in exactly one of "
+            f"TEMPLATE_FILLABLE / TEMPLATE_NOT_AVAILABLE; got "
+            f"fillable={in_fillable}, not_available={in_not_available}"
+        )
+
+
+def test_classification_sets_are_disjoint() -> None:
+    """The two sets share no members."""
+    assert frozenset() == TEMPLATE_FILLABLE & TEMPLATE_NOT_AVAILABLE
+
+
+def test_classification_sets_cover_all_patterns() -> None:
+    """Union of both sets equals the full IdempotencyPattern enum."""
+    all_patterns = set(IdempotencyPattern)
+    union = TEMPLATE_FILLABLE | TEMPLATE_NOT_AVAILABLE
+    assert union == all_patterns, (
+        f"Missing patterns: {all_patterns - union}; "
+        f"extra patterns: {union - all_patterns}"
+    )


### PR DESCRIPTION
## Summary

Fixes [#128](https://github.com/evoludigit/confiture/issues/128) — `CREATE TABLE` bodies got corrupted when a `--` comment sat between two table-level `CONSTRAINT … FOREIGN KEY` clauses. The emitted SQL had the comment glued onto a column line and a stray trailing comma before `)`, producing `syntax error at or near \")\"`.

- Replace dual-regex FK extraction with an index-map from a comment-stripped view back to original positions (`_strip_comments_with_map`).
- Suppress newline-eat on either side of a comment-only adjacent line (`_line_has_data`) so comments stay on their own line.
- Walk back through blank and comment-only lines in `_fix_trailing_commas` so the comma is stripped from the actual last data column.
- Confirmed `len(fks) == 2` against the reporter's input — the FKs were being collected, the visible bug was the corrupted body, not Pass-2.

Ships as **v0.16.1** (patch).

## Test plan

- [x] `uv run pytest tests/unit/test_fk_extractor.py -v` (66 passed, including 2 new regression tests)
- [x] `uv run pytest tests/unit/test_builder_two_pass.py -v` (9 passed)
- [x] `uv run pytest tests/unit/` (6464 passed, 41 skipped)
- [x] `uv run ruff check python/confiture/core/fk_extractor.py tests/unit/test_fk_extractor.py`
- [x] `uv run ty check python/confiture/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)