### PR TITLE
docs: #125 #127 migration-only positioning + dry-run/preflight cross-link (v0.16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Confiture will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2026-05-27
+
+### Documentation
+
+- **Migration-only positioning.** README now answers "Can I use confiture
+  without a `db/schema/` directory?" above the fold. The comparison
+  grid's "Source of truth" row lists *DDL files or migration chain*, an
+  adoption-checklist row covers migration-chain projects, and
+  `docs/guides/02-incremental-migrations.md` opens with a callout
+  pointing migration-only readers at the rest of the guide. Closes
+  [#125](https://github.com/evoludigit/confiture/issues/125).
+- **Dry-run ↔ preflight cross-link.** `docs/guides/dry-run.md` gains a
+  "Need a structural diff?" section explaining that `--dry-run` /
+  `--dry-run-execute` answer *would this run?* while
+  `migrate preflight --against` answers *what would change?*, plus a
+  decision table for picking between them. `migrate up --help` mentions
+  preflight in a STRUCTURAL DIFF block. Closing
+  [#127](https://github.com/evoludigit/confiture/issues/127) as docs
+  option B; the structural-diff flag remains a future feature ask.
+
 ## [0.16.1] - 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ confiture migrate baseline --through 004 -c db/environments/production.yaml
 $ confiture migrate status -c db/environments/production.yaml --format json | jq '.applied | length'
 4
 
-# 3. Preflight the next deploy end-to-end against a parallel database:
+# 3. Preflight: replay pending migrations on a parallel DB, emit a structural diff vs. db/schema/.
 $ confiture migrate preflight --against "$PREFLIGHT_URL" -c db/environments/production.yaml
 ▸ Replaying pending migrations on preflight DB …
   ✓ 20260520143015_add_user_bio                 applied in 24 ms
@@ -54,11 +54,26 @@ The walkthrough — including failure modes, the integration test that backs the
 
 ---
 
+## No `db/schema/` directory? That works too.
+
+`confiture migrate up`, `down`, `status`, `baseline`, and `preflight` are
+the migration runner — they don't require a `db/schema/` directory. The
+"Build from DDL" pitch above the fold sells one of confiture's four
+strategies; the other three (incremental migrations, production sync,
+schema-to-schema FDW migration) work against a project whose only source
+of truth is the migration chain itself.
+
+If you're evaluating confiture against Flyway / Alembic / dbmate / sqlx-cli
+as a pure migration runner, skip `confiture build` and use everything else.
+Walkthrough: [docs/guides/02-incremental-migrations.md](docs/guides/02-incremental-migrations.md).
+
+---
+
 ## When to use Confiture?
 
 | Capability | Confiture | Flyway | Alembic | dbmate | sqlx-cli | plain psql |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
-| Source of truth | DDL files | migration chain | model classes | migration chain | migration chain | DDL files |
+| Source of truth | DDL files *or* migration chain | migration chain | model classes | migration chain | migration chain | DDL files |
 | Tracking table | yes | yes | yes | yes | yes | no |
 | Rollback (`down.sql`) | yes | paid | yes | yes | yes | no |
 | Preflight against a copy DB | **yes (structural diff)** | no | no | no | no | no |
@@ -67,6 +82,8 @@ The walkthrough — including failure modes, the integration test that backs the
 | Zero-downtime via FDW | **yes** | no | no | no | no | no |
 | Multi-agent coordination | **yes** | no | no | no | no | no |
 | Ecosystem maturity / stars | early | very mature | mature | mature | mature | n/a |
+
+> **Note on "source of truth":** confiture can run as a pure migration tool against a project that has no `db/schema/` directory — the DDL workflow is opt-in. See [No `db/schema/` directory?](#no-dbschema-directory-that-works-too) above.
 
 Confiture wins on **build-from-DDL**, **structural-diff preflight**, **production sync**, and **multi-agent coordination**. It loses on ecosystem age — Flyway and Alembic have a decade of community knowledge. Pick honestly.
 
@@ -77,6 +94,7 @@ Confiture wins on **build-from-DDL**, **structural-diff preflight**, **productio
 | 1 environment + 1 contributor, schema rarely changes | plain `psql` |
 | 2+ environments, schema changes weekly | Confiture, Flyway, Alembic, or dbmate |
 | Multi-agent / AI-driven development on shared schemas | **Confiture** |
+| You have a migration chain (no `db/schema/`) and want preflight + tracking | **Confiture** (use everything except `confiture build`) |
 | You want `db/schema/` to be source of truth, not a migration chain | **Confiture** |
 | You need zero-downtime schema swaps with `postgres_fdw` | **Confiture** (Medium 4) |
 | You're committed to SQLAlchemy ORM | Alembic |

--- a/docs/guides/02-incremental-migrations.md
+++ b/docs/guides/02-incremental-migrations.md
@@ -6,6 +6,19 @@
 
 ---
 
+## Use this guide if you're a migration-only project
+
+`confiture build` (Medium 1) requires a `db/schema/` directory. **Every
+other command in this guide does not.** `migrate up`, `migrate down`,
+`migrate status`, `migrate baseline`, and `migrate preflight --against`
+all operate on a pure migration chain — no canonical DDL required.
+
+If your project is laid out as `db/migrations/001_*.sql … 005_*.sql` with
+no `db/schema/` directory, this guide is your entry point. Skip the
+build-from-DDL strategy entirely; the rest of confiture works.
+
+---
+
 ## Overview
 
 Incremental migrations apply targeted changes (ALTER TABLE, CREATE INDEX) to existing databases while preserving data.

--- a/docs/guides/dry-run.md
+++ b/docs/guides/dry-run.md
@@ -69,6 +69,32 @@ confiture migrate down --dry-run --steps 3
 
 ---
 
+## Need a structural diff?
+
+`migrate up --dry-run` and `--dry-run-execute` answer *"would this run?"*
+They print row-count / time / disk estimates and verify the SQL executes
+inside a SAVEPOINT — but they don't show **what would change** in
+schema terms ("this would add column `users.bio TEXT NULL`, drop index
+`idx_legacy_users_email` …").
+
+For that, use `migrate preflight --against <preflight-db>` (covered in
+[Preflight against a parallel database](#preflight-against-a-parallel-database)
+below). Preflight replays every pending migration on a parallel database,
+then emits a structural diff against `db/schema/` — the human-readable
+"what's about to change" output that lets you pull the trigger on a prod
+apply with confidence.
+
+**Quick decision**:
+
+| You want to … | Use |
+|---|---|
+| Verify the SQL parses + executes inside a transaction | `migrate up --dry-run-execute` |
+| See row-count / time / disk estimates | `migrate up --dry-run` |
+| See "this would add table X, drop column Y" | `migrate preflight --against <preflight-db>` |
+| Gate a CI pipeline on schema drift | `migrate preflight --against` (exit 7 on drift) |
+
+---
+
 ## SAVEPOINT Testing
 
 Execute migrations with guaranteed rollback:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.16.1"
+version = "0.16.2"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -569,6 +569,11 @@ def migrate_up(
       DRY-RUN: --dry-run, --dry-run-execute, --verbose, --format, --output
         Analyze migrations before executing, with optional SAVEPOINT testing
 
+      STRUCTURAL DIFF: --dry-run does not emit a structural diff (column adds,
+        index drops, etc.). For that, use `migrate preflight --against <url>`
+        which replays migrations on a parallel database and diffs the result
+        against db/schema/. See docs/guides/dry-run.md#need-a-structural-diff.
+
       SAFETY: --verify-checksums, --on-checksum-mismatch, --strict, --no-lock, --lock-timeout
         Control verification and locking behavior for production safety
 


### PR DESCRIPTION
## Summary

Closes [#125](https://github.com/evoludigit/confiture/issues/125) and [#127](https://github.com/evoludigit/confiture/issues/127). Stacked on top of #129 (v0.16.1).

- **#125 — migration-only positioning.** README answers "Can I use confiture without a `db/schema/` directory?" above the fold (new H2 block, grid row + footnote, adoption-checklist row). `docs/guides/02-incremental-migrations.md` opens with a migration-only callout.
- **#127 — dry-run ↔ preflight cross-link.** `docs/guides/dry-run.md` gains a "Need a structural diff?" section with a decision table; `migrate up --help` epilog points at preflight. Closing as docs option B; the `--dry-run --structural-diff` feature remains a future ask.

Ships as **v0.16.2** (patch — docs only).

> **Note on base branch**: this PR is stacked on `fix/128-create-table-comment-constraint-loss`. Merge #129 first, then GitHub will retarget this one to `main`.

## Test plan

- [x] `uv run pytest tests/unit/` — 6466 passed, 41 skipped
- [x] `uv run ruff check python/confiture/cli/commands/migrate_core.py`
- [x] `uv run ty check python/confiture/`
- [x] `uv run confiture migrate up --help` — STRUCTURAL DIFF block appears
- [x] Markdown anchors verified 2026-05-27 in plan files

🤖 Generated with [Claude Code](https://claude.com/claude-code)