### PR TITLE
feat: stabilize machine-readable contracts (#139–#148, v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ severity. The `--against` execution path is unchanged.
 
 ### Added
 
+- Replica-aware forward-compatibility lint
+  ([#139](https://github.com/fraiseql/confiture/issues/139)). Classifies each
+  migration DDL operation and flags those unsafe under streaming replication —
+  `DROP COLUMN`, `RENAME COLUMN`, type changes, `ADD COLUMN NOT NULL/DEFAULT`,
+  immediate `ADD CONSTRAINT`, non-concurrent `CREATE INDEX` — with the exact
+  multi-step remediation. Surfaced via `confiture lint --replica-safe`
+  (rule `replica_001`) and `migrate preflight` (`PFLIGHT_REPLICA_*` issues in the
+  structured report). **Soft default** (owner decision): warns when no replicas
+  are declared, errors when `infrastructure.replicas` is non-empty;
+  `migration.allow_unsafe_under_replication: true` downgrades errors to warnings.
+  Reuses the pglast/regex two-tier parser (no new SQL parser). Guide:
+  [`docs/guides/replica-safe-migrations.md`](docs/guides/replica-safe-migrations.md).
 - `confiture validate-config` — offline config + migrations-tree validation
   ([#144](https://github.com/fraiseql/confiture/issues/144)). Checks YAML/schema
   validity, include-dir existence, DSN *format*, and the migrations tree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ severity. The `--against` execution path is unchanged.
   the rollback ([#142](https://github.com/fraiseql/confiture/issues/142)).
   Previously only `migrate up` locked, so a `down` racing a concurrent deploy
   had no mutual exclusion. Pass `--no-lock` / `no_lock=True` to opt out.
+  Consequence: a `migrate down` now blocks (or fails with exit 6 once
+  `--lock-timeout` expires) when another migration holds the lock, where it
+  previously proceeded unguarded.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ severity. The `--against` execution path is unchanged.
 
 ### Added
 
+- `confiture validate-config` — offline config + migrations-tree validation
+  ([#144](https://github.com/fraiseql/confiture/issues/144)). Checks YAML/schema
+  validity, include-dir existence, DSN *format*, and the migrations tree
+  (well-formed filenames, no duplicate versions) **without ever connecting to a
+  database**. Accepts `--config` / `--database-url` / env (same sources as the
+  migrate family) and `--migrations-path`. Valid → exit 0; invalid → exit 5
+  (config invalid) with structured stderr; `--format json` returns
+  `{valid, config_source, migrations_path, migration_count, issues[]}` (each
+  issue the shared issue object). `--strict` promotes warnings to failures.
 - Lock-holder identity in lock-contention errors
   ([#147](https://github.com/fraiseql/confiture/issues/147)). When the migration
   lock can't be acquired, `migrate up`/`down`/`down-to` now name the holder —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ Internally, `load_config()` / `create_connection()` now raise `ConfigurationErro
 (with `CONFIG_002`/`CONFIG_004`/`CONFIG_006`) instead of `MigrationError`, so the
 correct exit code flows from the registry through `ConfiturError.exit_code`.
 
+### ⚠️ BREAKING — `migrate preflight` JSON reshaped ([#148](https://github.com/fraiseql/confiture/issues/148))
+
+`migrate preflight --format json` (no `--against`) now returns the structured
+report `{ok, summary, issues[]}` instead of the flat `PreflightResult` JSON. Each
+`issues[]` element is the unified issue object with a `PFLIGHT_*` code
+(`PFLIGHT_MISSING_DOWN`, `PFLIGHT_NON_TRANSACTIONAL`, `PFLIGHT_DUPLICATE_VERSION`,
+`PFLIGHT_CHECKSUM_MISMATCH`). Error-severity issues exit **7** (was 1);
+**non-transactional statements are now warnings** (exit 0 by default) unless
+`--strict` promotes warnings to failures. Table output gains the issue code +
+severity. The `--against` execution path is unchanged.
+
 ### Fixed
 
 - `migrate down` now acquires the migration advisory lock for the duration of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ correct exit code flows from the registry through `ConfiturError.exit_code`.
 
 ### Added
 
+- Lock-holder identity in lock-contention errors
+  ([#147](https://github.com/fraiseql/confiture/issues/147)). When the migration
+  lock can't be acquired, `migrate up`/`down`/`down-to` now name the holder —
+  pid, hostname, user, command, and `held_for_seconds` — in stderr and under the
+  `LOCK_1300` envelope's `details.holder`. Identity is recorded best-effort in a
+  new `confiture_lock_holder` metadata table written under the advisory lock; the
+  advisory lock stays the crash-safe source of truth (a crashed holder's lingering
+  row is reported as stale, and a new acquirer still succeeds). Writing identity
+  never blocks a migration. A hold longer than 5 minutes adds a stale-lock hint.
 - `confiture migrate down-to <revision>` — roll back to a specific revision
   ([#142](https://github.com/fraiseql/confiture/issues/142)). The absolute
   counterpart to `migrate down --steps N`. A pure planner computes the rollback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ correct exit code flows from the registry through `ConfiturError.exit_code`.
 
 ### Added
 
+- `--database-url` / `-d` on `migrate up`/`down`/`status`/`verify`/`preflight`
+  ([#140](https://github.com/fraiseql/confiture/issues/140)). Resolution
+  precedence: flag > `CONFITURE_DATABASE_URL` > `DATABASE_URL` > `--config`. When
+  a DSN is supplied via flag or env var, no YAML is required (tracking table
+  defaults to `tb_confiture`). For `migrate preflight` the flag is the *tracking*
+  DB (pending detection), distinct from `--against`. SSH-tunnel configs still
+  require `--config`. A malformed DSN fails with `CONFIG_003` (exit 5).
 - `docs/reference/exit-codes.md` — the canonical exit-code convention, generated
   from the hand-authored `CANONICAL_EXIT_CODES` contract and asserted against the
   registry by `tests/unit/test_exit_code_convention.py`. ([#146](https://github.com/fraiseql/confiture/issues/146))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to Confiture will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - Unreleased
+
+Bundled release stabilizing Confiture's machine-readable contracts (CLI exit
+codes, structured error JSON, new `migrate` subcommands) for tooling that wraps
+Confiture. Covers GitHub issues #139–#148.
+
+### ⚠️ BREAKING — exit codes renumbered ([#146](https://github.com/fraiseql/confiture/issues/146))
+
+The process exit codes for three error families have changed so the structured
+exception registry now emits a wrapper-facing convention (no-table = 2,
+connection failed = 3, config invalid = 5). **Wrappers that branch on these exit
+codes must update.** Exit codes are now a documented **stability contract** —
+see [`docs/reference/exit-codes.md`](docs/reference/exit-codes.md).
+
+| Symbolic code | Meaning | Old exit (≤0.18.0) | New exit |
+|---------------|---------|:------------------:|:--------:|
+| `PRECON_1001` | Database not initialized (tracking table absent) | 5 | **2** |
+| `CONFIG_001` | Missing required config field | 2 | **5** |
+| `CONFIG_002` | Invalid YAML syntax | 2 | **5** |
+| `CONFIG_003` | Invalid database URL format | 2 | **5** |
+| `CONFIG_004` | Environment config not found | 2 | **5** |
+| `CONFIG_005` | Invalid include/exclude pattern | 2 | **5** |
+| `CONFIG_006` | Database connection failed | 2 | **3** |
+| `CONFIG_010` | Database URL not set in environment | 2 | **5** |
+
+Migration guidance for wrapper authors:
+
+- If you branched on **exit 2 = config error**, it is now **5**.
+- **Exit 2** now means **tracking table absent** (fresh DB, no current revision).
+- **Exit 3** now distinguishes a **connection failure** from a config error.
+
+Internally, `load_config()` / `create_connection()` now raise `ConfigurationError`
+(with `CONFIG_002`/`CONFIG_004`/`CONFIG_006`) instead of `MigrationError`, so the
+correct exit code flows from the registry through `ConfiturError.exit_code`.
+
+### Added
+
+- `docs/reference/exit-codes.md` — the canonical exit-code convention, generated
+  from the hand-authored `CANONICAL_EXIT_CODES` contract and asserted against the
+  registry by `tests/unit/test_exit_code_convention.py`. ([#146](https://github.com/fraiseql/confiture/issues/146))
+- `confiture --exit-codes` — hidden utility printing the convention; the
+  top-level `--help` epilog names the operationally important codes. ([#146](https://github.com/fraiseql/confiture/issues/146))
+
 ## [0.18.0] - 2026-05-28
 
 Bundled release covering three open issues. One feature branch, one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ report `{ok, summary, issues[]}` instead of the flat `PreflightResult` JSON. Eac
 `--strict` promotes warnings to failures. Table output gains the issue code +
 severity. The `--against` execution path is unchanged.
 
+### Deprecated
+
+- `confiture verify` is renamed to `confiture verify-checksums`
+  ([#143](https://github.com/fraiseql/confiture/issues/143)) to disambiguate it
+  from `confiture migrate verify` (runtime correctness via `.verify.sql`).
+  `verify-checksums` is the canonical name for file-checksum integrity;
+  `confiture verify` keeps working as a deprecated alias for one release cycle
+  (it prints a deprecation warning to **stderr**, so piped stdout stays clean,
+  and behaves identically otherwise) and is removed in the next major. Each
+  command's `--help` now names its sibling.
+
 ### Fixed
 
 - `migrate down` now acquires the migration advisory lock for the duration of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,24 @@ Internally, `load_config()` / `create_connection()` now raise `ConfigurationErro
 (with `CONFIG_002`/`CONFIG_004`/`CONFIG_006`) instead of `MigrationError`, so the
 correct exit code flows from the registry through `ConfiturError.exit_code`.
 
+### Fixed
+
+- `migrate down` now acquires the migration advisory lock for the duration of
+  the rollback ([#142](https://github.com/fraiseql/confiture/issues/142)).
+  Previously only `migrate up` locked, so a `down` racing a concurrent deploy
+  had no mutual exclusion. Pass `--no-lock` / `no_lock=True` to opt out.
+
 ### Added
 
+- `confiture migrate down-to <revision>` — roll back to a specific revision
+  ([#142](https://github.com/fraiseql/confiture/issues/142)). The absolute
+  counterpart to `migrate down --steps N`. A pure planner computes the rollback
+  set and validates that every required `.down.sql` exists **before** touching
+  the database; if any is missing it refuses atomically (`ROLLBACK_600`, exit 8,
+  nothing applied). Edge cases: no-op when already at the target (exit 0),
+  unknown/forward target (`MIGR_100`, exit 3). `--dry-run` prints the plan;
+  `--format json` returns `{from, to, rolled_back, skipped, errors}`. Accepts
+  `--database-url` (#140). Also exposed as `MigratorSession.down_to()`.
 - `confiture migrate current` — print the latest applied migration revision
   ([#141](https://github.com/fraiseql/confiture/issues/141)). Text mode prints
   the bare revision (empty line if none); `--format json` returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ correct exit code flows from the registry through `ConfiturError.exit_code`.
 
 ### Added
 
+- `confiture migrate current` — print the latest applied migration revision
+  ([#141](https://github.com/fraiseql/confiture/issues/141)). Text mode prints
+  the bare revision (empty line if none); `--format json` returns
+  `{revision, name, applied_at, checksum}` with `revision: null` for an empty
+  tracking table (exit 0). An absent tracking table exits 2 (`PRECON_1001`).
+  Accepts `--database-url` (#140). Also exposed as
+  `MigratorSession.current_revision()`.
 - Structured error envelope in `--format json` mode
   ([#145](https://github.com/fraiseql/confiture/issues/145)). On an error path,
   migrate-family commands now emit `{"ok": false, "error": {code, message,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ correct exit code flows from the registry through `ConfiturError.exit_code`.
 
 ### Added
 
+- Structured error envelope in `--format json` mode
+  ([#145](https://github.com/fraiseql/confiture/issues/145)). On an error path,
+  migrate-family commands now emit `{"ok": false, "error": {code, message,
+  severity, actionable, details, migration, file, line}}` on stdout (human/text
+  output unchanged) and exit with the #146 code. The `error` value is the unified
+  inner issue object shared with `validate-config` (#144) and the preflight report
+  (#148). New: `confiture.cli.error_json` (`emit_error_json` / `fail`),
+  `docs/reference/error-codes.md` codebook (generated from the registry), and the
+  `error-envelope` / `issue-object` JSON schemas. `migrate status`'s informative
+  no-table / pending payloads are preserved (success-with-signal, not errors).
 - `--database-url` / `-d` on `migrate up`/`down`/`status`/`verify`/`preflight`
   ([#140](https://github.com/fraiseql/confiture/issues/140)). Resolution
   precedence: flag > `CONFITURE_DATABASE_URL` > `DATABASE_URL` > `--config`. When

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ confiture/
 │   │   │   ├── migrate_core.py  # migrate status/up/down/generate
 │   │   │   ├── migrate_state.py # migrate baseline/reinit/rebuild
 │   │   │   ├── migrate_analysis.py  # migrate diff/validate/fix/introspect/verify
-│   │   │   └── admin.py         # install-helpers, validate_profile, verify, restore
+│   │   │   └── admin.py         # install-helpers, validate_profile, verify-checksums (+ deprecated `verify` alias), restore
 │   │   ├── formatters/
 │   │   │   ├── build_formatter.py
 │   │   │   ├── migrate_formatter.py

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ jobs:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
 ```
 
-Exit codes: `0` success, `2` config error, `3` SQL failure, `6` lock contention, `7` structural drift. See [the dry-run guide](docs/guides/dry-run.md) for what each one means.
+Exit codes are a documented stability contract — see [the exit-code reference](docs/reference/exit-codes.md). The most operationally important: `2` tracking table absent, `3` DB connection failed, `5` config invalid, `6` lock contention. For `migrate preflight`'s drift-gate codes specifically, see [the dry-run guide](docs/guides/dry-run.md).
 
 > Migrations that open their own SAVEPOINTs, use `psycopg`'s
 > `conn.transaction()`, or wrap `DO $$ … EXCEPTION WHEN … $$` blocks
@@ -267,6 +267,7 @@ with Migrator.from_config("db/environments/prod.yaml") as m:
 **Reference**
 - [Tracking table (`tb_confiture`)](docs/reference/tracking-table.md)
 - [Transaction & SAVEPOINT contract](docs/reference/transaction-contract.md) — what migration bodies may and may not do under the wrapping transaction.
+- [Exit-code convention](docs/reference/exit-codes.md) — the stable, wrapper-facing exit codes.
 - [CLI](docs/reference/cli.md)
 - [Configuration YAML](docs/reference/configuration.md)
 - [Complete feature list](docs/features/overview.md)

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ The walkthrough — including failure modes, the integration test that backs the
 
 ## No `db/schema/` directory? That works too.
 
-`confiture migrate up`, `down`, `status`, `baseline`, and `preflight` are
-the migration runner — they don't require a `db/schema/` directory. The
+`confiture migrate up`, `down`, `status`, `current`, `baseline`, and
+`preflight` are the migration runner — they don't require a `db/schema/`
+directory (`migrate current` prints the latest applied revision as a narrow
+"what's deployed?" contract). The
 "Build from DDL" pitch above the fold sells one of confiture's four
 strategies; the other three (incremental migrations, production sync,
 schema-to-schema FDW migration) work against a project whose only source

--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ The walkthrough — including failure modes, the integration test that backs the
 
 ## No `db/schema/` directory? That works too.
 
-`confiture migrate up`, `down`, `status`, `current`, `baseline`, and
-`preflight` are the migration runner — they don't require a `db/schema/`
+`confiture migrate up`, `down`, `down-to`, `status`, `current`, `baseline`,
+and `preflight` are the migration runner — they don't require a `db/schema/`
 directory (`migrate current` prints the latest applied revision as a narrow
-"what's deployed?" contract). The
+"what's deployed?" contract; `migrate down --steps N` rolls back relatively
+while `migrate down-to <revision>` rolls back to a specific revision, refusing
+atomically if any required `.down.sql` is missing). The
 "Build from DDL" pitch above the fold sells one of confiture's four
 strategies; the other three (incremental migrations, production sync,
 schema-to-schema FDW migration) work against a project whose only source

--- a/README.md
+++ b/README.md
@@ -156,10 +156,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
       - run: uv pip install --system "fraiseql-confiture[ast]"
-      - run: confiture migrate up -c db/environments/production.yaml
+      # No YAML needed in CI — the migrate family reads DATABASE_URL directly
+      # (or pass --database-url "$DSN"). See the connection-source docs below.
+      - run: confiture migrate up
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
 ```
+
+`migrate up`/`down`/`status`/`verify`/`preflight` accept `--database-url <dsn>` (or read `CONFITURE_DATABASE_URL` / `DATABASE_URL`) so runtime-resolved DSNs need no temp YAML — precedence and details in [the CLI reference](docs/reference/cli.md#connection-source-and-precedence).
 
 Exit codes are a documented stability contract — see [the exit-code reference](docs/reference/exit-codes.md). The most operationally important: `2` tracking table absent, `3` DB connection failed, `5` config invalid, `6` lock contention. For `migrate preflight`'s drift-gate codes specifically, see [the dry-run guide](docs/guides/dry-run.md).
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ with Migrator.from_config("db/environments/prod.yaml") as m:
 
 **For agents and tooling**
 - Every machine-readable CLI output has a published JSON schema under [`docs/reference/json-schemas/`](docs/reference/json-schemas/) — see [`docs/reference/json-schemas.md`](docs/reference/json-schemas.md).
+- On an **error path** in `--format json` mode, the migrate family emits a structured error envelope on stdout — `{"ok": false, "error": {code, message, severity, actionable, details, migration, file, line}}` — and exits with the [exit code](docs/reference/exit-codes.md) for that error. The full code list and the envelope schema are in the [error-code codebook](docs/reference/error-codes.md).
 - `confiture migrate validate --list-patterns --format json` exposes the full idempotency-detection catalog (read-only, no DB / config / migrations directory needed).
 - Quiet-success ambiguities surface advisory hints in `payload["hints"]` (or on stderr in text mode) — exit codes are unaffected.
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ with Migrator.from_config("db/environments/prod.yaml") as m:
 - [Production Data Sync](docs/guides/03-production-sync.md)
 - [Zero-Downtime Migrations](docs/guides/04-schema-to-schema.md)
 - [Dry-Run + Preflight](docs/guides/dry-run.md)
+- [Replica-safe migrations](docs/guides/replica-safe-migrations.md) — `replica_001` / `PFLIGHT_REPLICA_*` forward-compatibility lint under streaming replication.
 - [Bootstrap](docs/guides/bootstrap.md) — `confiture bootstrap` for one-shot env ownership setup.
 - [Superuser Migrations](docs/guides/superuser-migrations.md) — `requires_superuser = True` + `migrate apply-as` recovery workflow.
 - [Function Uniqueness](docs/guides/function-uniqueness.md) — `func_001` catches duplicate `CREATE FUNCTION` across DDL files.

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -4,6 +4,10 @@ Complete guide to understanding and fixing Confiture errors.
 
 When something goes wrong, Confiture provides detailed error messages with step-by-step solutions. This guide explains each error type and how to fix it.
 
+> Looking for the **integer process exit codes** each error maps to? See the
+> [exit-code convention](reference/exit-codes.md) — a documented stability
+> contract for tooling that wraps Confiture.
+
 ---
 
 ## Error Message Format

--- a/docs/guides/replica-safe-migrations.md
+++ b/docs/guides/replica-safe-migrations.md
@@ -1,0 +1,88 @@
+# Replica-safe migrations
+
+Confiture's replica-aware forward-compatibility lint (`replica_001`, issue #139)
+flags DDL that is unsafe to apply as a single step while read replicas serve
+traffic. This guide explains *why* the hazard exists and how to fix each case.
+
+## Why replicas need this
+
+Under PostgreSQL streaming replication, a replica replays the primary's WAL with
+a small lag. During that **lag window**, the primary already has the *new*
+schema while replicas still serve reads against the *old* one. Application code
+deployed alongside the migration may hit either schema depending on which node
+answers a read.
+
+The crux: **"safe within one migration" ≠ "safe under replication."** A migration
+that backfills a new `NOT NULL` column in the same transaction is internally
+consistent, but a reader on a lagging replica during the rollout still queries
+the pre-migration schema — and a writer on the primary already enforces the new
+constraint. The fix is almost always to split the change into forward-compatible
+steps spread across releases.
+
+## The safety matrix
+
+| Operation | Safe in one step? | Multi-step remediation |
+|---|---|---|
+| `ADD COLUMN` (nullable, no default) | ✅ yes | — |
+| `ADD COLUMN` (NOT NULL and/or DEFAULT) | ❌ no | add nullable → backfill → `SET NOT NULL` in a later release |
+| `DROP COLUMN` | ❌ no | deprecate (stop using) → wait one release → drop |
+| `RENAME COLUMN` | ❌ no | add new → dual-write → migrate readers → drop old |
+| `CHANGE TYPE` | ❌ no | add new column → backfill → swap readers → drop old |
+| `ADD CONSTRAINT` (immediate) | ❌ no | `ADD ... NOT VALID` → backfill → `VALIDATE CONSTRAINT` |
+| `ADD CONSTRAINT ... NOT VALID` | ✅ yes | — |
+| `CREATE INDEX` | ❌ no | `CREATE INDEX CONCURRENTLY` in its own non-transactional migration |
+| `CREATE INDEX CONCURRENTLY` | ✅ yes | — |
+| `CREATE TABLE` | ✅ yes | — |
+
+> **`ADD COLUMN NOT NULL DEFAULT` stays unsafe** even on PostgreSQL 11+ where the
+> "fast default" optimization makes the *primary* change cheap. The fast-default
+> optimization is orthogonal to the replica-lag concern: a reader on the old
+> schema still errors on the new `NOT NULL` column. (OD-13.)
+
+## Default severity policy
+
+The lint is **active by default but soft** so it doesn't break non-replicated
+projects on upgrade:
+
+- **No replicas declared** → unsafe operations are **warnings** (visible in CI,
+  non-blocking, exit 0).
+- **Replicas declared** (`infrastructure.replicas` non-empty) → unsafe operations
+  are **errors** (exit 7 in preflight; exit 1 in `lint`).
+- Operations the parser can't classify (e.g. dynamic `EXECUTE format(...)`) are
+  always **warnings** ("review manually") — never a hard block.
+
+Declare replicas in the environment YAML:
+
+```yaml
+infrastructure:
+  replicas:
+    - read-replica-1
+    - read-replica-2
+```
+
+### Bypassing (with documented risk)
+
+```yaml
+migration:
+  allow_unsafe_under_replication: true
+```
+
+This downgrades replica errors to warnings everywhere — even with replicas
+declared. **Risk**: you are accepting that a single-step DDL change may surface
+errors on read replicas during the replication-lag window. Use only when you
+control the rollout (e.g. you drain replica reads during the migration).
+
+## Surfaces
+
+- **`confiture migrate preflight --format json`** emits `PFLIGHT_REPLICA_*` issues
+  in the [structured report](../reference/json-schemas.md) — the deploy-gate
+  contract. Errors exit 7.
+- **`confiture lint --replica-safe`** runs the rule (`replica_001`) over the
+  migrations tree for standalone CI.
+
+## Coordination
+
+This static guarantee is the foundation for read-replica routing and replica-safe
+plan generation in the broader stack: specql#13 (replica-safe migration plan
+generation) and fraiseql#407 (read-replica read routing) rely on it; the deploy
+tool (fraisier) owns the live replica topology and sets `infrastructure.replicas`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -296,6 +296,31 @@ All migration commands are subcommands of `confiture migrate`:
 - `confiture migrate down` - Rollback applied migrations
 - `confiture migrate preflight` - Pre-deploy safety check
 
+### Connection source and precedence
+
+`migrate up`, `down`, `status`, `verify`, and `preflight` accept a direct
+PostgreSQL DSN via `--database-url` / `-d`, so tooling that resolves a DSN at
+runtime no longer has to synthesize a temporary YAML file. The connection is
+resolved with this **precedence**:
+
+1. `--database-url <dsn>` flag
+2. `CONFITURE_DATABASE_URL` environment variable (canonical)
+3. `DATABASE_URL` environment variable (ubiquitous fallback)
+4. `--config <yaml>` / `--env <name>` file (`database_url` field)
+
+When a DSN is supplied via flag or env var, **no YAML is required** — the
+migrations directory falls back to `db/migrations` and the tracking table to
+`tb_confiture`. A malformed DSN (not starting with `postgresql://` /
+`postgres://`) fails with `CONFIG_003` (exit 5).
+
+> **SSH tunnels**: a `--config` YAML may define an `ssh_tunnel` block that
+> rewrites the DSN. `--database-url` bypasses that — the flag is for
+> directly-reachable databases. Tunnelled connections still require `--config`.
+>
+> **`migrate preflight`**: `--database-url` is the *tracking* DB used for
+> pending-migration detection; it is distinct from `--against`, which is the
+> throwaway database migrations are replayed into.
+
 ---
 
 ### `confiture migrate status`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -290,6 +290,7 @@ Migration management commands (Medium 2: Incremental Migrations).
 All migration commands are subcommands of `confiture migrate`:
 
 - `confiture migrate status` - View migration status
+- `confiture migrate current` - Print the latest applied revision
 - `confiture migrate generate` - Create new migration template
 - `confiture migrate diff` - Compare schemas and detect changes
 - `confiture migrate up` - Apply pending migrations
@@ -417,6 +418,43 @@ case $? in
   3) echo "Fatal error" ; exit 1 ;;
 esac
 ```
+
+---
+
+### `confiture migrate current`
+
+Print the **latest applied** migration revision — a narrow, stable contract for
+tooling ("what is deployed right now?") without parsing the full `migrate
+status` payload.
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--config` | `-c` | Path | `db/environments/local.yaml` | Configuration file |
+| `--database-url` | `-d` | str | (none) | Tracking-DB DSN (see [Connection source and precedence](#connection-source-and-precedence)) |
+| `--format` | `-f` | str | `text` | `text` (bare revision) or `json` |
+| `--output` | `-o` | Path | (stdout) | Write output to a file |
+
+Output:
+
+- **text** — the bare revision string, or an empty line if none applied.
+- **json** — `{revision, name, applied_at, checksum}`; `revision` is `null` when
+  the tracking table exists but is empty.
+
+Exit codes:
+
+| Exit | Meaning |
+|---|---|
+| 0 | Current revision printed (or `null` when the tracking table is empty) |
+| 2 | Tracking table absent — confiture not initialized on this database (`PRECON_1001`) |
+| 3 | Database connection failed |
+
+```bash
+confiture migrate current -c db/environments/prod.yaml
+confiture migrate current --database-url "$DATABASE_URL" --format json
+```
+
+`migrate current` is the narrow form; [`migrate status`](#confiture-migrate-status)
+is the full applied/pending picture.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -294,7 +294,8 @@ All migration commands are subcommands of `confiture migrate`:
 - `confiture migrate generate` - Create new migration template
 - `confiture migrate diff` - Compare schemas and detect changes
 - `confiture migrate up` - Apply pending migrations
-- `confiture migrate down` - Rollback applied migrations
+- `confiture migrate down` - Rollback applied migrations (relative, `--steps N`)
+- `confiture migrate down-to` - Rollback to a specific revision (absolute)
 - `confiture migrate preflight` - Pre-deploy safety check
 
 ### Connection source and precedence
@@ -951,6 +952,46 @@ confiture migrate down --steps 3
 - **Development iteration**: Test migration changes
 - **Production hotfix**: Emergency rollback of problematic changes
 - **Environment reset**: Return to known-good state
+
+---
+
+### `confiture migrate down-to`
+
+Roll back to a **specific revision** (absolute), the counterpart to `migrate
+down --steps N` (relative). Name the revision to return to — typically captured
+earlier with [`migrate current`](#confiture-migrate-current) — and Confiture
+computes the rollback set, validates that every required `.down.sql` exists
+**before** touching the database, and rolls back newest→oldest under the
+migration lock. If any required `.down.sql` is missing it refuses atomically:
+**nothing is rolled back**.
+
+```bash
+confiture migrate down-to 20260101000001 -c db/environments/staging.yaml
+confiture migrate down-to 20260101000001 --dry-run --format json
+```
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `revision` | | str (arg) | — | Target revision to keep applied |
+| `--migrations-dir` | | Path | `db/migrations` | Migrations directory |
+| `--config` | `-c` | Path | `db/environments/local.yaml` | Configuration file |
+| `--database-url` | `-d` | str | (none) | Tracking-DB DSN (see [precedence](#connection-source-and-precedence)) |
+| `--dry-run` | | flag | off | Print the plan, apply nothing, exit 0 |
+| `--format` | `-f` | str | `text` | `text` or `json` (`{from, to, rolled_back, skipped, errors}`) |
+| `--output` | `-o` | Path | (stdout) | Write output to a file |
+
+Edge cases and exit codes:
+
+| Case | Exit | Behavior |
+|---|---|---|
+| `<revision>` == current | 0 | No-op ("already at `<revision>`") |
+| `<revision>` newer than current | 3 | Refuse — "use `migrate up --target`" (`MIGR_100`) |
+| `<revision>` unknown | 3 | Refuse — "unknown revision" (`MIGR_100`) |
+| any required `.down.sql` missing | 8 | Refuse atomically, nothing applied (`ROLLBACK_600`) |
+
+> `migrate down-to` (and `migrate down`) acquire the migration advisory lock for
+> the duration of the rollback, so the applied-set read and the rollback are
+> atomic with respect to a concurrent `migrate up`.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1243,13 +1243,22 @@ confiture migrate preflight [OPTIONS]
 |--------|------|---------|-------------|
 | `--migrations-dir` | Path | `db/migrations` | Migrations directory |
 | `--format`, `-f` | String | `table` | Output format: `table` or `json` |
+| `--strict` | flag | off | Treat warnings as errors for exit purposes |
 
-#### Exit Codes
+`--format json` (no `--against`) returns the **structured report**
+`{ok, summary, issues[]}` (issue #148); each `issues[]` element is the shared
+[issue object](error-codes.md#pflight_--preflight-report-issue-codes-148) with a
+`PFLIGHT_*` code.
+
+#### Exit Codes (no `--against`)
 
 | Code | Meaning |
 |------|---------|
-| `0` | All migrations safe to deploy |
-| `1` | One or more issues detected |
+| `0` | No error-severity issues (warnings alone are non-fatal unless `--strict`) |
+| `7` | One or more error-severity issues (or, under `--strict`, any warning) |
+
+A preflight that *crashes* (config / DB error) exits per the
+[exit-code convention](exit-codes.md) (e.g. 5, 3) with the error envelope.
 
 #### Examples
 
@@ -1257,8 +1266,11 @@ confiture migrate preflight [OPTIONS]
 # Basic check
 confiture migrate preflight
 
-# JSON output for CI/CD
+# JSON output for CI/CD — {ok, summary, issues[]}
 confiture migrate preflight --format json
+
+# Fail on warnings too
+confiture migrate preflight --strict
 
 # Custom migrations directory
 confiture migrate preflight --migrations-dir custom/migrations

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -1,0 +1,140 @@
+# Error-code codebook
+
+When a `confiture` command fails in `--format json` mode, it emits a structured
+**error envelope** on stdout (the process still exits with the
+[exit code](exit-codes.md) for that error):
+
+```json
+{
+  "ok": false,
+  "error": {
+    "severity": "error",
+    "code": "MIGR_106",
+    "message": "Duplicate migration versions detected: 20260101000001",
+    "actionable": "Rename files to use unique version prefixes.",
+    "details": { "conflicting_files": ["a.up.sql", "b.up.sql"] },
+    "migration": null,
+    "file": null,
+    "line": null
+  }
+}
+```
+
+The `error` value is the **unified inner issue object** shared with
+`validate-config` (#144) and the preflight report (#148): every one carries the
+same `{severity, code, message, actionable, details, migration, file, line}`
+shape, so downstream tooling parses one structure everywhere. `severity`,
+`code`, and `message` are always present; the rest are present-but-nullable.
+`CRITICAL`-severity errors serialize as `"error"` in the public contract.
+
+The JSON Schemas are published under
+[`docs/reference/json-schemas/`](json-schemas/) — `error-envelope.schema.json`
+(`$ref`s `issue-object.schema.json`).
+
+## Codebook
+
+Every registered symbolic code, its exit code (see [exit-codes.md](exit-codes.md)
+for the convention), severity, message template, and the `actionable`
+resolution hint surfaced in the envelope.
+
+<!-- BEGIN GENERATED: codebook -->
+| Code | Exit | Severity | Message | Actionable |
+|------|:----:|----------|---------|------------|
+| `ANON_1400` | 5 | error | Invalid anonymization rule | Check anonymization rule syntax |
+| `ANON_1401` | 5 | error | Anonymization function not found: {function} | Define the anonymization function or use a built-in |
+| `CONFIG_001` | 5 | error | Missing required field '{field}' in {file} | Add the field to your config file or set the corresponding environment variable |
+| `CONFIG_002` | 5 | error | Invalid YAML syntax in {file} | Check the YAML syntax in your configuration file |
+| `CONFIG_003` | 5 | error | Invalid database URL format | Use format: postgresql://user:password@host:port/database |
+| `CONFIG_004` | 5 | error | Environment config not found: {env} | Create configuration file for this environment or use an existing one |
+| `CONFIG_005` | 5 | error | Invalid include/exclude pattern | Check glob patterns in your configuration |
+| `CONFIG_006` | 3 | error | Database connection failed | Check database URL, host, port, and credentials |
+| `CONFIG_010` | 5 | error | Database URL not set in environment '{env}' | Set database_url in db/environments/{env}.yaml or DATABASE_URL environment variable |
+| `DIFF_001` | 5 | error | Schema diff error | Check SQL DDL for parsing issues |
+| `DIFFER_400` | 5 | error | Cannot parse SQL DDL | Fix the SQL syntax in your schema files |
+| `DIFFER_401` | 5 | error | Schema comparison failed | Verify both schema definitions are valid |
+| `DIFFER_402` | 1 | warning | Ambiguous schema changes detected | Review and clarify the schema changes |
+| `GEN_001` | 3 | error | External generator error | Check the external generator command and its output |
+| `GIT_001` | 7 | error | Git operation error | Check git repository status |
+| `GIT_002` | 7 | error | Not a git repository | Initialize a git repository or use a valid repository path |
+| `GIT_800` | 7 | error | Git command failed | Check git repository status |
+| `GIT_801` | 7 | error | Invalid git reference: {ref} | Check the git reference name |
+| `GIT_802` | 7 | error | Not a git repository | Initialize a git repository or use a valid repository path |
+| `GRANT_001` | 7 | error | Grant accompaniment error | Stage a migration file alongside grant changes |
+| `HOOK_1100` | 1 | error | Pre-migration hook failed | Check hook script and address the failure |
+| `HOOK_1101` | 1 | error | Post-migration hook failed | Migration succeeded but hook failed |
+| `LINT_1500` | 5 | error | Schema lint error: {message} | Fix the schema linting error |
+| `LINT_1501` | 0 | warning | Schema lint warning: {message} | Address the linting warning |
+| `LOCK_1300` | 6 | error | Cannot acquire database lock | Wait for other operations to complete |
+| `LOCK_1301` | 6 | warning | Lock held by {holder} | Check what operation is holding the lock |
+| `MIGR_001` | 3 | error | Migration error | Check migration files and database state |
+| `MIGR_004` | 3 | error | Migration file already exists | Use --force flag to overwrite existing file |
+| `MIGR_010` | 3 | error | Lock timeout waiting for migration lock | Retry with a higher --lock-timeout value or schedule during low-traffic window |
+| `MIGR_011` | 3 | error | Checksum mismatch for migration '{version}' | Migration file was modified after application. Restore the original file or use --force to override. |
+| `MIGR_100` | 3 | error | Migration {version} not found | Check the migration version and ensure the file exists |
+| `MIGR_101` | 0 | warning | Migration {version} already applied | This migration has already been applied to the database |
+| `MIGR_102` | 3 | error | Migration file corrupted: {file} | Regenerate or restore the migration file |
+| `MIGR_103` | 3 | error | Migration dependency not met: {version} | Apply prerequisite migrations before this one |
+| `MIGR_104` | 3 | error | Migration locked by another process | Wait for other migration to complete or check for stale locks |
+| `MIGR_105` | 0 | info | No pending migrations to apply | Your database schema is up to date |
+| `MIGR_106` | 3 | error | Duplicate migration version: {version} | Multiple migration files share the same version number. Rename files to use unique version prefixes. Run 'confiture migrate validate' to see all duplicates. |
+| `MIGR_107` | 3 | error | Migration {version} ({name}) issued an explicit COMMIT or ROLLBACK in its body, breaking confiture's transaction envelope | Remove any explicit COMMIT or ROLLBACK from the migration body. Confiture manages the outer transaction; embedded transaction control leaves the database in an unrecoverable state if a subsequent statement fails. If you need autocommit semantics, set transactional = False on the migration. |
+| `PGGIT_900` | 7 | error | pgGit command failed | Check pgGit is installed and configured |
+| `PGGIT_901` | 7 | error | Invalid pgGit configuration | Check pgGit configuration in confiture config |
+| `POOL_1200` | 6 | error | Connection pool exhausted | Increase pool size or wait for connections to be released |
+| `POOL_1201` | 6 | error | Connection pool initialization failed | Check database connection settings |
+| `PRECON_1000` | 5 | error | Precondition not met: {condition} | Ensure the precondition is satisfied before retrying |
+| `PRECON_1001` | 2 | error | Database not initialized | Run 'confiture init' to initialize the database |
+| `REBUILD_001` | 4 | error | Schema rebuild error | Check schema DDL and database state |
+| `RESTORE_001` | 5 | error | Restore error | Check backup format and pg_restore availability |
+| `ROLLBACK_001` | 8 | critical | Rollback error | Check rollback SQL and database state |
+| `ROLLBACK_600` | 8 | critical | Cannot rollback: irreversible change | Manual intervention required; cannot automatically rollback |
+| `ROLLBACK_601` | 8 | critical | Rollback SQL failed | Check rollback script syntax and database state |
+| `ROLLBACK_602` | 8 | critical | Database state inconsistent after rollback | Database may be partially rolled back; manual recovery needed |
+| `SCHEMA_001` | 4 | error | Schema error | Check SQL DDL files for errors |
+| `SCHEMA_200` | 4 | error | SQL syntax error in {file} at line {line} | Fix the SQL syntax error at the specified location |
+| `SCHEMA_201` | 4 | error | Schema directory not found: {directory} | Create the schema directory or check the path |
+| `SCHEMA_202` | 4 | error | Circular dependency detected | Break the circular dependency between schema files |
+| `SCHEMA_203` | 4 | error | Duplicate table definition: {table} | Remove the duplicate table definition |
+| `SCHEMA_204` | 4 | error | Schema hash mismatch | Schema definition has changed; rebuild the schema |
+| `SEED_001` | 5 | error | Seed execution error | Check seed file syntax and database state |
+| `SQL_001` | 1 | error | SQL execution error | Check the SQL statement for errors |
+| `SQL_700` | 1 | error | SQL execution failed | Check the SQL statement for errors |
+| `SQL_701` | 1 | error | Prepared statement error | Check statement parameters |
+| `SQL_702` | 1 | warning | Transaction deadlock detected | Retry the transaction |
+| `SQL_703` | 1 | error | Lock timeout exceeded | Wait for locks to be released or reduce query load |
+| `SYNC_001` | 5 | error | Sync error | Check source and target database connections |
+| `SYNC_300` | 5 | error | Cannot connect to source database | Check source database connection settings |
+| `SYNC_301` | 5 | error | Table '{table}' not found in source database | Verify table exists in source database |
+| `SYNC_302` | 5 | error | Anonymization rule failed for column '{column}' | Check anonymization rule syntax |
+| `SYNC_303` | 5 | error | Data copy operation failed | Check both source and target database connections |
+| `VALID_001` | 5 | error | Validation error | Check validation rules and data integrity |
+| `VALID_500` | 5 | error | Row count mismatch: expected {expected}, got {actual} | Verify data was copied correctly |
+| `VALID_501` | 5 | error | Foreign key constraint violated | Check foreign key relationships in your data |
+| `VALID_502` | 5 | error | Custom validation rule failed | Review custom validation rules |
+| `VERIFY_001` | 5 | error | Verify file contains forbidden SQL | Verify files must only contain SELECT queries |
+<!-- END GENERATED -->
+
+> The table above is generated from `ERROR_CODE_REGISTRY`. Regenerate with
+> `python -c "from confiture.core.error_codes import render_error_codebook;
+> print(render_error_codebook())"`; the codebook test
+> (`tests/unit/test_error_codebook.py`) fails if it drifts.
+
+## Stability contract
+
+Symbolic error codes are **public API**:
+
+- **Additive only** — new codes may be added; existing codes are not renamed.
+- A code's meaning is stable. Its integer exit code follows the
+  [exit-code convention](exit-codes.md) and is likewise frozen.
+- Removing or renaming a code requires a **major version bump** and a CHANGELOG
+  note.
+
+Some codes (`PGGIT_*`, `GIT_*`) are internal and unlikely to surface in the
+`--format json` output of the migrate family — depend on the codes the migrate
+commands actually emit (the connection / migration / lock / rollback families).
+
+## See also
+
+- [Exit-code convention](exit-codes.md)
+- [Error Reference Guide](../error-reference.md) — human-facing fix-it walkthroughs
+- [JSON output schemas](json-schemas.md)

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -143,6 +143,24 @@ stale-lock hint to `actionable`. When no identity is available (older holder, or
 the metadata table is absent), `details.holder` is `null` and the message says
 so — diagnostics never block a migration.
 
+## `PFLIGHT_*` — preflight report issue codes (#148)
+
+`migrate preflight --format json` (no `--against`) returns a *report*
+(`{ok, summary, issues[]}`), not the error envelope above. Each `issues[]`
+element is the same unified issue object, carrying a `PFLIGHT_*` code. These are
+report codes (not `ConfiturError` registry codes); the command's exit comes from
+the summary — any error → 7, warnings → 0 unless `--strict`.
+
+| Code | Default severity | Meaning |
+|------|------------------|---------|
+| `PFLIGHT_MISSING_DOWN` | error | Migration has no matching `.down.sql` (not reversible) |
+| `PFLIGHT_NON_TRANSACTIONAL` | warning | Migration contains a statement that can't run in a transaction (e.g. `CREATE INDEX CONCURRENTLY`) |
+| `PFLIGHT_DUPLICATE_VERSION` | error | Two migration files share a version prefix |
+| `PFLIGHT_CHECKSUM_MISMATCH` | error | An applied migration's file changed after it was applied |
+| `PFLIGHT_REPLAY_FAILED` | error | (reserved) a migration failed to replay against the `--against` DB |
+| `PFLIGHT_LIVE_DEPENDENTS` | warning | (reserved) live dependents found for a replaced object |
+| `PFLIGHT_REPLICA_*` | — | reserved for the replica-aware lint (#139) |
+
 ## Stability contract
 
 Symbolic error codes are **public API**:

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -159,7 +159,26 @@ the summary — any error → 7, warnings → 0 unless `--strict`.
 | `PFLIGHT_CHECKSUM_MISMATCH` | error | An applied migration's file changed after it was applied |
 | `PFLIGHT_REPLAY_FAILED` | error | (reserved) a migration failed to replay against the `--against` DB |
 | `PFLIGHT_LIVE_DEPENDENTS` | warning | (reserved) live dependents found for a replaced object |
-| `PFLIGHT_REPLICA_*` | — | reserved for the replica-aware lint (#139) |
+
+### Replica-safety codes (`PFLIGHT_REPLICA_*`, lint `replica_001`, #139)
+
+The replica-aware forward-compatibility lint emits these (severity per the
+[policy](replica-safe-migrations.md#default-severity-policy): warning by
+default, error when replicas are declared, downgraded by
+`allow_unsafe_under_replication`):
+
+| Code | Operation | Multi-step fix |
+|------|-----------|----------------|
+| `PFLIGHT_REPLICA_ADD_COLUMN` | `ADD COLUMN` NOT NULL / DEFAULT | add nullable → backfill → `SET NOT NULL` later |
+| `PFLIGHT_REPLICA_DROP_COLUMN` | `DROP COLUMN` | deprecate → wait one release → drop |
+| `PFLIGHT_REPLICA_RENAME_COLUMN` | `RENAME COLUMN` | add new → dual-write → migrate readers → drop old |
+| `PFLIGHT_REPLICA_CHANGE_TYPE` | `ALTER COLUMN ... TYPE` | add new column → backfill → swap readers → drop old |
+| `PFLIGHT_REPLICA_ADD_CONSTRAINT` | `ADD CONSTRAINT` (immediate) | `NOT VALID` → backfill → `VALIDATE` |
+| `PFLIGHT_REPLICA_CREATE_INDEX` | non-concurrent `CREATE INDEX` | `CREATE INDEX CONCURRENTLY` |
+| `PFLIGHT_REPLICA_UNCLASSIFIED` | dynamic / unparseable DDL | review manually (always a warning) |
+
+See the [replica-safe migrations guide](replica-safe-migrations.md) for the full
+rationale.
 
 ## Stability contract
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -119,6 +119,30 @@ resolution hint surfaced in the envelope.
 > print(render_error_codebook())"`; the codebook test
 > (`tests/unit/test_error_codebook.py`) fails if it drifts.
 
+## `LOCK_1300` — lock-holder identity (`details.holder`)
+
+When `migrate up`/`down`/`down-to` cannot acquire the migration lock, the
+`LOCK_1300` envelope carries the current holder under `details.holder` (issue
+#147):
+
+```json
+{ "ok": false, "error": { "code": "LOCK_1300",
+  "message": "Could not acquire migration lock within 30.0s. Held by pid 12345 on deploy-1 running \"confiture migrate up\"; acquired 47s ago.",
+  "details": { "holder": {
+    "pid": 12345, "hostname": "deploy-1", "user": "deploy",
+    "command": "confiture migrate up",
+    "acquired_at": "2026-05-31T14:30:00+00:00", "held_for_seconds": 47 } },
+  "actionable": "Wait for the current migration to finish, then retry." } }
+```
+
+Identity is recorded best-effort in a `confiture_lock_holder` metadata table
+written *under* the advisory lock. The advisory lock remains the source of truth
+for "is it held" — if the holder crashes, the advisory lock auto-releases and
+the lingering row is reported as stale. `held_for_seconds > 300` adds a
+stale-lock hint to `actionable`. When no identity is available (older holder, or
+the metadata table is absent), `details.holder` is `null` and the message says
+so — diagnostics never block a migration.
+
 ## Stability contract
 
 Symbolic error codes are **public API**:

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -1,0 +1,140 @@
+# Exit-code convention
+
+Confiture's process exit codes are a **stability contract**. Tooling that wraps
+Confiture — CI gates, deploy adapters, monitoring — branches on them, so they
+are documented here and frozen going forward (see [Stability
+contract](#stability-contract)).
+
+Every `confiture` command exits with one of the integer codes below. The
+authoritative source is the hand-authored `CANONICAL_EXIT_CODES` table in
+[`python/confiture/core/error_codes.py`](../../python/confiture/core/error_codes.py);
+the runtime reads it through `ConfiturError.exit_code`. You can print this
+reference from the CLI with `confiture --exit-codes`.
+
+> Symbolic error codes (`CONFIG_006`, `PRECON_1001`, …) are documented in
+> [error-reference.md](../error-reference.md) and surfaced in `--format json`
+> output. This document maps each symbolic code to its **integer exit code**.
+
+## Canonical table
+
+<!-- BEGIN GENERATED: confiture --exit-codes -->
+| Exit | Meaning |
+|------|---------|
+| 0 | Success (including success-with-signal: already applied, nothing pending, advisories) |
+| 1 | Generic failure (SQL/hook execution, ambiguous-change advisory, status: pending) |
+| 2 | Tracking table absent — confiture not initialized on this database yet |
+| 3 | Database connection failed — host/auth/network unreachable |
+| 4 | Schema / DDL / build error |
+| 5 | Configuration invalid, or validation / sync / lint / precondition failure |
+| 6 | Lock or connection-pool contention — another writer holds the lock |
+| 7 | Git / pgGit / grant-accompaniment error |
+| 8 | Irreversible rollback, or inconsistent state after rollback |
+
+### Symbolic codes per exit code
+
+- **0** — Success (including success-with-signal: already applied, nothing pending, advisories)
+  - LINT_1501, MIGR_101, MIGR_105
+- **1** — Generic failure (SQL/hook execution, ambiguous-change advisory, status: pending)
+  - DIFFER_402, HOOK_1100, HOOK_1101, SQL_001, SQL_700, SQL_701, SQL_702, SQL_703
+- **2** — Tracking table absent — confiture not initialized on this database yet
+  - PRECON_1001
+- **3** — Database connection failed — host/auth/network unreachable
+  - CONFIG_006, GEN_001, MIGR_001, MIGR_004, MIGR_010, MIGR_011, MIGR_100, MIGR_102, MIGR_103, MIGR_104, MIGR_106, MIGR_107
+- **4** — Schema / DDL / build error
+  - REBUILD_001, SCHEMA_001, SCHEMA_200, SCHEMA_201, SCHEMA_202, SCHEMA_203, SCHEMA_204
+- **5** — Configuration invalid, or validation / sync / lint / precondition failure
+  - ANON_1400, ANON_1401, CONFIG_001, CONFIG_002, CONFIG_003, CONFIG_004, CONFIG_005, CONFIG_010, DIFFER_400, DIFFER_401, DIFF_001, LINT_1500, PRECON_1000, RESTORE_001, SEED_001, SYNC_001, SYNC_300, SYNC_301, SYNC_302, SYNC_303, VALID_001, VALID_500, VALID_501, VALID_502, VERIFY_001
+- **6** — Lock or connection-pool contention — another writer holds the lock
+  - LOCK_1300, LOCK_1301, POOL_1200, POOL_1201
+- **7** — Git / pgGit / grant-accompaniment error
+  - GIT_001, GIT_002, GIT_800, GIT_801, GIT_802, GRANT_001, PGGIT_900, PGGIT_901
+- **8** — Irreversible rollback, or inconsistent state after rollback
+  - ROLLBACK_001, ROLLBACK_600, ROLLBACK_601, ROLLBACK_602
+<!-- END GENERATED -->
+
+> The block above is generated from `CANONICAL_EXIT_CODES` /
+> `EXIT_CODE_MEANINGS`. Regenerate with `confiture --exit-codes` after adding a
+> code; the convention test (`tests/unit/test_exit_code_convention.py`) fails if
+> the registry and the hand-authored table disagree.
+
+## Per-code carve-outs
+
+A few codes deliberately differ from their family's default number. During any
+call-site audit these are **intentional** — do not "align" them to the family
+number:
+
+| Code | Exit | Family default | Why it differs |
+|------|------|----------------|----------------|
+| `MIGR_101` (already applied) | 0 | 3 | success-with-signal, not an error |
+| `MIGR_105` (no pending migrations) | 0 | 3 | success-with-signal, not an error |
+| `LINT_1501` (lint advisory) | 0 | 5 | informational, non-blocking |
+| `DIFFER_402` (ambiguous change) | 1 | 5 | generic advisory, not a hard diff error |
+| `PRECON_1001` (tracking table absent) | 2 | 5 | the fresh-DB "not initialized yet" signal |
+| `CONFIG_006` (connection failed) | 3 | 5 | host/auth/network, distinct from config-invalid |
+
+`migrate status` additionally uses **1** for the established "pending migrations
+exist" signal and **2** for "tracking table absent" — both are
+success-with-signal exit codes specific to that command, not errors.
+
+## How the convention was decided (issue #146)
+
+Confiture 0.18.0 shipped **three incompatible** exit-code conventions: the CLI's
+de-facto literals, the `ErrorCodeRegistry`'s family mapping, and the convention
+proposed by issue #146. The decision (owner-accepted, 2026-05-31):
+
+> Keep the **`ErrorCodeRegistry` as the canonical home** for exit codes — it is
+> the one wired to the structured exception hierarchy and to
+> `ConfiturError.exit_code` — but **renumber three families** so the registry
+> *emits* the wrapper-facing convention: no-table = 2, connection failed = 3,
+> config invalid = 5. The lock family stays 6.
+
+Rationale: low numbers go to the most common operational failures (a fresh DB
+with no tracking table; an unreachable database), and the structured exception
+hierarchy stays the single source of truth. This was a **deliberate,
+documented breaking change** to `.exit_code` output, made before the downstream
+adapter shipped (so the breaking-change window was open).
+
+## Reconciliation appendix — what changed vs 0.18.0
+
+Only these codes' integer values changed. Wrappers that branched on the old
+numbers must update:
+
+| Symbolic code | Meaning | Old exit (≤0.18.0) | New exit |
+|---------------|---------|:------------------:|:--------:|
+| `PRECON_1001` | Database not initialized (tracking table absent) | 5 | **2** |
+| `CONFIG_001` | Missing required config field | 2 | **5** |
+| `CONFIG_002` | Invalid YAML syntax | 2 | **5** |
+| `CONFIG_003` | Invalid database URL format | 2 | **5** |
+| `CONFIG_004` | Environment config not found | 2 | **5** |
+| `CONFIG_005` | Invalid include/exclude pattern | 2 | **5** |
+| `CONFIG_006` | Database connection failed | 2 | **3** |
+| `CONFIG_010` | Database URL not set in environment | 2 | **5** |
+
+Migration guidance for wrapper authors:
+
+- If you branched on **exit 2 = config error**, it is now **5**.
+- **Exit 2** now means **tracking table absent** (fresh DB, no current revision).
+- **Exit 3** now distinguishes a **connection failure** from a config error.
+
+Codes that already matched the convention and did **not** change: `MIGR_106`
+(duplicate version) = 3, `ROLLBACK_600` (irreversible) = 8, the entire lock/pool
+family = 6.
+
+## Stability contract
+
+Going forward, the exit-code convention is **frozen**:
+
+- **Additive only** — new symbolic codes may map to an existing integer; new
+  integers may be introduced for genuinely new failure classes.
+- **Meaning never changes** — the integer→meaning mapping above is stable. A
+  code never silently changes which integer it exits with.
+- **Breaking changes require a major version bump** and a prominent
+  CHANGELOG old→new table.
+
+The one sanctioned break before this contract took effect was the #146
+renumbering documented in the reconciliation appendix above.
+
+## See also
+
+- [Symbolic error-code reference](../error-reference.md)
+- [JSON output schemas](json-schemas.md)

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -54,6 +54,10 @@ change without a top-level version bump.
 
 [migrate-current.schema.json](./json-schemas/migrate-current.schema.json) — `{revision, name, applied_at, checksum}` for the latest applied migration (all `null` when the tracking table is empty). An absent tracking table is an error path emitting the [error envelope](./json-schemas/error-envelope.schema.json) at exit 2.
 
+### `confiture migrate down-to <revision> --format json`
+
+[migrate-down-to.schema.json](./json-schemas/migrate-down-to.schema.json) — `{from, to, rolled_back, skipped, errors}` for an absolute rollback. An invalid plan (unknown/forward target, or a missing `.down.sql`) emits the [error envelope](./json-schemas/error-envelope.schema.json) and applies nothing.
+
 ### `confiture migrate validate --list-patterns --format json`
 
 [migrate-validate-list-patterns.schema.json](./json-schemas/migrate-validate-list-patterns.schema.json)

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -46,6 +46,10 @@ change without a top-level version bump.
 
 ## Schemas by command
 
+### Error envelope (any migrate command, `--format json` error path)
+
+[error-envelope.schema.json](./json-schemas/error-envelope.schema.json) — `{ "ok": false, "error": { … } }`, where `error` is the shared [issue-object.schema.json](./json-schemas/issue-object.schema.json). Emitted on stdout when a migrate-family command fails in JSON mode; the process exits with the matching [exit code](exit-codes.md). The full code list is the [error-code codebook](error-codes.md).
+
 ### `confiture migrate validate --list-patterns --format json`
 
 [migrate-validate-list-patterns.schema.json](./json-schemas/migrate-validate-list-patterns.schema.json)

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -50,6 +50,10 @@ change without a top-level version bump.
 
 [error-envelope.schema.json](./json-schemas/error-envelope.schema.json) — `{ "ok": false, "error": { … } }`, where `error` is the shared [issue-object.schema.json](./json-schemas/issue-object.schema.json). Emitted on stdout when a migrate-family command fails in JSON mode; the process exits with the matching [exit code](exit-codes.md). The full code list is the [error-code codebook](error-codes.md).
 
+### `confiture validate-config --format json`
+
+[validate-config.schema.json](./json-schemas/validate-config.schema.json) — `{valid, config_source, migrations_path, migration_count, issues[]}` for offline config + migrations-tree validation (#144). **Never connects to a database.** Each `issues[]` element is the shared [issue object](./json-schemas/issue-object.schema.json). Invalid config exits 5.
+
 ### `confiture migrate current --format json`
 
 [migrate-current.schema.json](./json-schemas/migrate-current.schema.json) — `{revision, name, applied_at, checksum}` for the latest applied migration (all `null` when the tracking table is empty). An absent tracking table is an error path emitting the [error envelope](./json-schemas/error-envelope.schema.json) at exit 2.

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -50,6 +50,10 @@ change without a top-level version bump.
 
 [error-envelope.schema.json](./json-schemas/error-envelope.schema.json) — `{ "ok": false, "error": { … } }`, where `error` is the shared [issue-object.schema.json](./json-schemas/issue-object.schema.json). Emitted on stdout when a migrate-family command fails in JSON mode; the process exits with the matching [exit code](exit-codes.md). The full code list is the [error-code codebook](error-codes.md).
 
+### `confiture migrate current --format json`
+
+[migrate-current.schema.json](./json-schemas/migrate-current.schema.json) — `{revision, name, applied_at, checksum}` for the latest applied migration (all `null` when the tracking table is empty). An absent tracking table is an error path emitting the [error envelope](./json-schemas/error-envelope.schema.json) at exit 2.
+
 ### `confiture migrate validate --list-patterns --format json`
 
 [migrate-validate-list-patterns.schema.json](./json-schemas/migrate-validate-list-patterns.schema.json)

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -210,7 +210,7 @@ Rewrites non-idempotent SQL files in place (or previews with `--dry-run`). Pytho
 
 [migrate-preflight.schema.json](./json-schemas/migrate-preflight.schema.json)
 
-Static preflight analysis — per-migration reversibility, transactionality, duplicate version prefixes, checksum mismatches. No DB required.
+Structured preflight report (#148): `{ok, summary, issues[]}`, where each `issues[]` element is the shared [issue object](./json-schemas/issue-object.schema.json) (`PFLIGHT_*` codes). Covers reversibility, transactionality, duplicate version prefixes, and checksum mismatches. No DB required. Errors → exit 7; warnings are non-fatal unless `--strict`. A preflight that *crashes* (config/DB error) emits the [error envelope](./json-schemas/error-envelope.schema.json) instead.
 
 ### `confiture migrate preflight --against <url> --format json`
 

--- a/docs/reference/json-schemas/error-envelope.schema.json
+++ b/docs/reference/json-schemas/error-envelope.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/error-envelope.schema.json",
+  "title": "Confiture structured error envelope",
+  "description": "Emitted on stdout by migrate-family commands in --format json mode on an error path (issue #145). The process exits with the error's exit code (see exit-codes.md). The `error` value is the shared issue object.",
+  "type": "object",
+  "required": ["ok", "error"],
+  "additionalProperties": false,
+  "properties": {
+    "ok": {
+      "const": false,
+      "description": "Always false for the error envelope."
+    },
+    "error": {
+      "$ref": "issue-object.schema.json#"
+    }
+  }
+}

--- a/docs/reference/json-schemas/issue-object.schema.json
+++ b/docs/reference/json-schemas/issue-object.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/issue-object.schema.json",
+  "title": "Confiture unified issue/error object",
+  "description": "The shared inner object embedded by every structured error/issue surface (error envelope #145, validate-config #144, preflight report #148). severity/code/message are always present; the rest are present-but-nullable. Stable contract: changes require a version bump.",
+  "type": "object",
+  "required": ["severity", "code", "message", "actionable", "details", "migration", "file", "line"],
+  "additionalProperties": false,
+  "properties": {
+    "severity": {
+      "type": "string",
+      "enum": ["error", "warning", "info"],
+      "description": "Lowercased ErrorSeverity. CRITICAL folds to \"error\" in the public contract."
+    },
+    "code": {
+      "type": "string",
+      "description": "Stable symbolic code (e.g. CONFIG_006, MIGR_106). INTERNAL_ERROR for an unexpected non-ConfiturError."
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable message."
+    },
+    "actionable": {
+      "type": ["string", "null"],
+      "description": "Suggested fix (maps from ConfiturError.resolution_hint); null when none."
+    },
+    "details": {
+      "type": "object",
+      "description": "Code-specific structured data; {} when none."
+    },
+    "migration": {
+      "type": ["string", "null"],
+      "description": "Migration version identifier when the issue is migration-specific; else null."
+    },
+    "file": {
+      "type": ["string", "null"],
+      "description": "Filesystem path when known; else null."
+    },
+    "line": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "description": "1-based line within `file` when known; else null."
+    }
+  }
+}

--- a/docs/reference/json-schemas/migrate-current.schema.json
+++ b/docs/reference/json-schemas/migrate-current.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-current.schema.json",
+  "title": "confiture migrate current --format json",
+  "description": "The latest applied migration revision (issue #141). All fields are null when the tracking table exists but is empty (exit 0). An absent tracking table is an error path that emits the error envelope (error-envelope.schema.json, exit 2), not this shape.",
+  "type": "object",
+  "required": ["revision", "name", "applied_at", "checksum"],
+  "additionalProperties": false,
+  "properties": {
+    "revision": {
+      "type": ["string", "null"],
+      "description": "Version identifier of the latest applied migration; null when none applied."
+    },
+    "name": {
+      "type": ["string", "null"],
+      "description": "Human-readable name of the latest applied migration; null when none applied."
+    },
+    "applied_at": {
+      "type": ["string", "null"],
+      "description": "ISO-8601 timestamp the migration was applied; null when none applied or unknown."
+    },
+    "checksum": {
+      "type": ["string", "null"],
+      "description": "Checksum recorded for the migration; null when none applied or recorded (e.g. baseline rows)."
+    }
+  }
+}

--- a/docs/reference/json-schemas/migrate-down-to.schema.json
+++ b/docs/reference/json-schemas/migrate-down-to.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-down-to.schema.json",
+  "title": "confiture migrate down-to <revision> --format json",
+  "description": "Plan+result of an absolute rollback (issue #142). rolled_back is newest → oldest. An invalid plan (unknown/forward target, or a missing .down.sql) is an error path that emits the error envelope (error-envelope.schema.json) and applies nothing — not this shape.",
+  "type": "object",
+  "required": ["from", "to", "rolled_back", "skipped", "errors"],
+  "additionalProperties": false,
+  "properties": {
+    "from": {
+      "type": ["string", "null"],
+      "description": "The revision that was current before the rollback; null if nothing was applied."
+    },
+    "to": {
+      "type": "string",
+      "description": "The target revision rolled back to (kept applied)."
+    },
+    "rolled_back": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Versions rolled back, newest → oldest. In --dry-run these are the versions that would be rolled back."
+    },
+    "skipped": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Versions in the computed set that were unexpectedly not applied (empty with a consistent tracking table)."
+    },
+    "errors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Runtime rollback failures during execution (empty in the happy path; distinct from the up-front missing-.down.sql refusal, which aborts before any execution)."
+    }
+  }
+}

--- a/docs/reference/json-schemas/migrate-preflight.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight.schema.json
@@ -2,18 +2,31 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://confiture.fraiseql.dev/schemas/migrate-preflight.schema.json",
   "title": "confiture migrate preflight --format json (no --against)",
-  "description": "Static preflight analysis output. Reports per-migration reversibility (.down.sql present), transactionality, duplicate version prefixes, and checksum mismatches. No database connection required.",
-  "allOf": [
-    { "$ref": "_preflight_defs.schema.json#/$defs/StaticPreflight" },
-    {
+  "description": "Structured preflight report (issue #148): {ok, summary, issues[]}. Reports per-migration reversibility (.down.sql present), transactionality, duplicate version prefixes, and checksum mismatches as a uniform issues[] of the shared issue object. No database connection required. A preflight that *crashed* (config/DB error) emits the #145 error envelope instead — branch on `issues` vs `error`.",
+  "type": "object",
+  "required": ["ok", "summary", "issues"],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "description": "False if any error-severity issue (or, under --strict, any warning)."
+    },
+    "summary": {
       "type": "object",
-      "required": ["hints"],
+      "required": ["errors", "warnings", "info", "migrations_checked"],
+      "additionalProperties": false,
       "properties": {
-        "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" },
-        "dependent_analysis": {
-          "$ref": "_preflight_defs.schema.json#/$defs/DependentAnalysis"
-        }
+        "errors": { "type": "integer", "minimum": 0 },
+        "warnings": { "type": "integer", "minimum": 0 },
+        "info": { "type": "integer", "minimum": 0 },
+        "migrations_checked": { "type": "integer", "minimum": 0 }
       }
+    },
+    "issues": {
+      "type": "array",
+      "items": { "$ref": "issue-object.schema.json#" }
+    },
+    "dependent_analysis": {
+      "$ref": "_preflight_defs.schema.json#/$defs/DependentAnalysis"
     }
-  ]
+  }
 }

--- a/docs/reference/json-schemas/validate-config.schema.json
+++ b/docs/reference/json-schemas/validate-config.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/validate-config.schema.json",
+  "title": "confiture validate-config --format json",
+  "description": "Offline config + migrations-tree validation report (issue #144). Never connects to a database. Each issues[] element is the shared issue object.",
+  "type": "object",
+  "required": ["valid", "config_source", "migrations_path", "migration_count", "issues"],
+  "additionalProperties": false,
+  "properties": {
+    "valid": {
+      "type": "boolean",
+      "description": "True if there are no error-severity issues."
+    },
+    "config_source": {
+      "type": "string",
+      "enum": ["yaml-file", "flags", "env"],
+      "description": "Where the validated config came from."
+    },
+    "migrations_path": {
+      "type": "string",
+      "description": "The migrations directory that was validated."
+    },
+    "migration_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of migration files discovered in migrations_path."
+    },
+    "issues": {
+      "type": "array",
+      "items": { "$ref": "issue-object.schema.json#" }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.18.0"
+version = "0.19.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/admin.py
+++ b/python/confiture/cli/commands/admin.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import typer
 
-from confiture.cli.helpers import console
+from confiture.cli.helpers import console, error_console
 from confiture.core.connection import create_connection
 from confiture.core.error_handler import handle_cli_error
 
@@ -149,7 +149,7 @@ def validate_profile(
         raise typer.Exit(1) from e
 
 
-def verify(
+def verify_checksums(
     migrations_dir: Path = typer.Option(
         Path("db/migrations"),
         "--migrations-dir",
@@ -171,7 +171,11 @@ def verify(
 
     Compares SHA-256 checksums of migration files against the checksums
     stored when migrations were applied. Detects if files have been
-    modified after application.
+    modified after application (file-tampering / schema-drift detection).
+
+    For *runtime correctness* (did the migrations produce the expected
+    schema/data state, via .verify.sql sidecars?) use `confiture migrate verify`
+    instead — this command checks file integrity, not runtime state.
 
     This helps prevent:
     - Silent schema drift between environments
@@ -180,13 +184,13 @@ def verify(
 
     Examples:
         # Verify all migrations
-        confiture verify
+        confiture verify-checksums
 
         # Verify with specific config
-        confiture verify --config db/environments/production.yaml
+        confiture verify-checksums --config db/environments/production.yaml
 
         # Fix checksums (update stored to match current files)
-        confiture verify --fix
+        confiture verify-checksums --fix
     """
     from confiture.core.checksum import (
         ChecksumConfig,
@@ -245,6 +249,39 @@ def verify(
     except Exception as e:
         console.print(f"[red]❌ Error: {e}[/red]")
         raise typer.Exit(1) from e
+
+
+def verify_deprecated(
+    migrations_dir: Path = typer.Option(
+        Path("db/migrations"),
+        "--migrations-dir",
+        help="Migrations directory",
+    ),
+    config: Path = typer.Option(
+        Path("db/environments/local.yaml"),
+        "--config",
+        "-c",
+        help="Configuration file",
+    ),
+    fix: bool = typer.Option(
+        False,
+        "--fix",
+        help="Update stored checksums to match current files (dangerous)",
+    ),
+) -> None:
+    """[DEPRECATED] Alias for `confiture verify-checksums`.
+
+    `confiture verify` was ambiguous with `confiture migrate verify` (runtime
+    correctness). Use `confiture verify-checksums` for file-integrity checks.
+    This alias still works for one release cycle and is removed in the next major.
+    """
+    # Warning to stderr so piped/JSON stdout consumers stay clean (#143).
+    error_console.print(
+        "[yellow]⚠️  'confiture verify' is deprecated and will be removed in a "
+        "future major release. Use 'confiture verify-checksums' for checksum "
+        "integrity (or 'confiture migrate verify' for runtime correctness).[/yellow]"
+    )
+    verify_checksums(migrations_dir=migrations_dir, config=config, fix=fix)
 
 
 def restore(

--- a/python/confiture/cli/commands/admin.py
+++ b/python/confiture/cli/commands/admin.py
@@ -358,9 +358,7 @@ def validate_config(
             database_url=database_url, migrations_path=migrations_path
         )
     elif (env_url := resolve_database_url(None, None)) is not None:
-        validator = ConfigValidator.from_env(
-            database_url=env_url, migrations_path=migrations_path
-        )
+        validator = ConfigValidator.from_env(database_url=env_url, migrations_path=migrations_path)
     else:
         validator = ConfigValidator.from_config(
             Path("db/environments/local.yaml"), migrations_path=migrations_path

--- a/python/confiture/cli/commands/admin.py
+++ b/python/confiture/cli/commands/admin.py
@@ -1,10 +1,18 @@
-"""Admin commands: install_helpers, validate_profile, verify, restore."""
+"""Admin commands: install_helpers, validate_profile, verify-checksums, restore,
+validate-config."""
 
 from pathlib import Path
 
 import typer
 
-from confiture.cli.helpers import console, error_console
+from confiture.cli.helpers import (
+    DATABASE_URL_OPTION_HELP,
+    _output_json,
+    console,
+    error_console,
+    is_json,
+    resolve_database_url,
+)
 from confiture.core.connection import create_connection
 from confiture.core.error_handler import handle_cli_error
 
@@ -282,6 +290,112 @@ def verify_deprecated(
         "integrity (or 'confiture migrate verify' for runtime correctness).[/yellow]"
     )
     verify_checksums(migrations_dir=migrations_dir, config=config, fix=fix)
+
+
+def validate_config(
+    config: Path = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Configuration file to validate (default: db/environments/local.yaml)",
+    ),
+    database_url: str = typer.Option(
+        None,
+        "--database-url",
+        "-d",
+        help=DATABASE_URL_OPTION_HELP,
+    ),
+    migrations_path: Path = typer.Option(
+        Path("db/migrations"),
+        "--migrations-path",
+        help="Migrations directory to validate (default: db/migrations)",
+    ),
+    output_format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text or json (default: text)",
+    ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help="Treat warnings as errors for exit purposes.",
+    ),
+) -> None:
+    """Validate configuration and the migrations tree — without connecting (#144).
+
+    Checks YAML/schema validity, include-dir existence, DSN *format*, and the
+    migrations tree (well-formed filenames, no duplicate versions). It never
+    opens a database connection — for DB-level checks use `migrate preflight
+    --against`.
+
+    Accepts the same connection sources as the migrate family
+    (`--config` / `--database-url` / `CONFITURE_DATABASE_URL` / `DATABASE_URL`).
+
+    EXIT CODES:
+      0 — config valid (warnings alone are non-fatal unless --strict)
+      5 — config invalid (or, under --strict, warnings present)
+
+    JSON output: {valid, config_source, migrations_path, migration_count, issues[]}.
+    """
+    from confiture.core.config_validator import ConfigValidator
+
+    if output_format not in ("text", "json"):
+        error_console.print(
+            f"[red]❌ Error: Invalid format '{output_format}'. Use 'text' or 'json'[/red]"
+        )
+        raise typer.Exit(2)
+
+    # Source selection: an explicit --config validates that YAML; a
+    # --database-url flag is validated for *format* as an issue (not raised);
+    # otherwise an env-var DSN, else the default config path. We avoid routing
+    # the flag through resolve_database_url() here so a malformed DSN surfaces
+    # as a CONFIG_003 issue rather than raising before validation.
+    if config is not None:
+        validator = ConfigValidator.from_config(config, migrations_path=migrations_path)
+    elif database_url:
+        validator = ConfigValidator.from_flags(
+            database_url=database_url, migrations_path=migrations_path
+        )
+    elif (env_url := resolve_database_url(None, None)) is not None:
+        validator = ConfigValidator.from_env(
+            database_url=env_url, migrations_path=migrations_path
+        )
+    else:
+        validator = ConfigValidator.from_config(
+            Path("db/environments/local.yaml"), migrations_path=migrations_path
+        )
+
+    report = validator.validate()
+    has_error = any(i.severity in ("error", "critical") for i in report.issues)
+    has_warning = any(i.severity == "warning" for i in report.issues)
+    exit_code = 5 if has_error or (strict and has_warning) else 0
+
+    if is_json(output_format):
+        _output_json(report.to_dict(), None, console)
+        if exit_code:
+            raise typer.Exit(exit_code)
+        return
+
+    if report.valid and not report.issues:
+        console.print(
+            f"[green]✅ Configuration valid[/green] "
+            f"({report.config_source}, {report.migration_count} migration(s))"
+        )
+        if exit_code:
+            raise typer.Exit(exit_code)
+        return
+
+    error_console.print(f"[red]❌ Configuration issues ({report.config_source}):[/red]")
+    for issue in report.issues:
+        color = "red" if issue.severity in ("error", "critical") else "yellow"
+        error_console.print(
+            f"  [{color}]{issue.severity.upper()}[/{color}] {issue.code}: {issue.message}"
+        )
+        if issue.actionable:
+            error_console.print(f"    [dim]💡 {issue.actionable}[/dim]")
+    if exit_code:
+        raise typer.Exit(exit_code)
 
 
 def restore(

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import typer
 
+from confiture.cli.error_json import fail
 from confiture.cli.formatters.common import display_drift_report, display_signature_drift_report
 from confiture.cli.helpers import (
     DATABASE_URL_OPTION_HELP,
@@ -18,6 +19,7 @@ from confiture.cli.helpers import (
     _validate_idempotency,
     console,
     error_console,
+    is_json,
 )
 from confiture.core._migrator.session import MigratorSession
 from confiture.core.connection import create_connection, load_config, open_connection
@@ -1598,6 +1600,8 @@ def migrate_verify(
     except typer.Exit:
         raise
     except Exception as e:
+        if is_json(format_output):
+            fail(e, json_mode=True, output_file=output_file)
         error_console.print(f"[red]Verify failed: {e}[/red]")
         raise typer.Exit(1) from e
 
@@ -2504,6 +2508,8 @@ def migrate_preflight(
             database_url_override=resolve_database_url(database_url, config),
         )
     except Exception as e:
+        if is_json(format_type):
+            fail(e, json_mode=True, output_file=None)
         error_console.print(f"[red]❌ Failed to resolve pending migrations: {e}[/red]")
         raise typer.Exit(2) from e
 

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -2125,7 +2125,9 @@ def _resolve_preflight_pending(
     """Return migration files to test in a preflight --against run.
 
     Priority order:
-    1. --database-url / env override: connect to that DB, return pending files.
+    1. --database-url override (explicit flag only): connect to that DB, return
+       pending files. Ambient env vars do not reach here — the caller passes a
+       value only for an explicit flag (issue #140 precedence).
     2. --config / --env: connect to configured DB, return pending files.
     3. --since: all local files with version >= since (no DB required).
     4. Neither: all local migration files.
@@ -2547,7 +2549,13 @@ def migrate_preflight(
             config_path=config,
             env_name=env,
             since=since,
-            database_url_override=resolve_database_url(database_url, config),
+            # Flag-only: an explicit --database-url drives pending-detection, but
+            # an ambient CONFITURE_DATABASE_URL / DATABASE_URL must NOT silently
+            # flip "--against alone → all local files" into a tracking-DB connect
+            # (issue #140 precedence; matches `migrate status`/`verify`).
+            database_url_override=(
+                resolve_database_url(database_url, None) if database_url else None
+            ),
         )
     except Exception as e:
         if is_json(format_type):

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -1561,8 +1561,12 @@ def migrate_verify(
     from confiture.models.results import VerifyAllResult
 
     try:
-        # Connection source (#140): --database-url / env override wins over --config.
-        _db_url_override = resolve_database_url(database_url, config)
+        # Connection source (#140): an explicit --database-url flag or --config.
+        # An ambient DATABASE_URL env var must NOT satisfy the "config required"
+        # check — only an explicit source does. (#140 / CI regression fix)
+        _db_url_override = (
+            resolve_database_url(database_url, None) if database_url else None
+        )
         if _db_url_override is not None:
             config_data: Any = {"database_url": _db_url_override}
         elif config and config.exists():

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -2089,6 +2089,31 @@ def _target_tracking_table_is_empty(session: MigratorSession) -> bool:
         return True
 
 
+def _preflight_replica_policy(
+    config: Path | None, env_name: str | None
+) -> tuple[bool, bool]:
+    """Best-effort (has_replicas, bypass) for the replica lint, never connects.
+
+    Reads ``infrastructure.replicas`` and ``migration.allow_unsafe_under_replication``
+    from --env or --config when available; otherwise defaults to (False, False)
+    — no replicas declared, so the replica lint warns rather than errors (#139).
+    """
+    try:
+        from confiture.config.environment import Environment
+
+        if env_name:
+            e = Environment.load(env_name)
+        elif config is not None and config.exists():
+            from confiture.core.connection import load_config
+
+            e = Environment.model_validate(load_config(config))
+        else:
+            return False, False
+        return bool(e.infrastructure.replicas), bool(e.migration.allow_unsafe_under_replication)
+    except Exception:  # noqa: BLE001 — policy degrades to warn-by-default
+        return False, False
+
+
 def _resolve_preflight_pending(
     migrations_dir: Path,
     *,
@@ -2421,6 +2446,7 @@ def migrate_preflight(
     """
     from rich.table import Table
 
+    from confiture.core.linting.libraries.replica import replica_preflight_issues
     from confiture.core.preflight import preflight_exit_code, run_preflight
 
     if check_dependents not in {"off", "fail", "warn"}:
@@ -2443,13 +2469,27 @@ def migrate_preflight(
                 "skip_reason": "no_preflight_db",
             }
 
-        # #148: structured report — {ok, summary, issues[]}; exit 7 on errors
-        # (or warnings under --strict), exit 0 otherwise.
-        summary = result.summary
+        # #148 structured report + #139 replica-safety: merge the base preflight
+        # issues with the replica-forward-compat findings (PFLIGHT_REPLICA_*).
+        _has_replicas, _replica_bypass = _preflight_replica_policy(config, env)
+        replica_issues = replica_preflight_issues(
+            migrations_dir, has_replicas=_has_replicas, bypass=_replica_bypass
+        )
+        all_issues = result.issues + replica_issues
+        summary = {
+            "errors": sum(1 for i in all_issues if i.severity in ("error", "critical")),
+            "warnings": sum(1 for i in all_issues if i.severity == "warning"),
+            "info": sum(1 for i in all_issues if i.severity == "info"),
+            "migrations_checked": len(result.migrations),
+        }
         exit_code = preflight_exit_code(summary, strict=strict)
 
         if format_type == "json":
-            payload = result.to_report_dict(strict=strict)
+            payload = {
+                "ok": exit_code == 0,
+                "summary": summary,
+                "issues": [i.to_dict() for i in all_issues],
+            }
             if dependent_skip_payload is not None:
                 payload["dependent_analysis"] = dependent_skip_payload
             _output_json(payload, None, console)
@@ -2477,7 +2517,7 @@ def migrate_preflight(
             f"{summary['errors']} error(s), {summary['warnings']} warning(s)"
         )
 
-        issues = result.issues
+        issues = all_issues
         if not issues:
             console.print("  [green]✓ No issues[/green]")
         for issue in issues:

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -9,6 +9,7 @@ import typer
 
 from confiture.cli.formatters.common import display_drift_report, display_signature_drift_report
 from confiture.cli.helpers import (
+    DATABASE_URL_OPTION_HELP,
     _emit_hint,
     _fix_idempotency,
     _fix_ownership,
@@ -1502,6 +1503,12 @@ def migrate_verify(
         "-c",
         help="Configuration file path",
     ),
+    database_url: str | None = typer.Option(
+        None,
+        "--database-url",
+        "-d",
+        help=DATABASE_URL_OPTION_HELP,
+    ),
     version: str | None = typer.Option(
         None,
         "--version",
@@ -1541,18 +1548,24 @@ def migrate_verify(
       confiture migrate up      - Apply pending migrations
     """
     from confiture.cli.formatters.migrate_formatter import format_verify_results
-    from confiture.cli.helpers import _get_tracking_table
+    from confiture.cli.helpers import _get_tracking_table, resolve_database_url
     from confiture.core.connection import create_connection, load_config
     from confiture.core.migration_verifier import MigrationVerifier
     from confiture.core.migrator import Migrator
     from confiture.models.results import VerifyAllResult
 
     try:
-        if not config or not config.exists():
-            error_console.print("[red]Config file required for migrate verify[/red]")
+        # Connection source (#140): --database-url / env override wins over --config.
+        _db_url_override = resolve_database_url(database_url, config)
+        if _db_url_override is not None:
+            config_data: Any = {"database_url": _db_url_override}
+        elif config and config.exists():
+            config_data = load_config(str(config))
+        else:
+            error_console.print(
+                "[red]Config file or --database-url required for migrate verify[/red]"
+            )
             raise typer.Exit(1)
-
-        config_data = load_config(str(config))
         tracking_table = _get_tracking_table(config_data)
 
         conn = create_connection(config_data)
@@ -2074,19 +2087,24 @@ def _resolve_preflight_pending(
     config_path: Path | None,
     env_name: str | None,
     since: str | None,
+    database_url_override: str | None = None,
 ) -> list[Path]:
     """Return migration files to test in a preflight --against run.
 
     Priority order:
-    1. --config / --env: connect to configured DB, return pending files.
-    2. --since: all local files with version >= since (no DB required).
-    3. Neither: all local migration files.
+    1. --database-url / env override: connect to that DB, return pending files.
+    2. --config / --env: connect to configured DB, return pending files.
+    3. --since: all local files with version >= since (no DB required).
+    4. Neither: all local migration files.
     """
-    if config_path is not None or env_name is not None:
+    if database_url_override is not None or config_path is not None or env_name is not None:
         from confiture.cli.helpers import _get_tracking_table, _resolve_config  # noqa: PLC0415
 
-        resolved = _resolve_config(config_path or Path("confiture.yaml"), env_name)
-        config_data = load_config(resolved)
+        if database_url_override is not None:
+            config_data: Any = {"database_url": database_url_override}
+        else:
+            resolved = _resolve_config(config_path or Path("confiture.yaml"), env_name)
+            config_data = load_config(resolved)
         conn = create_connection(config_data)
         try:
             migrator = Migrator(
@@ -2280,6 +2298,17 @@ def migrate_preflight(
             "Connects to the configured database to read the tracking table."
         ),
     ),
+    database_url: str | None = typer.Option(
+        None,
+        "--database-url",
+        "-d",
+        help=(
+            "PostgreSQL DSN of the tracking database for pending-migration "
+            "detection (distinct from --against, which is the throwaway target). "
+            "Takes precedence over --config / --env and the CONFITURE_DATABASE_URL "
+            "/ DATABASE_URL env vars."
+        ),
+    ),
     env: str | None = typer.Option(
         None,
         "--env",
@@ -2465,11 +2494,14 @@ def migrate_preflight(
 
     # --against path: static analysis + exhaustive execution against preflight DB.
     try:
+        from confiture.cli.helpers import resolve_database_url  # noqa: PLC0415
+
         pending_files = _resolve_preflight_pending(
             migrations_dir=migrations_dir,
             config_path=config,
             env_name=env,
             since=since,
+            database_url_override=resolve_database_url(database_url, config),
         )
     except Exception as e:
         error_console.print(f"[red]❌ Failed to resolve pending migrations: {e}[/red]")

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -1529,11 +1529,15 @@ def migrate_verify(
         help="Save output to file (default: stdout)",
     ),
 ) -> None:
-    """Verify applied migrations using .verify.sql sidecar files.
+    """Verify applied migrations using .verify.sql sidecar files (runtime correctness).
 
     Each .verify.sql file contains a SELECT query that returns a truthy value
     when the migration was applied correctly. Queries run inside SAVEPOINT
     (read-only, no side effects).
+
+    This checks *runtime correctness* — did the migrations produce the expected
+    schema/data state? For *file-checksum integrity* (have applied migration
+    files been modified since?) use `confiture verify-checksums` instead.
 
     EXAMPLES:
       confiture migrate verify -c db/environments/local.yaml

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -2347,6 +2347,11 @@ def migrate_preflight(
             "Requires the [ast] extra (pglast)."
         ),
     ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help="Treat warnings as errors for exit purposes (warnings → exit 7).",
+    ),
 ) -> None:
     """Check if pending migrations are safe to deploy.
 
@@ -2396,10 +2401,14 @@ def migrate_preflight(
       confiture migrate preflight --against postgresql://localhost/myapp_preflight --format json
         ↳ Output static + execution results as JSON
 
-    EXIT CODES:
-      0 — all migrations safe to deploy (skipped non-transactional migrations are neutral)
-      1 — one or more issues detected or execution failures
-      2 — config or connection error
+    EXIT CODES (default, no --against — the structured report, issue #148):
+      0 — no error-severity issues (warnings alone are non-fatal unless --strict)
+      7 — one or more error-severity issues (or, under --strict, any warning)
+      A preflight that *crashes* (config/DB error) exits per the #146 convention
+      (e.g. 5 config invalid, 3 connection failed) with the #145 error envelope.
+
+    With --against (execution replay):
+      0 — all replays passed; 1 — a replay failed; config/connection errors per #146.
 
     JSON SCHEMA:
       See docs/reference/json-schemas.md for the JSON output schemas:
@@ -2408,7 +2417,7 @@ def migrate_preflight(
     """
     from rich.table import Table
 
-    from confiture.core.preflight import run_preflight
+    from confiture.core.preflight import preflight_exit_code, run_preflight
 
     if check_dependents not in {"off", "fail", "warn"}:
         error_console.print(
@@ -2430,14 +2439,18 @@ def migrate_preflight(
                 "skip_reason": "no_preflight_db",
             }
 
+        # #148: structured report — {ok, summary, issues[]}; exit 7 on errors
+        # (or warnings under --strict), exit 0 otherwise.
+        summary = result.summary
+        exit_code = preflight_exit_code(summary, strict=strict)
+
         if format_type == "json":
-            payload = result.to_dict()
+            payload = result.to_report_dict(strict=strict)
             if dependent_skip_payload is not None:
                 payload["dependent_analysis"] = dependent_skip_payload
-            payload["hints"] = []
             _output_json(payload, None, console)
-            if not result.safe_to_deploy:
-                raise typer.Exit(1)
+            if exit_code:
+                raise typer.Exit(exit_code)
             return
 
         table = Table(title="Pre-flight Check")
@@ -2455,45 +2468,30 @@ def migrate_preflight(
             table.add_row(m.version, m.name, rev, txn)
 
         console.print(table)
-        console.print(f"\nSummary: {len(result.migrations)} migrations checked")
+        console.print(
+            f"\nSummary: {summary['migrations_checked']} migration(s) checked, "
+            f"{summary['errors']} error(s), {summary['warnings']} warning(s)"
+        )
 
-        if result.irreversible:
+        issues = result.issues
+        if not issues:
+            console.print("  [green]✓ No issues[/green]")
+        for issue in issues:
+            color = "red" if issue.severity == "error" else "yellow"
             console.print(
-                f"  [red]✗[/red] {len(result.irreversible)} irreversible (missing .down.sql)"
+                f"  [{color}]{issue.severity.upper()}[/{color}] {issue.code}: {issue.message}"
             )
-        else:
-            console.print("  [green]✓[/green] All reversible")
-
-        if result.non_transactional:
-            total_stmts = sum(len(m.non_transactional_statements) for m in result.non_transactional)
-            console.print(f"  [red]✗[/red] {total_stmts} non-transactional statements")
-        else:
-            console.print("  [green]✓[/green] All transactional")
-
-        if result.has_duplicates:
-            console.print(f"  [red]✗[/red] {len(result.duplicate_versions)} duplicate version(s)")
-        else:
-            console.print("  [green]✓[/green] No duplicate versions")
-
-        if result.checksum_verified:
-            if result.has_checksum_mismatches:
-                console.print(
-                    f"  [red]✗[/red] {len(result.checksum_mismatches)} checksum mismatch(es)"
-                )
-            else:
-                console.print("  [green]✓[/green] Checksums verified")
-
-        if result.safe_to_deploy:
-            console.print("  [green]→ Safe to deploy[/green]")
-        else:
-            console.print("  [red]→ Not safe to deploy with rollback guarantee[/red]")
-            raise typer.Exit(1)
+            if issue.actionable:
+                console.print(f"    [dim]💡 {issue.actionable}[/dim]")
 
         if check_dependents != "off":
             console.print(
                 "[yellow]⚠️  Dependent check skipped: no preflight DB configured. "
                 "Pass --against <url> to enable.[/yellow]"
             )
+
+        if exit_code:
+            raise typer.Exit(exit_code)
         return
 
     # --against path: static analysis + exhaustive execution against preflight DB.

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -2089,9 +2089,7 @@ def _target_tracking_table_is_empty(session: MigratorSession) -> bool:
         return True
 
 
-def _preflight_replica_policy(
-    config: Path | None, env_name: str | None
-) -> tuple[bool, bool]:
+def _preflight_replica_policy(config: Path | None, env_name: str | None) -> tuple[bool, bool]:
     """Best-effort (has_replicas, bypass) for the replica lint, never connects.
 
     Reads ``infrastructure.replicas`` and ``migration.allow_unsafe_under_replication``

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -1564,9 +1564,7 @@ def migrate_verify(
         # Connection source (#140): an explicit --database-url flag or --config.
         # An ambient DATABASE_URL env var must NOT satisfy the "config required"
         # check — only an explicit source does. (#140 / CI regression fix)
-        _db_url_override = (
-            resolve_database_url(database_url, None) if database_url else None
-        )
+        _db_url_override = resolve_database_url(database_url, None) if database_url else None
         if _db_url_override is not None:
             config_data: Any = {"database_url": _db_url_override}
         elif config and config.exists():

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -168,7 +168,11 @@ def migrate_status(
         db_error: str | None = None
         tracking_table_absent: bool = False
         status_tracking_table: str | None = None
-        _db_url_override = resolve_database_url(database_url, config)
+        # status only connects when a source is *explicitly* given: a
+        # --database-url flag or an existing --config. An ambient DATABASE_URL
+        # env var must NOT force a connection here — "no config" stays the
+        # informative status-unknown state (exit 0). (#140 / CI regression fix)
+        _db_url_override = resolve_database_url(database_url, None) if database_url else None
         _status_config_data: Any = None
         if _db_url_override is not None:
             _status_config_data = {"database_url": _db_url_override}

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import typer
 
+from confiture.cli.error_json import fail
 from confiture.cli.helpers import (
     DATABASE_URL_OPTION_HELP,
     _emit_hint,
@@ -16,6 +17,7 @@ from confiture.cli.helpers import (
     _print_orphaned_files_warning,
     console,
     error_console,
+    is_json,
     resolve_database_url,
 )
 from confiture.core.error_handler import handle_cli_error, print_error_to_console
@@ -418,8 +420,10 @@ def migrate_status(
 
     except Exception as e:
         if output_format == "json":
-            result = {"error": str(e)}
-            _output_json(result, output_file, console)
+            # #145: a genuinely unexpected status failure emits the structured
+            # error envelope (the informative no-table/pending payloads above are
+            # emitted on their own paths and are not errors).
+            fail(e, json_mode=True, output_file=output_file)
         elif output_format == "csv":
             from confiture.cli.formatters.common import handle_output
 
@@ -667,6 +671,21 @@ def migrate_up(
 
         _up_duplicates = find_duplicate_migration_versions(migrations_dir)
         if _up_duplicates:
+            if is_json(format_output):
+                from confiture.exceptions import MigrationConflictError
+
+                _dupe_files = sorted(
+                    f.name for files in _up_duplicates.values() for f in files
+                )
+                fail(
+                    MigrationConflictError(
+                        "Duplicate migration versions detected: "
+                        + ", ".join(sorted(_up_duplicates)),
+                        conflicting_files=_dupe_files,
+                    ),
+                    json_mode=True,
+                    output_file=output_file,
+                )
             error_console.print(
                 "[red]❌ Duplicate migration versions detected — refusing to proceed[/red]"
             )
@@ -1103,6 +1122,15 @@ def migrate_up(
                             break
 
         except LockAcquisitionError as e:
+            conn.close()
+            if is_json(format_output):
+                from confiture.exceptions import ConfiturError
+
+                fail(
+                    ConfiturError(str(e), error_code="LOCK_1300"),
+                    json_mode=True,
+                    output_file=output_file,
+                )
             print_error_to_console(e, error_console)
             if e.timeout:
                 error_console.print(
@@ -1112,7 +1140,6 @@ def migrate_up(
                 error_console.print(
                     "[yellow]💡 Tip: Check if another migration is running, or use --no-lock (dangerous)[/yellow]"
                 )
-            conn.close()
             raise typer.Exit(6) from e
 
         # Handle results
@@ -1176,6 +1203,8 @@ def migrate_up(
         # Already handled above
         raise
     except Exception as e:
+        if is_json(format_output):
+            fail(e, json_mode=True, output_file=output_file)
         print_error_to_console(e, error_console)
         raise typer.Exit(handle_cli_error(e)) from e
 
@@ -1434,6 +1463,8 @@ def migrate_down(
     except typer.Exit:
         raise
     except Exception as e:
+        if is_json(format_output):
+            fail(e, json_mode=True, output_file=output_file)
         print_error_to_console(e, error_console)
         raise typer.Exit(handle_cli_error(e)) from e
 

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -1572,6 +1572,109 @@ def migrate_down(
         raise typer.Exit(handle_cli_error(e)) from e
 
 
+def migrate_down_to(
+    revision: str = typer.Argument(
+        ...,
+        help="Target revision to roll back to (stays applied). Use 'migrate current' to find it.",
+    ),
+    migrations_dir: Path = typer.Option(
+        Path("db/migrations"),
+        "--migrations-dir",
+        help="Migrations directory (default: db/migrations)",
+    ),
+    config: Path = typer.Option(
+        Path("db/environments/local.yaml"),
+        "--config",
+        "-c",
+        help="Configuration file (default: db/environments/local.yaml)",
+    ),
+    database_url: str = typer.Option(
+        None,
+        "--database-url",
+        "-d",
+        help=DATABASE_URL_OPTION_HELP,
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the rollback plan and exit 0 without applying anything.",
+    ),
+    format_output: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text or json (default: text)",
+    ),
+    output_file: Path | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Save output to file (default: stdout)",
+    ),
+) -> None:
+    """Roll back every migration newer than <revision> (absolute rollback).
+
+    The absolute counterpart to ``migrate down --steps N``: instead of a
+    relative count, name the revision to return to. Confiture computes the
+    rollback set, validates that every required ``.down.sql`` exists *before*
+    touching the database, and rolls back newest→oldest under the migration
+    lock. If any required ``.down.sql`` is missing, it refuses atomically —
+    nothing is rolled back.
+
+    EDGE CASES:
+      <revision> == current      → no-op, exit 0 ("already at <revision>")
+      <revision> newer than current → exit 3 ("use 'migrate up --target'")
+      <revision> unknown         → exit 3 ("unknown revision")
+      any required .down.sql missing → exit 8, nothing applied (ROLLBACK_600)
+
+    OUTPUT (--format json): {from, to, rolled_back, skipped, errors}
+
+    EXAMPLES:
+      confiture migrate down-to 20260101_a -c db/environments/staging.yaml
+      confiture migrate down-to 20260101_a --dry-run --format json
+    """
+    from confiture.core.migrator import Migrator, MigratorSession
+
+    if format_output not in ("text", "json"):
+        error_console.print(
+            f"[red]❌ Error: Invalid format '{format_output}'. Use 'text' or 'json'[/red]"
+        )
+        raise typer.Exit(2)
+
+    try:
+        override = resolve_database_url(database_url, config)
+        if override is not None:
+            session = MigratorSession(
+                config=None,
+                migrations_dir=migrations_dir,
+                database_url_override=override,
+            )
+        else:
+            session = Migrator.from_config(str(config), migrations_dir=migrations_dir)
+        with session as s:
+            result = s.down_to(revision, dry_run=dry_run)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if is_json(format_output):
+            fail(e, json_mode=True, output_file=output_file)
+        print_error_to_console(e, error_console)
+        raise typer.Exit(handle_cli_error(e)) from e
+
+    if is_json(format_output):
+        _output_json(result.to_dict(), output_file, console)
+    elif result.noop:
+        console.print(f"Already at {revision}; nothing to roll back.")
+    else:
+        verb = "Would roll back" if dry_run else "Rolled back"
+        console.print(
+            f"{verb} {len(result.rolled_back)} migration(s) "
+            f"from {result.from_} to {revision}:"
+        )
+        for v in result.rolled_back:
+            console.print(f"  • {v}")
+
+
 def migrate_generate(
     name: str = typer.Argument(..., help="Migration name (snake_case)"),
     migrations_dir: Path = typer.Option(

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -444,6 +444,109 @@ def migrate_status(
         raise typer.Exit(1)
 
 
+def migrate_current(
+    config: Path = typer.Option(
+        Path("db/environments/local.yaml"),
+        "--config",
+        "-c",
+        help="Configuration file (default: db/environments/local.yaml)",
+    ),
+    database_url: str = typer.Option(
+        None,
+        "--database-url",
+        "-d",
+        help=DATABASE_URL_OPTION_HELP,
+    ),
+    output_format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text or json (default: text)",
+    ),
+    output_file: Path | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Save output to file (default: stdout)",
+    ),
+) -> None:
+    """Print the current (latest applied) migration revision.
+
+    Reads the tracking table and reports the most-recently-applied migration.
+    A narrow, stable contract for tooling — no need to parse `migrate status`.
+
+    OUTPUT:
+      text  — the bare revision string (empty line if none applied)
+      json  — {revision, name, applied_at, checksum}; revision is null when
+              the tracking table exists but is empty.
+
+    EXIT CODES:
+      0  Current revision printed (or null when the table is empty).
+      2  Tracking table absent — confiture not initialized on this database.
+      3  Database connection failed.
+
+    EXAMPLES:
+      confiture migrate current -c db/environments/prod.yaml
+      confiture migrate current --database-url "$DATABASE_URL" --format json
+    """
+    from confiture.core.connection import create_connection, load_config
+    from confiture.core.migrator import Migrator
+    from confiture.exceptions import DatabaseNotInitializedError
+    from confiture.models.results import CurrentRevision
+
+    if output_format not in ("text", "json"):
+        error_console.print(
+            f"[red]❌ Error: Invalid format '{output_format}'. Use 'text' or 'json'[/red]"
+        )
+        raise typer.Exit(2)
+
+    try:
+        override = resolve_database_url(database_url, config)
+        config_data = {"database_url": override} if override is not None else load_config(config)
+        conn = create_connection(config_data)
+        try:
+            migrator = Migrator(
+                connection=conn, migration_table=_get_tracking_table(config_data)
+            )
+            # Probe first: the row query raises on an absent table (≠ empty).
+            if not migrator.tracking_table_exists():
+                raise DatabaseNotInitializedError(
+                    "Database not initialized (tracking table absent)"
+                )
+            row = migrator.get_current_revision_row()
+        finally:
+            conn.close()
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if is_json(output_format):
+            fail(e, json_mode=True, output_file=output_file)
+        print_error_to_console(e, error_console)
+        raise typer.Exit(handle_cli_error(e)) from e
+
+    cur = (
+        None
+        if row is None
+        else CurrentRevision(
+            version=row["version"],
+            name=row["name"],
+            applied_at=row["applied_at"],
+            checksum=row.get("checksum"),
+        )
+    )
+
+    if is_json(output_format):
+        payload = (
+            {"revision": None, "name": None, "applied_at": None, "checksum": None}
+            if cur is None
+            else cur.to_dict()
+        )
+        _output_json(payload, output_file, console)
+    else:
+        # Bare revision on stdout (plain print avoids Rich markup interpretation).
+        print(cur.version if cur is not None else "")
+
+
 def migrate_up(
     migrations_dir: Path = typer.Option(
         Path("db/migrations"),

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -7,6 +7,7 @@ from typing import Any
 import typer
 
 from confiture.cli.helpers import (
+    DATABASE_URL_OPTION_HELP,
     _emit_hint,
     _find_orphaned_sql_files,
     _get_tracking_table,
@@ -15,6 +16,7 @@ from confiture.cli.helpers import (
     _print_orphaned_files_warning,
     console,
     error_console,
+    resolve_database_url,
 )
 from confiture.core.error_handler import handle_cli_error, print_error_to_console
 from confiture.core.migration_generator import MigrationGenerator
@@ -32,6 +34,12 @@ def migrate_status(
         "-c",
         help="Config file for database connection. Must appear after 'status': "
         "confiture migrate status -c config.yaml",
+    ),
+    database_url: str = typer.Option(
+        None,
+        "--database-url",
+        "-d",
+        help=DATABASE_URL_OPTION_HELP,
     ),
     output_format: str = typer.Option(
         "table",
@@ -151,18 +159,28 @@ def migrate_status(
                     _print_orphaned_files_warning(orphaned_sql_files, console)
             return
 
-        # Get applied migrations from database if config provided
+        # Get applied migrations from database if a connection source is given.
+        # Precedence (#140): --database-url / env override > --config file.
         applied_versions: set[str] = set()
         applied_at_by_version: dict[str, Any] = {}
         db_error: str | None = None
         tracking_table_absent: bool = False
         status_tracking_table: str | None = None
-        if config and config.exists():
+        _db_url_override = resolve_database_url(database_url, config)
+        _status_config_data: Any = None
+        if _db_url_override is not None:
+            _status_config_data = {"database_url": _db_url_override}
+        elif config and config.exists():
+            from confiture.core.connection import load_config
+
+            _status_config_data = load_config(config)
+        _db_source = _status_config_data is not None
+        if _db_source:
             try:
-                from confiture.core.connection import create_connection, load_config
+                from confiture.core.connection import create_connection
                 from confiture.core.migrator import Migrator
 
-                config_data = load_config(config)
+                config_data = _status_config_data
                 status_tracking_table = _get_tracking_table(config_data)
                 conn = create_connection(config_data)
                 migrator = Migrator(connection=conn, migration_table=status_tracking_table)
@@ -197,7 +215,7 @@ def migrate_status(
             name = parts[1] if len(parts) > 1 else base_name
 
             # Determine status
-            if config and config.exists() and not db_error:
+            if _db_source and not db_error:
                 # tracking_table_absent: table was missing → all migrations are pending
                 # (confiture has not been set up on this database yet)
                 if tracking_table_absent or version not in applied_versions:
@@ -388,11 +406,10 @@ def migrate_status(
                     )
 
         # Set exit flags after output is written (avoids raising inside try)
-        if config and config.exists() and db_error:
+        if _db_source and db_error:
             fatal_error_exit = True
         elif (
-            config
-            and config.exists()
+            _db_source
             and not db_error
             and not tracking_table_absent
             and len(pending_list) > 0
@@ -434,6 +451,12 @@ def migrate_up(
         "--config",
         "-c",
         help="Configuration file (default: db/environments/local.yaml)",
+    ),
+    database_url: str = typer.Option(
+        None,
+        "--database-url",
+        "-d",
+        help=DATABASE_URL_OPTION_HELP,
     ),
     target: str = typer.Option(
         None,
@@ -662,13 +685,19 @@ def migrate_up(
             )
             raise typer.Exit(3)
 
-        # Load configuration
-        config_data = load_config(config)
+        # Load configuration — a --database-url / env override (#140) wins over
+        # the --config file and skips YAML loading entirely.
+        _db_url_override = resolve_database_url(database_url, config)
+        if _db_url_override is not None:
+            config_data = {"database_url": _db_url_override}
+        else:
+            config_data = load_config(config)
 
         # Try to load environment config for migration settings
         effective_strict_mode = strict
         if (
-            not strict
+            _db_url_override is None
+            and not strict
             and config.parent.name == "environments"
             and config.parent.parent.name == "db"
         ):
@@ -1163,6 +1192,12 @@ def migrate_down(
         "-c",
         help="Configuration file (default: db/environments/local.yaml)",
     ),
+    database_url: str = typer.Option(
+        None,
+        "--database-url",
+        "-d",
+        help=DATABASE_URL_OPTION_HELP,
+    ),
     steps: int = typer.Option(
         1,
         "--steps",
@@ -1242,8 +1277,13 @@ def migrate_down(
             )
             raise typer.Exit(2)
 
-        # Load configuration
-        config_data = load_config(config)
+        # Load configuration — a --database-url / env override (#140) wins over
+        # the --config file and skips YAML loading entirely.
+        _db_url_override = resolve_database_url(database_url, config)
+        if _db_url_override is not None:
+            config_data = {"database_url": _db_url_override}
+        else:
+            config_data = load_config(config)
 
         # Create database connection
         conn = create_connection(config_data)

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -410,12 +410,7 @@ def migrate_status(
         # Set exit flags after output is written (avoids raising inside try)
         if _db_source and db_error:
             fatal_error_exit = True
-        elif (
-            _db_source
-            and not db_error
-            and not tracking_table_absent
-            and len(pending_list) > 0
-        ):
+        elif _db_source and not db_error and not tracking_table_absent and len(pending_list) > 0:
             pending_migrations_exit = True
 
     except Exception as e:
@@ -505,9 +500,7 @@ def migrate_current(
         config_data = {"database_url": override} if override is not None else load_config(config)
         conn = create_connection(config_data)
         try:
-            migrator = Migrator(
-                connection=conn, migration_table=_get_tracking_table(config_data)
-            )
+            migrator = Migrator(connection=conn, migration_table=_get_tracking_table(config_data))
             # Probe first: the row query raises on an absent table (≠ empty).
             if not migrator.tracking_table_exists():
                 raise DatabaseNotInitializedError(
@@ -777,9 +770,7 @@ def migrate_up(
             if is_json(format_output):
                 from confiture.exceptions import MigrationConflictError
 
-                _dupe_files = sorted(
-                    f.name for files in _up_duplicates.values() for f in files
-                )
+                _dupe_files = sorted(f.name for files in _up_duplicates.values() for f in files)
                 fail(
                     MigrationConflictError(
                         "Duplicate migration versions detected: "
@@ -1558,9 +1549,7 @@ def migrate_down(
                 rolled_back_count = 0
                 for version in reversed(versions_to_rollback):
                     # Find migration file
-                    migration_files = migrator.find_migration_files(
-                        migrations_dir=migrations_dir
-                    )
+                    migration_files = migrator.find_migration_files(migrations_dir=migrations_dir)
                     migration_file = None
                     for mf in migration_files:
                         if migrator._version_from_filename(mf.name) == version:
@@ -1704,8 +1693,7 @@ def migrate_down_to(
     else:
         verb = "Would roll back" if dry_run else "Rolled back"
         console.print(
-            f"{verb} {len(result.rolled_back)} migration(s) "
-            f"from {result.from_} to {revision}:"
+            f"{verb} {len(result.rolled_back)} migration(s) from {result.from_} to {revision}:"
         )
         for v in result.rolled_back:
             console.print(f"  • {v}")

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -1121,10 +1121,11 @@ def migrate_up(
                 conn.close()
                 raise typer.Exit(1) from e
 
-        # Configure locking
+        # Configure locking (command recorded in the lock-holder metadata, #147)
         lock_config = LockConfig(
             enabled=not no_lock,
             timeout_ms=lock_timeout,
+            command="confiture migrate up",
         )
 
         # Create lock manager
@@ -1227,10 +1228,11 @@ def migrate_up(
         except LockAcquisitionError as e:
             conn.close()
             if is_json(format_output):
-                from confiture.exceptions import ConfiturError
+                from confiture.cli.error_json import lock_error_to_confiture
 
+                # LOCK_1300 envelope enriched with holder identity (#147).
                 fail(
-                    ConfiturError(str(e), error_code="LOCK_1300"),
+                    lock_error_to_confiture(e),
                     json_mode=True,
                     output_file=output_file,
                 )
@@ -1341,6 +1343,16 @@ def migrate_down(
         "--dry-run",
         help="Analyze rollback without executing (default: off)",
     ),
+    lock_timeout: int = typer.Option(
+        30000,
+        "--lock-timeout",
+        help="Lock timeout in milliseconds (default: 30000ms)",
+    ),
+    no_lock: bool = typer.Option(
+        False,
+        "--no-lock",
+        help="Disable migration locking (default: off, DANGEROUS in multi-pod)",
+    ),
     verbose: bool = typer.Option(
         False,
         "--verbose",
@@ -1399,6 +1411,7 @@ def migrate_down(
         load_config,
         load_migration_class,
     )
+    from confiture.core.locking import LockAcquisitionError, LockConfig, MigrationLock
     from confiture.core.migrator import Migrator
 
     try:
@@ -1529,34 +1542,57 @@ def migrate_down(
 
         console.print(f"[cyan]📦 Rolling back {len(versions_to_rollback)} migration(s)[/cyan]\n")
 
-        # Rollback migrations in reverse order
-        rolled_back_count = 0
-        for version in reversed(versions_to_rollback):
-            # Find migration file
-            migration_files = migrator.find_migration_files(migrations_dir=migrations_dir)
-            migration_file = None
-            for mf in migration_files:
-                if migrator._version_from_filename(mf.name) == version:
-                    migration_file = mf
-                    break
+        # Acquire the migration lock for the rollback (#142): atomic w.r.t. a
+        # concurrent migrate up/down.
+        lock = MigrationLock(
+            conn,
+            LockConfig(
+                enabled=not no_lock,
+                timeout_ms=lock_timeout,
+                command="confiture migrate down",
+            ),
+        )
+        try:
+            with lock.acquire():
+                # Rollback migrations in reverse order
+                rolled_back_count = 0
+                for version in reversed(versions_to_rollback):
+                    # Find migration file
+                    migration_files = migrator.find_migration_files(
+                        migrations_dir=migrations_dir
+                    )
+                    migration_file = None
+                    for mf in migration_files:
+                        if migrator._version_from_filename(mf.name) == version:
+                            migration_file = mf
+                            break
 
-            if not migration_file:
-                console.print(f"[red]❌ Migration file for version {version} not found[/red]")
-                continue
+                    if not migration_file:
+                        console.print(
+                            f"[red]❌ Migration file for version {version} not found[/red]"
+                        )
+                        continue
 
-            # Load migration module
-            migration_class = load_migration_class(migration_file)
+                    # Load migration module + instance
+                    migration_class = load_migration_class(migration_file)
+                    migration = migration_class(connection=conn)
 
-            # Create migration instance
-            migration = migration_class(connection=conn)
+                    # Rollback migration
+                    console.print(
+                        f"[cyan]⚡ Rolling back {migration.version}_{migration.name}...[/cyan]",
+                        end=" ",
+                    )
+                    migrator.rollback(migration)
+                    console.print("[green]✅[/green]")
+                    rolled_back_count += 1
+        except LockAcquisitionError as e:
+            conn.close()
+            if is_json(format_output):
+                from confiture.cli.error_json import lock_error_to_confiture
 
-            # Rollback migration
-            console.print(
-                f"[cyan]⚡ Rolling back {migration.version}_{migration.name}...[/cyan]", end=" "
-            )
-            migrator.rollback(migration)
-            console.print("[green]✅[/green]")
-            rolled_back_count += 1
+                fail(lock_error_to_confiture(e), json_mode=True, output_file=output_file)
+            print_error_to_console(e, error_console)
+            raise typer.Exit(6) from e
 
         console.print(
             f"\n[green]✅ Successfully rolled back {rolled_back_count} migration(s)![/green]"
@@ -1652,7 +1688,7 @@ def migrate_down_to(
         else:
             session = Migrator.from_config(str(config), migrations_dir=migrations_dir)
         with session as s:
-            result = s.down_to(revision, dry_run=dry_run)
+            result = s.down_to(revision, dry_run=dry_run, command="confiture migrate down-to")
     except typer.Exit:
         raise
     except Exception as e:

--- a/python/confiture/cli/commands/schema.py
+++ b/python/confiture/cli/commands/schema.py
@@ -716,11 +716,11 @@ def lint(
                         f"({v.object_name}): {v.message}"
                     )
                 rep_errors = any(v.severity == RuleSeverity.ERROR for v in replica_violations)
-                rep_warnings = any(
-                    v.severity == RuleSeverity.WARNING for v in replica_violations
-                )
-                should_fail = should_fail or (rep_errors and fail_on_error) or (
-                    rep_warnings and fail_on_warning
+                rep_warnings = any(v.severity == RuleSeverity.WARNING for v in replica_violations)
+                should_fail = (
+                    should_fail
+                    or (rep_errors and fail_on_error)
+                    or (rep_warnings and fail_on_warning)
                 )
             else:
                 console.print("\n[green]🔁 Replica forward-compatibility: no issues[/green]")

--- a/python/confiture/cli/commands/schema.py
+++ b/python/confiture/cli/commands/schema.py
@@ -589,6 +589,17 @@ def lint(
         "--fail-on-warning",
         help="Exit with code 1 if warnings found (default: off, stricter)",
     ),
+    replica_safe: bool = typer.Option(
+        False,
+        "--replica-safe",
+        help="Also run the replica-aware forward-compatibility lint over the "
+        "migrations tree (#139).",
+    ),
+    migrations_dir: Path = typer.Option(
+        Path("db/migrations"),
+        "--migrations-dir",
+        help="Migrations directory for --replica-safe (default: db/migrations)",
+    ),
 ) -> None:
     """Validate schema against best practices.
 
@@ -675,6 +686,45 @@ def lint(
         should_fail = (report.has_errors and fail_on_error) or (
             report.has_warnings and fail_on_warning
         )
+
+        # #139: replica-aware forward-compatibility lint over the migrations tree
+        # (a migration-tree check, distinct from the schema lint above).
+        if replica_safe:
+            from confiture.core.linting.libraries.replica import Replica001ForwardCompat
+            from confiture.core.linting.schema_linter import RuleSeverity
+
+            has_replicas = False
+            bypass = False
+            try:
+                from confiture.config.environment import Environment
+
+                _env = Environment.load(env, project_dir=project_dir)
+                has_replicas = bool(_env.infrastructure.replicas)
+                bypass = _env.migration.allow_unsafe_under_replication
+            except Exception:  # noqa: BLE001 — replica policy degrades to defaults
+                pass
+
+            replica_violations = Replica001ForwardCompat(
+                has_replicas=has_replicas, bypass=bypass
+            ).check(migrations_dir)
+            if replica_violations:
+                console.print("\n[cyan]🔁 Replica forward-compatibility:[/cyan]")
+                for v in replica_violations:
+                    color = "red" if v.severity == RuleSeverity.ERROR else "yellow"
+                    console.print(
+                        f"  [{color}]{v.severity.value.upper()}[/{color}] {v.rule_id} "
+                        f"({v.object_name}): {v.message}"
+                    )
+                rep_errors = any(v.severity == RuleSeverity.ERROR for v in replica_violations)
+                rep_warnings = any(
+                    v.severity == RuleSeverity.WARNING for v in replica_violations
+                )
+                should_fail = should_fail or (rep_errors and fail_on_error) or (
+                    rep_warnings and fail_on_warning
+                )
+            else:
+                console.print("\n[green]🔁 Replica forward-compatibility: no issues[/green]")
+
         if should_fail:
             raise typer.Exit(1)
 

--- a/python/confiture/cli/error_json.py
+++ b/python/confiture/cli/error_json.py
@@ -1,0 +1,128 @@
+"""Structured error envelope + JSON-aware CLI error boundary (issue #145).
+
+In ``--format json`` mode, every failure path emits a stable, machine-readable
+envelope on stdout instead of free-form Rich text. The ``error`` value is the
+unified inner issue object shared across #144 / #145 / #148 (see
+.phases/.../shared-issue-schema.md):
+
+    {"ok": false, "error": {severity, code, message, actionable,
+                            details, migration, file, line}}
+
+The process still exits with the #146 exit code (``ConfiturError.exit_code``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
+
+import typer
+
+from confiture.exceptions import ConfiturError
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+# Envelope `code` used when a non-ConfiturError escapes translation. It is not a
+# registry code (those are domain failures); it signals "unexpected internal
+# error" and pairs with the generic exit code 1.
+INTERNAL_ERROR_CODE = "INTERNAL_ERROR"
+
+
+def coerce_to_confiture_error(exc: Exception) -> ConfiturError:
+    """Wrap a non-ConfiturError so JSON consumers never see a raw traceback.
+
+    A genuine ``ConfiturError`` is returned unchanged. Anything else becomes a
+    generic ``ConfiturError`` (no registry code → exit 1) carrying the original
+    message, so ``emit_error_json`` still produces a valid envelope.
+    """
+    if isinstance(exc, ConfiturError):
+        return exc
+    message = str(exc) or exc.__class__.__name__
+    return ConfiturError(message)
+
+
+def _jsonify(value: Any) -> Any:
+    """Recursively coerce Paths (and containers of Paths) to JSON-safe values."""
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {k: _jsonify(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonify(v) for v in value]
+    return value
+
+
+def emit_error_json(error: ConfiturError) -> dict[str, Any]:
+    """Serialize a ConfiturError to the #145 error envelope.
+
+    ``details`` is everything in ``error.context`` except the keys promoted to
+    first-class fields (``file``, ``line``, ``migration_version``). Named-attribute
+    extras (``conflicting_files``, ``filepath``) that some subclasses store outside
+    ``context`` are folded into ``details`` so it is never silently empty.
+    """
+    base = error.to_dict()
+    context = dict(base.get("context") or {})
+
+    # Fold named-attribute extras into details (these subclasses keep data on
+    # attrs, not in context). setdefault: an explicit context key wins.
+    conflicting = getattr(error, "conflicting_files", None)
+    if conflicting:
+        context.setdefault("conflicting_files", conflicting)
+    filepath = getattr(error, "filepath", None)
+    if filepath is not None:
+        context.setdefault("filepath", filepath)
+
+    migration = context.pop("migration_version", None) or getattr(error, "version", None)
+    file = context.pop("file", None)
+    line = context.pop("line", None)
+
+    severity = base["severity"]
+    if severity == "critical":  # fold CRITICAL into the public "error" tier
+        severity = "error"
+
+    return {
+        "ok": False,
+        "error": {
+            "code": base["error_code"] or INTERNAL_ERROR_CODE,
+            "message": base["message"],
+            "severity": severity,
+            "details": _jsonify(context),
+            "migration": _jsonify(migration),
+            "file": _jsonify(file),
+            "line": line,
+            "actionable": base["resolution_hint"],
+        },
+    }
+
+
+def fail(
+    error: Exception,
+    *,
+    json_mode: bool,
+    output_file: Path | None = None,
+    console: Console | None = None,
+    error_console: Console | None = None,
+) -> NoReturn:
+    """Single error boundary: emit the failure, then exit with the #146 code.
+
+    In ``json_mode`` the envelope goes to stdout (OD-4) so a single ``jq`` pipe
+    reads it; otherwise the human-readable Rich rendering goes to stderr. The
+    human path is byte-for-byte the pre-#145 behavior.
+
+    Raises:
+        typer.Exit: always, with ``ConfiturError.exit_code``.
+    """
+    from confiture.cli.helpers import _output_json
+    from confiture.cli.helpers import console as default_console
+    from confiture.cli.helpers import error_console as default_error_console
+    from confiture.core.error_handler import print_error_to_console
+
+    err = coerce_to_confiture_error(error)
+
+    if json_mode:
+        _output_json(emit_error_json(err), output_file, console or default_console)
+    else:
+        print_error_to_console(err, error_console or default_error_console)
+
+    raise typer.Exit(err.exit_code)

--- a/python/confiture/cli/error_json.py
+++ b/python/confiture/cli/error_json.py
@@ -29,15 +29,52 @@ if TYPE_CHECKING:
 INTERNAL_ERROR_CODE = "INTERNAL_ERROR"
 
 
+# Stale-lock advisory threshold (seconds). Held longer than this, the message
+# suggests the holder may be stuck.
+_STALE_LOCK_SECONDS = 300
+
+
+def lock_error_to_confiture(exc: Exception) -> ConfiturError:
+    """Translate a LockAcquisitionError into a LOCK_1300 ConfiturError (#147).
+
+    Folds the holder identity into ``context["holder"]`` (so it lands under the
+    envelope's ``details.holder``) and adds a stale-lock hint when the lock has
+    been held a long time.
+    """
+    holder = getattr(exc, "holder", None)
+    context: dict[str, Any] = {}
+    if holder is not None:
+        context["holder"] = holder.to_dict()
+
+    hint = "Wait for the current migration to finish, then retry."
+    held = getattr(holder, "held_for_seconds", None) if holder is not None else None
+    if held is not None and held > _STALE_LOCK_SECONDS:
+        hint += (
+            f" Held for >{_STALE_LOCK_SECONDS // 60} min — this may be a stale lock; "
+            "investigate the holder process before forcing."
+        )
+    return ConfiturError(
+        str(exc) or "Migration lock is held by another process.",
+        error_code="LOCK_1300",
+        context=context,
+        resolution_hint=hint,
+    )
+
+
 def coerce_to_confiture_error(exc: Exception) -> ConfiturError:
     """Wrap a non-ConfiturError so JSON consumers never see a raw traceback.
 
-    A genuine ``ConfiturError`` is returned unchanged. Anything else becomes a
-    generic ``ConfiturError`` (no registry code → exit 1) carrying the original
-    message, so ``emit_error_json`` still produces a valid envelope.
+    A genuine ``ConfiturError`` is returned unchanged. A ``LockAcquisitionError``
+    becomes a ``LOCK_1300`` error with holder identity (#147). Anything else
+    becomes a generic ``ConfiturError`` (no registry code → exit 1) carrying the
+    original message, so ``emit_error_json`` still produces a valid envelope.
     """
     if isinstance(exc, ConfiturError):
         return exc
+    from confiture.core.locking import LockAcquisitionError
+
+    if isinstance(exc, LockAcquisitionError):
+        return lock_error_to_confiture(exc)
     message = str(exc) or exc.__class__.__name__
     return ConfiturError(message)
 

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -233,15 +233,20 @@ DATABASE_URL_OPTION_HELP = (
 def resolve_database_url(flag: str | None, config_path: Path | None) -> str | None:
     """Resolve the tracking-database DSN with documented precedence.
 
-    Precedence: ``--database-url`` flag > ``CONFITURE_DATABASE_URL`` >
-    ``DATABASE_URL`` > ``None``. A ``None`` result means no override was
-    supplied — the caller falls back to ``config_path`` so the session reads
-    ``config.database_url`` as before.
+    Precedence: ``--database-url`` flag > an **existing** ``--config`` file >
+    ``CONFITURE_DATABASE_URL`` > ``DATABASE_URL`` > ``None``.
+
+    The explicit flag always wins. An existing ``--config`` is authoritative over
+    the ambient env vars: ``DATABASE_URL`` is ubiquitous in CI / deploy
+    environments, and silently letting it override a project's ``--config``
+    would discard the config's ``tracking_table`` (and other settings) — so a
+    present config short-circuits to ``None`` (the caller loads the config). The
+    env vars are a last-resort fallback only when no config file is available.
 
     Args:
         flag: Value of the ``--database-url`` option (``None`` if not given).
-        config_path: The resolved ``--config`` path (unused for resolution; kept
-            for an explicit, self-documenting call site and future use).
+        config_path: The resolved ``--config`` path. When it points to an
+            existing file, the config wins over the env vars (returns ``None``).
 
     Returns:
         The DSN string to use as ``database_url_override``, or ``None`` to defer
@@ -261,6 +266,9 @@ def resolve_database_url(flag: str | None, config_path: Path | None) -> str | No
                 resolution_hint="Use format: postgresql://user:password@host:port/database",
             )
         return flag
+    # An explicit, existing config file beats the ambient env vars.
+    if config_path is not None and config_path.exists():
+        return None
     for var in _DATABASE_URL_ENV_VARS:
         val = os.environ.get(var)
         if val:

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -4,7 +4,6 @@ import difflib
 import json
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -23,9 +22,11 @@ from confiture.models.lint import LintReport, LintSeverity, Violation
 
 _VALID_ENV_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$")
 
-# Create Rich consoles for stdout and stderr
+# Create Rich consoles for stdout and stderr. Use stderr=True (not
+# file=sys.stderr) so the stream is resolved dynamically at write time — this
+# keeps it correct under pytest's capsys, which swaps sys.stderr per test.
 console = Console()
-error_console = Console(file=sys.stderr)
+error_console = Console(stderr=True)
 
 _MACHINE_OUTPUT_FORMATS = frozenset({"json", "csv", "yaml"})
 
@@ -265,6 +266,16 @@ def resolve_database_url(flag: str | None, config_path: Path | None) -> str | No
         if val:
             return val
     return None
+
+
+def is_json(fmt: str | None) -> bool:
+    """Whether a command's --format value selects JSON output (#145).
+
+    Commands use varied format param names (``format_output`` / ``output_format``
+    / ``format_type``) with different allowed sets; this collapses them to the
+    single boolean the error boundary needs.
+    """
+    return bool(fmt) and fmt.lower() == "json"
 
 
 def _get_tracking_table(config_data: Any) -> str:

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -2,6 +2,7 @@
 
 import difflib
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -213,6 +214,57 @@ def _resolve_config(config: Path, env: str | None) -> Path:
             )
         return Path("db") / "environments" / f"{env}.yaml"
     return config
+
+
+# Canonical env var for the connection DSN, plus the ubiquitous bare fallback
+# (OD-5). Checked in order; the first non-empty value wins.
+_DATABASE_URL_ENV_VARS = ("CONFITURE_DATABASE_URL", "DATABASE_URL")
+
+# Shared --help text for the --database-url flag across the migrate family (#140).
+DATABASE_URL_OPTION_HELP = (
+    "PostgreSQL DSN for the tracking database. Takes precedence over --config / "
+    "--env and the CONFITURE_DATABASE_URL / DATABASE_URL env vars. When given, no "
+    "YAML is required (tracking table defaults to tb_confiture). SSH-tunnel configs "
+    "still require --config."
+)
+
+
+def resolve_database_url(flag: str | None, config_path: Path | None) -> str | None:
+    """Resolve the tracking-database DSN with documented precedence.
+
+    Precedence: ``--database-url`` flag > ``CONFITURE_DATABASE_URL`` >
+    ``DATABASE_URL`` > ``None``. A ``None`` result means no override was
+    supplied — the caller falls back to ``config_path`` so the session reads
+    ``config.database_url`` as before.
+
+    Args:
+        flag: Value of the ``--database-url`` option (``None`` if not given).
+        config_path: The resolved ``--config`` path (unused for resolution; kept
+            for an explicit, self-documenting call site and future use).
+
+    Returns:
+        The DSN string to use as ``database_url_override``, or ``None`` to defer
+        to the config file.
+
+    Raises:
+        ConfigurationError: ``CONFIG_003`` if an explicit flag DSN is malformed.
+    """
+    if flag:
+        if not flag.startswith(("postgresql://", "postgres://")):
+            from confiture.exceptions import ConfigurationError  # noqa: PLC0415
+
+            raise ConfigurationError(
+                f"Invalid --database-url: must start with postgresql:// or "
+                f"postgres://, got: {flag}",
+                error_code="CONFIG_003",
+                resolution_hint="Use format: postgresql://user:password@host:port/database",
+            )
+        return flag
+    for var in _DATABASE_URL_ENV_VARS:
+        val = os.environ.get(var)
+        if val:
+            return val
+    return None
 
 
 def _get_tracking_table(config_data: Any) -> str:

--- a/python/confiture/cli/main.py
+++ b/python/confiture/cli/main.py
@@ -30,6 +30,7 @@ from confiture.cli.commands.migrate_analysis import (
     migrate_verify,
 )
 from confiture.cli.commands.migrate_core import (
+    migrate_current,
     migrate_down,
     migrate_estimate,
     migrate_generate,
@@ -179,6 +180,7 @@ app.command()(bootstrap)
 
 # Register migrate core commands
 migrate_app.command("status")(migrate_status)
+migrate_app.command("current")(migrate_current)
 migrate_app.command("up")(migrate_up)
 migrate_app.command("down")(migrate_down)
 migrate_app.command("generate")(migrate_generate)

--- a/python/confiture/cli/main.py
+++ b/python/confiture/cli/main.py
@@ -11,7 +11,8 @@ from confiture.cli.commands.admin import (
     install_helpers,
     restore,
     validate_profile,
-    verify,
+    verify_checksums,
+    verify_deprecated,
 )
 from confiture.cli.commands.apply_as import migrate_apply_as
 from confiture.cli.commands.bootstrap import bootstrap
@@ -173,7 +174,9 @@ app.command()(drift)
 # Register admin commands
 app.command("install-helpers")(install_helpers)
 app.command()(validate_profile)
-app.command()(verify)
+# #143: verify-checksums is canonical; `verify` is a deprecated alias for one cycle.
+app.command("verify-checksums")(verify_checksums)
+app.command("verify")(verify_deprecated)
 app.command()(restore)
 
 # Register bootstrap command (#137 — one-shot environment ownership setup)

--- a/python/confiture/cli/main.py
+++ b/python/confiture/cli/main.py
@@ -32,6 +32,7 @@ from confiture.cli.commands.migrate_analysis import (
 from confiture.cli.commands.migrate_core import (
     migrate_current,
     migrate_down,
+    migrate_down_to,
     migrate_estimate,
     migrate_generate,
     migrate_status,
@@ -183,6 +184,7 @@ migrate_app.command("status")(migrate_status)
 migrate_app.command("current")(migrate_current)
 migrate_app.command("up")(migrate_up)
 migrate_app.command("down")(migrate_down)
+migrate_app.command("down-to")(migrate_down_to)
 migrate_app.command("generate")(migrate_generate)
 migrate_app.command("estimate")(migrate_estimate)
 

--- a/python/confiture/cli/main.py
+++ b/python/confiture/cli/main.py
@@ -10,6 +10,7 @@ from confiture.cli.branch import branch_app
 from confiture.cli.commands.admin import (
     install_helpers,
     restore,
+    validate_config,
     validate_profile,
     verify_checksums,
     verify_deprecated,
@@ -177,6 +178,8 @@ app.command()(validate_profile)
 # #143: verify-checksums is canonical; `verify` is a deprecated alias for one cycle.
 app.command("verify-checksums")(verify_checksums)
 app.command("verify")(verify_deprecated)
+# #144: offline config + migrations-tree validation (never connects).
+app.command("validate-config")(validate_config)
 app.command()(restore)
 
 # Register bootstrap command (#137 — one-shot environment ownership setup)

--- a/python/confiture/cli/main.py
+++ b/python/confiture/cli/main.py
@@ -71,10 +71,20 @@ COMMON_COMMANDS = [
     "drift",
 ]
 
+# Exit-code summary shown in the top-level --help epilog. The full contract
+# lives in docs/reference/exit-codes.md (issue #146).
+_EXIT_CODE_EPILOG = (
+    "Exit codes (see docs/reference/exit-codes.md): "
+    "0 success · 1 generic failure · 2 tracking table absent · "
+    "3 DB connection failed · 4 schema/build · 5 config invalid · "
+    "6 lock contention · 7 git/grant · 8 irreversible rollback."
+)
+
 # Create Typer app
 app = typer.Typer(
     name="confiture",
     help="PostgreSQL migrations, sweetly done 🍓",
+    epilog=_EXIT_CODE_EPILOG,
     add_completion=False,
 )
 
@@ -113,6 +123,16 @@ def version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+def exit_codes_callback(value: bool) -> None:
+    """Print the canonical exit-code reference and exit."""
+    if value:
+        from confiture.core.error_codes import render_exit_codes_doc
+
+        console.print("confiture exit-code convention (#146):\n")
+        console.print(render_exit_codes_doc())
+        raise typer.Exit()
+
+
 @app.callback()
 def main(
     version: bool = typer.Option(
@@ -121,6 +141,14 @@ def main(
         callback=version_callback,
         is_eager=True,
         help="Show version and exit",
+    ),
+    exit_codes: bool = typer.Option(
+        False,
+        "--exit-codes",
+        callback=exit_codes_callback,
+        is_eager=True,
+        hidden=True,
+        help="Print the canonical exit-code convention and exit",
     ),
 ) -> None:
     """Confiture - PostgreSQL migrations, sweetly done 🍓."""

--- a/python/confiture/config/environment.py
+++ b/python/confiture/config/environment.py
@@ -228,6 +228,23 @@ class MigrationConfig(BaseModel):
     tracking_table: str = "tb_confiture"
     rebuild_threshold: int = 5
     grant_dir: str = "db/7_grant"
+    # Issue #139 — replica-aware forward-compatibility lint. When True, unsafe
+    # operations are downgraded from errors to warnings even if replicas are
+    # declared. RISK: you accept that a single-step DDL change may surface
+    # errors on read replicas during the replication-lag window.
+    allow_unsafe_under_replication: bool = False
+
+
+class InfrastructureConfig(BaseModel):
+    """Deployment-topology declarations confiture reads (issue #139).
+
+    ``replicas`` lists declared read-replica identifiers. Its mere presence
+    (non-empty) makes the replica-safety lint error rather than warn — the
+    project is telling confiture it runs under replication. The deploy tool
+    (fraisier) owns the live topology; confiture only reads this declaration.
+    """
+
+    replicas: list[str] = Field(default_factory=list)
 
 
 class SshTunnelConfig(BaseModel):
@@ -631,6 +648,7 @@ class Environment(BaseModel):
     require_confirmation: bool = True
     build: BuildConfig = Field(default_factory=BuildConfig)
     migration: MigrationConfig = Field(default_factory=MigrationConfig)
+    infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
     pggit: PgGitConfig = Field(default_factory=PgGitConfig)
     seed: SeedConfig = Field(default_factory=SeedConfig)
     ssh_tunnel: SshTunnelConfig | None = None

--- a/python/confiture/core/_migrator/engine.py
+++ b/python/confiture/core/_migrator/engine.py
@@ -1355,6 +1355,39 @@ class Migrator:
                 for row in cursor.fetchall()
             ]
 
+    def get_current_revision_row(self) -> dict[str, Any] | None:
+        """Return the most-recently-applied migration row, or None if empty.
+
+        Selects version, name, applied_at, checksum for the row with the latest
+        ``applied_at`` (``ORDER BY applied_at DESC LIMIT 1`` — avoids loading the
+        full history just to take the tail).
+
+        Returns:
+            Dict with 'version', 'name', 'applied_at' (ISO string or None), and
+            'checksum' (str or None), or None when the tracking table is empty.
+
+        Note:
+            Raises psycopg's UndefinedTable when the tracking table is absent;
+            callers must probe ``tracking_table_exists()`` first to distinguish
+            an absent table (not initialized) from an empty one (no migrations).
+        """
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                pgsql.SQL(
+                    "SELECT version, name, applied_at, checksum FROM {} "
+                    "ORDER BY applied_at DESC LIMIT 1"
+                ).format(self._table_ident)
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return {
+            "version": row[0],
+            "name": row[1],
+            "applied_at": row[2].isoformat() if row[2] else None,
+            "checksum": row[3],
+        }
+
     def find_migration_files(self, migrations_dir: Path | None = None) -> list[Path]:
         """Find all migration files in the migrations directory.
 

--- a/python/confiture/core/_migrator/rollback_planner.py
+++ b/python/confiture/core/_migrator/rollback_planner.py
@@ -1,0 +1,87 @@
+"""Pure rollback planner for `migrate down-to` (issue #142).
+
+Given the applied sequence, the set of known migration versions, a target
+revision, and the set of versions that have a usable ``.down.sql``, compute the
+ordered rollback set (newest → oldest) and fully validate reversibility — all
+*without touching the database*. Execution (Phase 2) consumes a validated plan.
+
+This module imports nothing DB-related on purpose; correctness lives here and is
+trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+# Typed reasons for an invalid plan (mirrors the issue's four edge cases).
+REASON_TARGET_NEWER = "target_newer_than_current"
+REASON_UNKNOWN = "unknown_revision"
+REASON_IRREVERSIBLE = "irreversible"
+
+
+@dataclass
+class RollbackPlan:
+    """The computed rollback plan.
+
+    Attributes:
+        target: The revision to roll back *to* (stays applied).
+        to_rollback: Versions to roll back, newest → oldest. Populated even for
+            an irreversible plan so the error can name the offending set.
+        valid: Whether the plan can be executed.
+        noop: True when ``target`` is already the current revision.
+        reason: Why an invalid plan failed (one of the REASON_* constants).
+        missing_down: Versions in ``to_rollback`` lacking a usable ``.down.sql``.
+    """
+
+    target: str
+    to_rollback: list[str]
+    valid: bool
+    noop: bool = False
+    reason: str | None = None
+    missing_down: list[str] = field(default_factory=list)
+
+
+def plan_down_to(
+    applied: list[str],
+    known: Iterable[str],
+    target: str,
+    down_available: Iterable[str],
+) -> RollbackPlan:
+    """Compute the rollback plan to reach ``target``.
+
+    Args:
+        applied: Applied versions in ascending ``applied_at`` order.
+        known: All discoverable migration versions (applied or not).
+        target: The revision to roll back to (kept applied).
+        down_available: Versions with a present, constructible ``.down.sql``
+            (or a reversible Python ``down()``).
+
+    Returns:
+        A ``RollbackPlan``. Invalid plans carry a typed ``reason`` and never a
+        partial execution instruction — the caller refuses atomically.
+    """
+    known_set = set(known)
+    down_set = set(down_available)
+
+    if target not in applied:
+        # Known-but-not-applied → a forward move; otherwise genuinely unknown.
+        reason = REASON_TARGET_NEWER if target in known_set else REASON_UNKNOWN
+        return RollbackPlan(target=target, to_rollback=[], valid=False, reason=reason)
+
+    idx = applied.index(target)
+    if idx == len(applied) - 1:
+        return RollbackPlan(target=target, to_rollback=[], valid=True, noop=True)
+
+    to_rollback = list(reversed(applied[idx + 1 :]))  # newest → oldest
+    missing = [v for v in to_rollback if v not in down_set]
+    if missing:
+        return RollbackPlan(
+            target=target,
+            to_rollback=to_rollback,
+            valid=False,
+            reason=REASON_IRREVERSIBLE,
+            missing_down=missing,
+        )
+
+    return RollbackPlan(target=target, to_rollback=to_rollback, valid=True)

--- a/python/confiture/core/_migrator/session.py
+++ b/python/confiture/core/_migrator/session.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from confiture.config.environment import Environment
     from confiture.models.results import (
         CurrentRevision,
+        DownToResult,
         MigrateDownResult,
         MigrateRebuildResult,
         MigrateReinitResult,
@@ -249,7 +250,7 @@ class MigratorSession:
             summary={"applied": applied_count, "pending": pending_count, "total": len(infos)},
         )
 
-    def current_revision(self) -> "CurrentRevision | None":
+    def current_revision(self) -> CurrentRevision | None:
         """Return the latest applied migration revision (issue #141).
 
         Returns:
@@ -632,80 +633,37 @@ class MigratorSession:
             warnings=["dry_run_execute: all SQL executed successfully, changes rolled back"],
         )
 
-    def down(
-        self,
-        *,
-        steps: int = 1,
-        dry_run: bool = False,
-    ) -> MigrateDownResult:
-        """Roll back applied migrations in reverse order.
+    def _rollback_sequence(
+        self, versions: list[str], *, dry_run: bool = False
+    ) -> tuple[list, int]:
+        """Roll back an ordered (newest → oldest) list of versions.
 
-        Rolls back the most recently applied migrations. Each migration's
-        ``down()`` method or ``.down.sql`` file is executed.
-
-        Args:
-            steps: Number of migrations to roll back (default: 1).
-                   Migrations are rolled back in reverse chronological order.
-            dry_run: If True, analyze without executing SQL.
+        The shared rollback loop behind both ``down(steps=N)`` and
+        ``down_to(target)`` — keeps the two paths from diverging. Reuses the
+        engine's ``rollback()`` (transactional vs. non-transactional handling
+        lives there). Does NOT acquire the lock itself; callers wrap it.
 
         Returns:
-            MigrateDownResult with:
-            - success: True if all rollbacks succeeded
-            - migrations_rolled_back: List of MigrationApplied (serialized as "rolled_back")
-            - total_execution_time_ms: Total time (serialized as "total_duration_ms")
-            - error: Error message if success=False
-
-        Raises:
-            ConfigurationError: If used outside ``with`` context manager.
-            MigrationError: If a migration file cannot be loaded.
-            RollbackError: If rollback SQL execution fails.
-
-        Example:
-            >>> with Migrator.from_config("db/environments/prod.yaml") as m:
-            ...     result = m.down(steps=2)
-            ...     if result.success:
-            ...         print(f"Rolled back {len(result.migrations_rolled_back)} migrations")
+            (rolled_back, total_execution_time_ms) where rolled_back is a list
+            of MigrationApplied in the order rolled back.
         """
         import time as _time
 
-        import confiture.core.migrator as _m
-
         # Import through confiture.core.migrator so tests can patch
         # confiture.core.migrator.load_migration_class.
-        from confiture.exceptions import ConfigurationError
-        from confiture.models.results import MigrateDownResult, MigrationApplied
+        import confiture.core.migrator as _m
+        from confiture.models.results import MigrationApplied
 
-        if self._migrator is None:
-            raise ConfigurationError(
-                "MigratorSession must be used as a context manager",
-                resolution_hint="Use: with Migrator.from_config(...) as m: ...",
-            )
-
-        self._migrator.initialize()
-        applied_versions = self._migrator.get_applied_versions()
-
-        if not applied_versions:
-            return MigrateDownResult(
-                success=True,
-                migrations_rolled_back=[],
-                total_execution_time_ms=0,
-            )
-
-        versions_to_rollback = applied_versions[-steps:]
         migration_files = self._migrator.find_migration_files(migrations_dir=self._migrations_dir)
+        by_version = {
+            self._migrator._version_from_filename(f.name): f for f in migration_files
+        }
 
         rolled_back: list[MigrationApplied] = []
         total_execution_time_ms = 0
 
-        for version in reversed(versions_to_rollback):
-            migration_file = next(
-                (
-                    f
-                    for f in migration_files
-                    if self._migrator._version_from_filename(f.name) == version
-                ),
-                None,
-            )
+        for version in versions:
+            migration_file = by_version.get(version)
             if migration_file is None:
                 continue
 
@@ -728,11 +686,214 @@ class MigratorSession:
                 )
             )
 
+        return rolled_back, total_execution_time_ms
+
+    def _reversible_versions(self) -> set[str]:
+        """Set of discoverable versions that have a usable rollback.
+
+        A ``.up.sql`` migration is reversible iff its sibling ``.down.sql``
+        exists on disk; Python migrations are treated as reversible (they define
+        ``down()``). This feeds the planner's ``down_available`` so an
+        irreversible target is refused *before* any execution.
+        """
+        reversible: set[str] = set()
+        for f in self._migrator.find_migration_files(migrations_dir=self._migrations_dir):
+            version = self._migrator._version_from_filename(f.name)
+            if f.name.endswith(".up.sql"):
+                down_file = f.parent / f.name.replace(".up.sql", ".down.sql")
+                if down_file.exists():
+                    reversible.add(version)
+            else:
+                reversible.add(version)
+        return reversible
+
+    def down(
+        self,
+        *,
+        steps: int = 1,
+        dry_run: bool = False,
+        lock_timeout: int = 30000,
+        no_lock: bool = False,
+    ) -> MigrateDownResult:
+        """Roll back applied migrations in reverse order.
+
+        Rolls back the most recently applied migrations. Each migration's
+        ``down()`` method or ``.down.sql`` file is executed.
+
+        Acquires the migration advisory lock for the duration of the rollback
+        (issue #142) so it is atomic w.r.t. a concurrent ``up()``/``down()`` —
+        previously ``down()`` ran unlocked, a latent race. Pass ``no_lock=True``
+        to skip (dangerous in multi-pod environments).
+
+        Args:
+            steps: Number of migrations to roll back (default: 1).
+                   Migrations are rolled back in reverse chronological order.
+            dry_run: If True, analyze without executing SQL (no lock taken).
+            lock_timeout: Lock acquisition timeout in milliseconds (default: 30000).
+            no_lock: If True, skip distributed locking.
+
+        Returns:
+            MigrateDownResult with:
+            - success: True if all rollbacks succeeded
+            - migrations_rolled_back: List of MigrationApplied (serialized as "rolled_back")
+            - total_execution_time_ms: Total time (serialized as "total_duration_ms")
+            - error: Error message if success=False
+
+        Raises:
+            ConfigurationError: If used outside ``with`` context manager.
+            MigrationError: If a migration file cannot be loaded.
+            RollbackError: If rollback SQL execution fails.
+            LockAcquisitionError: If the migration lock cannot be acquired.
+
+        Example:
+            >>> with Migrator.from_config("db/environments/prod.yaml") as m:
+            ...     result = m.down(steps=2)
+            ...     if result.success:
+            ...         print(f"Rolled back {len(result.migrations_rolled_back)} migrations")
+        """
+        import confiture.core.migrator as _m
+        from confiture.exceptions import ConfigurationError
+        from confiture.models.results import MigrateDownResult
+
+        if self._migrator is None:
+            raise ConfigurationError(
+                "MigratorSession must be used as a context manager",
+                resolution_hint="Use: with Migrator.from_config(...) as m: ...",
+            )
+
+        self._migrator.initialize()
+        applied_versions = self._migrator.get_applied_versions()
+
+        if not applied_versions:
+            return MigrateDownResult(
+                success=True,
+                migrations_rolled_back=[],
+                total_execution_time_ms=0,
+            )
+
+        versions_to_rollback = list(reversed(applied_versions[-steps:]))  # newest → oldest
+
+        if dry_run:
+            rolled_back, total_ms = self._rollback_sequence(versions_to_rollback, dry_run=True)
+        else:
+            lock_config = _m.LockConfig(enabled=not no_lock, timeout_ms=lock_timeout)
+            lock = _m.MigrationLock(self._conn, lock_config)
+            with lock.acquire():
+                rolled_back, total_ms = self._rollback_sequence(
+                    versions_to_rollback, dry_run=False
+                )
+
         return MigrateDownResult(
             success=True,
             migrations_rolled_back=rolled_back,
-            total_execution_time_ms=total_execution_time_ms,
+            total_execution_time_ms=total_ms,
         )
+
+    def down_to(
+        self,
+        target: str,
+        *,
+        dry_run: bool = False,
+        lock_timeout: int = 30000,
+        no_lock: bool = False,
+    ) -> DownToResult:
+        """Roll back every migration newer than ``target`` (issue #142).
+
+        Computes the rollback set via the pure planner, validates that *all*
+        required ``.down.sql`` files exist up front (refusing atomically if any
+        is missing — no partial application), then rolls back newest → oldest
+        under the migration lock so the read-and-rollback is atomic w.r.t. other
+        writers.
+
+        Args:
+            target: The revision to roll back to (kept applied).
+            dry_run: If True, compute + validate the plan but execute nothing.
+            lock_timeout: Lock acquisition timeout in milliseconds.
+            no_lock: If True, skip distributed locking.
+
+        Returns:
+            DownToResult with from/to/rolled_back/skipped/errors.
+
+        Raises:
+            ConfigurationError: If used outside ``with`` context manager.
+            RollbackError: ``ROLLBACK_600`` if a required ``.down.sql`` is missing.
+            MigrationError: ``MIGR_100`` for an unknown target, or a
+                forward-move ("use migrate up --target") for a target newer than
+                current.
+            LockAcquisitionError: If the migration lock cannot be acquired.
+        """
+        import confiture.core.migrator as _m
+        from confiture.core._migrator.rollback_planner import (
+            REASON_IRREVERSIBLE,
+            REASON_TARGET_NEWER,
+            plan_down_to,
+        )
+        from confiture.exceptions import ConfigurationError, MigrationError, RollbackError
+        from confiture.models.results import DownToResult
+
+        if self._migrator is None:
+            raise ConfigurationError(
+                "MigratorSession must be used as a context manager",
+                resolution_hint="Use: with Migrator.from_config(...) as m: ...",
+            )
+
+        self._migrator.initialize()
+        applied = self._migrator.get_applied_versions()  # ASC
+        known = {
+            self._migrator._version_from_filename(f.name)
+            for f in self._migrator.find_migration_files(migrations_dir=self._migrations_dir)
+        }
+        down_available = self._reversible_versions()
+
+        plan = plan_down_to(applied, known, target, down_available)
+
+        if not plan.valid:
+            if plan.reason == REASON_IRREVERSIBLE:
+                missing = ", ".join(plan.missing_down)
+                raise RollbackError(
+                    f"Cannot roll back to {target}: missing .down.sql for {missing}. "
+                    f"Aborting without applying anything.",
+                    error_code="ROLLBACK_600",
+                    resolution_hint=(
+                        f"Add the missing .down.sql file(s) for {missing}, or choose a "
+                        f"target that does not require rolling back past them."
+                    ),
+                )
+            if plan.reason == REASON_TARGET_NEWER:
+                raise MigrationError(
+                    f"Revision {target} is newer than the current revision — "
+                    f"down-to only moves backward.",
+                    error_code="MIGR_100",
+                    resolution_hint="Use 'confiture migrate up --target' for forward moves.",
+                )
+            # unknown_revision
+            raise MigrationError(
+                f"Unknown revision: {target}.",
+                error_code="MIGR_100",
+                resolution_hint="Run 'confiture migrate status' or 'migrate current' "
+                "to see known revisions.",
+            )
+
+        from_ = applied[-1] if applied else None
+
+        if plan.noop:
+            return DownToResult(from_=from_, to=target, rolled_back=[], noop=True)
+
+        # Defensive: any computed version not actually applied (consistent
+        # tracking table → empty).
+        applied_set = set(applied)
+        skipped = [v for v in plan.to_rollback if v not in applied_set]
+        to_execute = [v for v in plan.to_rollback if v in applied_set]
+
+        if dry_run:
+            return DownToResult(from_=from_, to=target, rolled_back=to_execute, skipped=skipped)
+
+        lock_config = _m.LockConfig(enabled=not no_lock, timeout_ms=lock_timeout)
+        lock = _m.MigrationLock(self._conn, lock_config)
+        with lock.acquire():
+            self._rollback_sequence(to_execute, dry_run=False)
+
+        return DownToResult(from_=from_, to=target, rolled_back=to_execute, skipped=skipped)
 
     def reinit(
         self,

--- a/python/confiture/core/_migrator/session.py
+++ b/python/confiture/core/_migrator/session.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
     from confiture.config.environment import Environment
     from confiture.models.results import (
+        CurrentRevision,
         MigrateDownResult,
         MigrateRebuildResult,
         MigrateReinitResult,
@@ -246,6 +247,51 @@ class MigratorSession:
             tracking_table_exists=table_exists,
             tracking_table=tracking_table,
             summary={"applied": applied_count, "pending": pending_count, "total": len(infos)},
+        )
+
+    def current_revision(self) -> "CurrentRevision | None":
+        """Return the latest applied migration revision (issue #141).
+
+        Returns:
+            A ``CurrentRevision`` for the most-recently-applied migration, or
+            ``None`` when the tracking table exists but is empty (no migrations
+            applied yet — a freshly-initialized database).
+
+        Raises:
+            ConfigurationError: If called outside the ``with`` context manager.
+            PreconditionError: ``PRECON_1001`` when the tracking table is absent
+                (confiture not initialized on this database) — exits 2 per #146.
+
+        Example:
+            >>> with Migrator.from_config("db/environments/prod.yaml") as m:
+            ...     cur = m.current_revision()
+            ...     print(cur.version if cur else "(none applied)")
+        """
+        from confiture.exceptions import ConfigurationError, DatabaseNotInitializedError
+        from confiture.models.results import CurrentRevision
+
+        if self._migrator is None:
+            raise ConfigurationError(
+                "MigratorSession must be used as a context manager",
+                resolution_hint="Use: with Migrator.from_config(...) as m: ...",
+            )
+
+        # MANDATORY probe: get_current_revision_row() raises psycopg's
+        # UndefinedTable on an absent table — it does NOT return None. Translate
+        # "absent" → PRECON_1001 (exit 2); reserve None for "exists but empty".
+        if not self._migrator.tracking_table_exists():
+            raise DatabaseNotInitializedError(
+                "Database not initialized (tracking table absent)"
+            )
+
+        row = self._migrator.get_current_revision_row()
+        if row is None:
+            return None
+        return CurrentRevision(
+            version=row["version"],
+            name=row["name"],
+            applied_at=row["applied_at"],
+            checksum=row.get("checksum"),
         )
 
     def up(

--- a/python/confiture/core/_migrator/session.py
+++ b/python/confiture/core/_migrator/session.py
@@ -714,6 +714,7 @@ class MigratorSession:
         dry_run: bool = False,
         lock_timeout: int = 30000,
         no_lock: bool = False,
+        command: str | None = None,
     ) -> MigrateDownResult:
         """Roll back applied migrations in reverse order.
 
@@ -776,7 +777,9 @@ class MigratorSession:
         if dry_run:
             rolled_back, total_ms = self._rollback_sequence(versions_to_rollback, dry_run=True)
         else:
-            lock_config = _m.LockConfig(enabled=not no_lock, timeout_ms=lock_timeout)
+            lock_config = _m.LockConfig(
+                enabled=not no_lock, timeout_ms=lock_timeout, command=command
+            )
             lock = _m.MigrationLock(self._conn, lock_config)
             with lock.acquire():
                 rolled_back, total_ms = self._rollback_sequence(
@@ -796,6 +799,7 @@ class MigratorSession:
         dry_run: bool = False,
         lock_timeout: int = 30000,
         no_lock: bool = False,
+        command: str | None = None,
     ) -> DownToResult:
         """Roll back every migration newer than ``target`` (issue #142).
 
@@ -888,7 +892,9 @@ class MigratorSession:
         if dry_run:
             return DownToResult(from_=from_, to=target, rolled_back=to_execute, skipped=skipped)
 
-        lock_config = _m.LockConfig(enabled=not no_lock, timeout_ms=lock_timeout)
+        lock_config = _m.LockConfig(
+            enabled=not no_lock, timeout_ms=lock_timeout, command=command
+        )
         lock = _m.MigrationLock(self._conn, lock_config)
         with lock.acquire():
             self._rollback_sequence(to_execute, dry_run=False)

--- a/python/confiture/core/_migrator/session.py
+++ b/python/confiture/core/_migrator/session.py
@@ -281,9 +281,7 @@ class MigratorSession:
         # UndefinedTable on an absent table — it does NOT return None. Translate
         # "absent" → PRECON_1001 (exit 2); reserve None for "exists but empty".
         if not self._migrator.tracking_table_exists():
-            raise DatabaseNotInitializedError(
-                "Database not initialized (tracking table absent)"
-            )
+            raise DatabaseNotInitializedError("Database not initialized (tracking table absent)")
 
         row = self._migrator.get_current_revision_row()
         if row is None:
@@ -633,9 +631,7 @@ class MigratorSession:
             warnings=["dry_run_execute: all SQL executed successfully, changes rolled back"],
         )
 
-    def _rollback_sequence(
-        self, versions: list[str], *, dry_run: bool = False
-    ) -> tuple[list, int]:
+    def _rollback_sequence(self, versions: list[str], *, dry_run: bool = False) -> tuple[list, int]:
         """Roll back an ordered (newest → oldest) list of versions.
 
         The shared rollback loop behind both ``down(steps=N)`` and
@@ -655,9 +651,7 @@ class MigratorSession:
         from confiture.models.results import MigrationApplied
 
         migration_files = self._migrator.find_migration_files(migrations_dir=self._migrations_dir)
-        by_version = {
-            self._migrator._version_from_filename(f.name): f for f in migration_files
-        }
+        by_version = {self._migrator._version_from_filename(f.name): f for f in migration_files}
 
         rolled_back: list[MigrationApplied] = []
         total_execution_time_ms = 0
@@ -782,9 +776,7 @@ class MigratorSession:
             )
             lock = _m.MigrationLock(self._conn, lock_config)
             with lock.acquire():
-                rolled_back, total_ms = self._rollback_sequence(
-                    versions_to_rollback, dry_run=False
-                )
+                rolled_back, total_ms = self._rollback_sequence(versions_to_rollback, dry_run=False)
 
         return MigrateDownResult(
             success=True,
@@ -892,9 +884,7 @@ class MigratorSession:
         if dry_run:
             return DownToResult(from_=from_, to=target, rolled_back=to_execute, skipped=skipped)
 
-        lock_config = _m.LockConfig(
-            enabled=not no_lock, timeout_ms=lock_timeout, command=command
-        )
+        lock_config = _m.LockConfig(enabled=not no_lock, timeout_ms=lock_timeout, command=command)
         lock = _m.MigrationLock(self._conn, lock_config)
         with lock.acquire():
             self._rollback_sequence(to_execute, dry_run=False)

--- a/python/confiture/core/config_validator.py
+++ b/python/confiture/core/config_validator.py
@@ -109,10 +109,7 @@ class ConfigValidator:
         # Resolve include_dirs relative to the project root: for the standard
         # db/environments/<env>.yaml layout that is three levels up; otherwise
         # the config file's own directory.
-        if (
-            config_path.parent.name == "environments"
-            and config_path.parent.parent.name == "db"
-        ):
+        if config_path.parent.name == "environments" and config_path.parent.parent.name == "db":
             project_dir = config_path.parent.parent.parent
         else:
             project_dir = config_path.parent
@@ -183,9 +180,7 @@ class ConfigValidator:
         )
 
     @classmethod
-    def from_env(
-        cls, *, database_url: str, migrations_path: Path | None = None
-    ) -> ConfigValidator:
+    def from_env(cls, *, database_url: str, migrations_path: Path | None = None) -> ConfigValidator:
         """Build from a DSN found in the environment (config_source = "env")."""
         return cls(
             config_source="env",
@@ -296,7 +291,9 @@ class ConfigValidator:
             if not resolved.is_absolute():
                 resolved = base / resolved
             # auto_discover dirs are allowed to be absent (created lazily).
-            auto_discover = getattr(item, "auto_discover", False) if not isinstance(item, str) else False
+            auto_discover = (
+                getattr(item, "auto_discover", False) if not isinstance(item, str) else False
+            )
             if not resolved.exists() and not auto_discover:
                 issues.append(
                     ConfigIssue(

--- a/python/confiture/core/config_validator.py
+++ b/python/confiture/core/config_validator.py
@@ -1,0 +1,383 @@
+"""Connection-free configuration validator (issue #144).
+
+`ConfigValidator` answers "is this config (or DSN) syntactically and
+semantically valid?" *without ever opening a database connection*. It composes
+the existing building blocks — `Environment` Pydantic validation, the
+migrations-tree helpers used by preflight — into a structured report.
+
+Each issue is the unified inner issue object (see the batch shared-issue-schema):
+``{severity, code, message, actionable, details, migration, file, line}``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from confiture.core._migrator.discovery import (
+    _version_from_migration_filename,
+    find_duplicate_migration_versions,
+)
+
+
+@dataclass(frozen=True)
+class ConfigIssue:
+    """A single config-validation finding — the unified inner issue object."""
+
+    severity: str
+    code: str
+    message: str
+    migration: str | None = None
+    file: str | None = None
+    line: int | None = None
+    actionable: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+            "migration": self.migration,
+            "file": self.file,
+            "line": self.line,
+            "actionable": self.actionable,
+            "details": self.details,
+        }
+
+
+@dataclass
+class ConfigValidationReport:
+    """Result of `validate-config` (issue #144)."""
+
+    valid: bool
+    config_source: str  # "yaml-file" | "flags" | "env"
+    migrations_path: str
+    migration_count: int
+    issues: list[ConfigIssue] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "valid": self.valid,
+            "config_source": self.config_source,
+            "migrations_path": self.migrations_path,
+            "migration_count": self.migration_count,
+            "issues": [i.to_dict() for i in self.issues],
+        }
+
+
+def _is_dsn(value: str) -> bool:
+    return value.startswith(("postgresql://", "postgres://"))
+
+
+class ConfigValidator:
+    """Validate a config source offline (never connects)."""
+
+    def __init__(
+        self,
+        *,
+        config_source: str,
+        migrations_path: Path,
+        raw: dict[str, Any] | None = None,
+        config_path: Path | None = None,
+        project_dir: Path | None = None,
+        database_url: str | None = None,
+        load_error: ConfigIssue | None = None,
+    ) -> None:
+        self._config_source = config_source
+        self._migrations_path = migrations_path
+        self._raw = raw
+        self._config_path = config_path
+        self._project_dir = project_dir
+        self._database_url = database_url
+        self._load_error = load_error
+
+    # ------------------------------------------------------------------ #
+    # Constructors
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def from_config(
+        cls, config_path: Path, *, migrations_path: Path | None = None
+    ) -> ConfigValidator:
+        """Build from a YAML config file (config_source = "yaml-file")."""
+        migrations_path = migrations_path or Path("db/migrations")
+        # Resolve include_dirs relative to the project root: for the standard
+        # db/environments/<env>.yaml layout that is three levels up; otherwise
+        # the config file's own directory.
+        if (
+            config_path.parent.name == "environments"
+            and config_path.parent.parent.name == "db"
+        ):
+            project_dir = config_path.parent.parent.parent
+        else:
+            project_dir = config_path.parent
+
+        if not config_path.exists():
+            return cls(
+                config_source="yaml-file",
+                migrations_path=migrations_path,
+                project_dir=project_dir,
+                config_path=config_path,
+                load_error=ConfigIssue(
+                    severity="error",
+                    code="CONFIG_004",
+                    message=f"Configuration file not found: {config_path}",
+                    actionable=f"Create a YAML config at {config_path} or check the path.",
+                ),
+            )
+
+        try:
+            raw = yaml.safe_load(config_path.read_text())
+        except yaml.YAMLError as e:
+            return cls(
+                config_source="yaml-file",
+                migrations_path=migrations_path,
+                project_dir=project_dir,
+                config_path=config_path,
+                load_error=ConfigIssue(
+                    severity="error",
+                    code="CONFIG_002",
+                    message=f"Invalid YAML syntax in {config_path}: {e}",
+                    file=str(config_path),
+                    actionable="Fix the YAML syntax (indentation / quoting).",
+                ),
+            )
+
+        if not isinstance(raw, dict):
+            return cls(
+                config_source="yaml-file",
+                migrations_path=migrations_path,
+                project_dir=project_dir,
+                config_path=config_path,
+                load_error=ConfigIssue(
+                    severity="error",
+                    code="CONFIG_002",
+                    message=f"Invalid config format in {config_path}: expected a mapping.",
+                    file=str(config_path),
+                    actionable="The top-level YAML must be a mapping of keys.",
+                ),
+            )
+
+        return cls(
+            config_source="yaml-file",
+            migrations_path=migrations_path,
+            project_dir=project_dir,
+            config_path=config_path,
+            raw=raw,
+        )
+
+    @classmethod
+    def from_flags(
+        cls, *, database_url: str, migrations_path: Path | None = None
+    ) -> ConfigValidator:
+        """Build from a direct --database-url flag (config_source = "flags")."""
+        return cls(
+            config_source="flags",
+            migrations_path=migrations_path or Path("db/migrations"),
+            database_url=database_url,
+        )
+
+    @classmethod
+    def from_env(
+        cls, *, database_url: str, migrations_path: Path | None = None
+    ) -> ConfigValidator:
+        """Build from a DSN found in the environment (config_source = "env")."""
+        return cls(
+            config_source="env",
+            migrations_path=migrations_path or Path("db/migrations"),
+            database_url=database_url,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Validation
+    # ------------------------------------------------------------------ #
+
+    def validate(self) -> ConfigValidationReport:
+        """Run all offline checks and return the structured report."""
+        issues: list[ConfigIssue] = []
+
+        if self._load_error is not None:
+            issues.append(self._load_error)
+        elif self._raw is not None:
+            issues.extend(self._validate_schema(self._raw))
+        elif self._database_url is not None:
+            issues.extend(self._validate_dsn_format(self._database_url))
+
+        migration_count, tree_issues = self._validate_migrations_tree()
+        issues.extend(tree_issues)
+
+        valid = not any(i.severity in ("error", "critical") for i in issues)
+        return ConfigValidationReport(
+            valid=valid,
+            config_source=self._config_source,
+            migrations_path=str(self._migrations_path),
+            migration_count=migration_count,
+            issues=issues,
+        )
+
+    def _validate_schema(self, raw: dict[str, Any]) -> list[ConfigIssue]:
+        from pydantic import ValidationError
+
+        from confiture.config.environment import Environment
+        from confiture.exceptions import ConfigurationError
+
+        # Best-effort env-var expansion so ${VAR} placeholders that are set
+        # validate; a missing var stays literal and surfaces as a config issue
+        # (a malformed DSN) rather than connecting or crashing.
+        expanded = _expand_env(raw)
+
+        issues: list[ConfigIssue] = []
+        try:
+            env = Environment.model_validate(expanded)
+        except ConfigurationError as e:
+            issues.append(
+                ConfigIssue(
+                    severity="error",
+                    code=e.error_code or "CONFIG_001",
+                    message=str(e),
+                    file=str(self._config_path) if self._config_path else None,
+                    actionable=e.resolution_hint,
+                )
+            )
+            return issues
+        except ValidationError as e:
+            issues.extend(self._pydantic_to_issues(e))
+            return issues
+
+        issues.extend(self._validate_include_dirs(env))
+        return issues
+
+    def _pydantic_to_issues(self, error: Any) -> list[ConfigIssue]:
+        """Translate a Pydantic ValidationError into ConfigIssues.
+
+        A missing required field → CONFIG_001; a bad database_url → CONFIG_003;
+        anything else → CONFIG_001. The non-filesystem loc path goes in
+        ``details.config_path`` (not ``file``).
+        """
+        issues: list[ConfigIssue] = []
+        for err in error.errors():
+            loc = list(err.get("loc", ()))
+            etype = err.get("type", "")
+            field_name = str(loc[0]) if loc else ""
+            if etype == "missing":
+                code = "CONFIG_001"
+                actionable = "Add the required field to your config file."
+            elif field_name == "database_url":
+                code = "CONFIG_003"
+                actionable = "Use format: postgresql://user:password@host:port/database"
+            else:
+                code = "CONFIG_001"
+                actionable = "Fix the field to match the expected type/shape."
+            issues.append(
+                ConfigIssue(
+                    severity="error",
+                    code=code,
+                    message=f"{'.'.join(map(str, loc)) or 'config'}: {err.get('msg', 'invalid')}",
+                    file=str(self._config_path) if self._config_path else None,
+                    actionable=actionable,
+                    details={"config_path": loc} if loc else {},
+                )
+            )
+        return issues
+
+    def _validate_include_dirs(self, env: Any) -> list[ConfigIssue]:
+        issues: list[ConfigIssue] = []
+        base = self._project_dir or Path.cwd()
+        for item in env.include_dirs:
+            path_str = item if isinstance(item, str) else getattr(item, "path", None)
+            if not path_str:
+                continue
+            resolved = Path(path_str)
+            if not resolved.is_absolute():
+                resolved = base / resolved
+            # auto_discover dirs are allowed to be absent (created lazily).
+            auto_discover = getattr(item, "auto_discover", False) if not isinstance(item, str) else False
+            if not resolved.exists() and not auto_discover:
+                issues.append(
+                    ConfigIssue(
+                        severity="error",
+                        code="CONFIG_001",
+                        message=f"Include directory does not exist: {resolved}",
+                        file=str(resolved),
+                        actionable="Create the directory or correct the include_dirs path.",
+                    )
+                )
+        return issues
+
+    def _validate_dsn_format(self, database_url: str) -> list[ConfigIssue]:
+        if _is_dsn(database_url):
+            return []
+        return [
+            ConfigIssue(
+                severity="error",
+                code="CONFIG_003",
+                message=f"Invalid database URL format: {database_url}",
+                actionable="Use format: postgresql://user:password@host:port/database",
+            )
+        ]
+
+    def _validate_migrations_tree(self) -> tuple[int, list[ConfigIssue]]:
+        issues: list[ConfigIssue] = []
+        migrations_dir = self._migrations_path
+        if not migrations_dir.exists():
+            # Not an error by itself — a project may have no migrations yet.
+            return 0, issues
+
+        sql_files = sorted(migrations_dir.glob("*.up.sql"))
+        py_files = sorted(
+            f
+            for f in migrations_dir.glob("*.py")
+            if f.name != "__init__.py" and not f.name.startswith("_")
+        )
+        files = sql_files + py_files
+
+        for f in files:
+            version = _version_from_migration_filename(f.name)
+            if not version or version == f.name.split(".")[0]:
+                # No parseable {version}_{name} prefix.
+                base = f.name.split(".")[0]
+                if "_" not in base:
+                    issues.append(
+                        ConfigIssue(
+                            severity="error",
+                            code="MIGR_102",
+                            message=f"Migration filename is not well-formed: {f.name} "
+                            f"(expected <version>_<name>.up.sql or .py).",
+                            file=str(f),
+                            migration=version or None,
+                            actionable="Rename to <version>_<name>.up.sql (e.g. "
+                            "20260531120000_add_users.up.sql).",
+                        )
+                    )
+
+        duplicates = find_duplicate_migration_versions(migrations_dir)
+        for version, dup_files in duplicates.items():
+            issues.append(
+                ConfigIssue(
+                    severity="error",
+                    code="MIGR_106",
+                    message=f"Duplicate migration version {version}: "
+                    f"{', '.join(f.name for f in dup_files)}.",
+                    migration=version,
+                    actionable="Rename files to use unique version prefixes.",
+                    details={"files": [f.name for f in dup_files]},
+                )
+            )
+
+        return len(files), issues
+
+
+def _expand_env(value: Any) -> Any:
+    """Recursively expand ${VAR} in strings (best-effort; missing → literal)."""
+    if isinstance(value, str):
+        return os.path.expandvars(value)
+    if isinstance(value, dict):
+        return {k: _expand_env(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_expand_env(v) for v in value]
+    return value

--- a/python/confiture/core/connection.py
+++ b/python/confiture/core/connection.py
@@ -11,7 +11,7 @@ from typing import Any
 import psycopg
 import yaml
 
-from confiture.exceptions import MigrationError
+from confiture.exceptions import ConfigurationError, MigrationError
 
 
 def load_config(config_file: Path) -> dict[str, Any]:
@@ -24,11 +24,12 @@ def load_config(config_file: Path) -> dict[str, Any]:
         Configuration dictionary
 
     Raises:
-        MigrationError: If config file is invalid
+        ConfigurationError: If the config file is missing or invalid (exit 5).
     """
     if not config_file.exists():
-        raise MigrationError(
+        raise ConfigurationError(
             f"Configuration file not found: {config_file}",
+            error_code="CONFIG_004",
             resolution_hint=f"Create a YAML config file at {config_file} or check the path is correct",
         )
 
@@ -37,8 +38,9 @@ def load_config(config_file: Path) -> dict[str, Any]:
             config: dict[str, Any] = yaml.safe_load(f)
         return config
     except yaml.YAMLError as e:
-        raise MigrationError(
+        raise ConfigurationError(
             f"Invalid YAML configuration: {e}",
+            error_code="CONFIG_002",
             resolution_hint="Check the YAML syntax in your config file for indentation or formatting errors",
         ) from e
 
@@ -54,7 +56,7 @@ def create_connection(config: dict[str, Any] | Any) -> psycopg.Connection:
         PostgreSQL connection
 
     Raises:
-        MigrationError: If connection fails
+        ConfigurationError: If the connection fails (CONFIG_006 → exit 3).
     """
     from confiture.config.environment import DatabaseConfig
 
@@ -91,8 +93,9 @@ def create_connection(config: dict[str, Any] | Any) -> psycopg.Connection:
                 )
         return conn
     except psycopg.Error as e:
-        raise MigrationError(
+        raise ConfigurationError(
             f"Failed to connect to database: {e}",
+            error_code="CONFIG_006",
             resolution_hint="Check that the database server is running and the connection credentials are correct",
         ) from e
 
@@ -145,8 +148,9 @@ def open_connection(
         elif isinstance(config, dict):
             database_url = config.get("database_url", "")
         else:
-            raise MigrationError(
+            raise ConfigurationError(
                 "Cannot determine database_url for SSH tunnel",
+                error_code="CONFIG_001",
                 resolution_hint="Ensure your config has a 'database_url' field",
             )
 
@@ -154,8 +158,9 @@ def open_connection(
             try:
                 conn = psycopg.connect(patched_url)
             except psycopg.Error as e:
-                raise MigrationError(
+                raise ConfigurationError(
                     f"Failed to connect through SSH tunnel: {e}",
+                    error_code="CONFIG_006",
                     resolution_hint="Check that the SSH tunnel opened correctly and the database URL is valid",
                 ) from e
             try:

--- a/python/confiture/core/error_codes.py
+++ b/python/confiture/core/error_codes.py
@@ -7,23 +7,29 @@ Error codes follow the format: CATEGORY_NNN where:
 - CATEGORY is a 3-6 letter category name (CONFIG, MIGR, SCHEMA, etc.)
 - NNN is a 3-digit number within the category (001-999)
 
-Categories and their exit codes:
-- CONFIG (001-099): Configuration errors → exit code 2
+Categories and their exit codes (the #146 stabilized convention; see
+docs/reference/exit-codes.md and CANONICAL_EXIT_CODES below for the contract):
+- CONFIG (001-099): Configuration errors → exit code 5
+    (carve-out: CONFIG_006 "connection failed" → 3)
 - MIGR (100-199): Migration execution errors → exit code 3
+    (carve-outs: MIGR_101/105 success-with-signal → 0)
 - SCHEMA (200-299): Schema DDL and build errors → exit code 4
 - SYNC (300-399): Production data sync errors → exit code 5
 - DIFFER (400-499): Schema diff detection errors → exit code 5
+    (carve-out: DIFFER_402 ambiguous-change advisory → 1)
 - VALID (500-599): Validation errors → exit code 5
 - ROLLBACK (600-699): Rollback errors → exit code 8
 - SQL (700-799): SQL execution errors → exit code 1
 - GIT (800-899): Git operation errors → exit code 7
 - PGGIT (900-999): pgGit integration errors → exit code 7
 - PRECON (1000-1099): Precondition errors → exit code 5
+    (carve-out: PRECON_1001 "tracking table absent" → 2)
 - HOOK (1100-1199): Hook execution errors → exit code 1
 - POOL (1200-1299): Connection pool errors → exit code 6
 - LOCK (1300-1399): Database locking errors → exit code 6
 - ANON (1400-1499): Anonymization errors → exit code 5
 - LINT (1500-1599): Schema linting errors → exit code 5
+    (carve-out: LINT_1501 non-blocking advisory → 0)
 """
 
 from dataclasses import dataclass
@@ -151,7 +157,7 @@ def _create_global_registry() -> ErrorCodeRegistry:
     """Create and populate the global error code registry.
 
     Returns:
-        Populated ErrorCodeRegistry with all 78 error codes
+        Populated ErrorCodeRegistry with all 72 error codes
     """
     registry = ErrorCodeRegistry()
 
@@ -161,42 +167,42 @@ def _create_global_registry() -> ErrorCodeRegistry:
             code="CONFIG_001",
             message_template="Missing required field '{field}' in {file}",
             severity=ErrorSeverity.ERROR,
-            exit_code=2,
+            exit_code=5,
             resolution_hint="Add the field to your config file or set the corresponding environment variable",
         ),
         ErrorCodeDefinition(
             code="CONFIG_002",
             message_template="Invalid YAML syntax in {file}",
             severity=ErrorSeverity.ERROR,
-            exit_code=2,
+            exit_code=5,
             resolution_hint="Check the YAML syntax in your configuration file",
         ),
         ErrorCodeDefinition(
             code="CONFIG_003",
             message_template="Invalid database URL format",
             severity=ErrorSeverity.ERROR,
-            exit_code=2,
+            exit_code=5,
             resolution_hint="Use format: postgresql://user:password@host:port/database",
         ),
         ErrorCodeDefinition(
             code="CONFIG_004",
             message_template="Environment config not found: {env}",
             severity=ErrorSeverity.ERROR,
-            exit_code=2,
+            exit_code=5,
             resolution_hint="Create configuration file for this environment or use an existing one",
         ),
         ErrorCodeDefinition(
             code="CONFIG_005",
             message_template="Invalid include/exclude pattern",
             severity=ErrorSeverity.ERROR,
-            exit_code=2,
+            exit_code=5,
             resolution_hint="Check glob patterns in your configuration",
         ),
         ErrorCodeDefinition(
             code="CONFIG_006",
             message_template="Database connection failed",
             severity=ErrorSeverity.ERROR,
-            exit_code=2,
+            exit_code=3,
             resolution_hint="Check database URL, host, port, and credentials",
         ),
     ]
@@ -536,7 +542,7 @@ def _create_global_registry() -> ErrorCodeRegistry:
             code="PRECON_1001",
             message_template="Database not initialized",
             severity=ErrorSeverity.ERROR,
-            exit_code=5,
+            exit_code=2,
             resolution_hint="Run 'confiture init' to initialize the database",
         ),
     ]
@@ -669,7 +675,7 @@ def _create_global_registry() -> ErrorCodeRegistry:
             code="CONFIG_010",
             message_template="Database URL not set in environment '{env}'",
             severity=ErrorSeverity.ERROR,
-            exit_code=2,
+            exit_code=5,
             resolution_hint="Set database_url in db/environments/{env}.yaml or DATABASE_URL environment variable",
         ),
     ]
@@ -803,3 +809,162 @@ def _create_global_registry() -> ErrorCodeRegistry:
 
 # Global registry instance
 ERROR_CODE_REGISTRY = _create_global_registry()
+
+
+# ============================================================================
+# Canonical exit-code contract (issue #146)
+# ============================================================================
+#
+# CANONICAL_EXIT_CODES is the single, HAND-AUTHORED source of truth for the
+# integer process exit code every symbolic error code maps to. It is written
+# directly from docs/reference/exit-codes.md — it is NOT derived from the
+# registry. The convention test (tests/unit/test_exit_code_convention.py)
+# asserts ERROR_CODE_REGISTRY == this dict; deriving one from the other would
+# make that test a tautology. The redundancy IS the enforcement mechanism.
+#
+# Family defaults (the renumbered convention #146 freezes as a contract):
+#   2 = tracking table absent (PRECON_1001 only)   3 = DB connection failed
+#   4 = schema/DDL/build       5 = config invalid + validation/sync/lint/...
+#   6 = lock / pool contention 7 = git / pggit / grant
+#   8 = irreversible rollback  1 = generic SQL/hook   0 = success-with-signal
+#
+# Per-code carve-outs that deliberately differ from their family default are
+# annotated inline; do not "align" them to the family number during audits.
+CANONICAL_EXIT_CODES: dict[str, int] = {
+    # CONFIG family → 5 (config invalid), with CONFIG_006 carved out to 3.
+    "CONFIG_001": 5,
+    "CONFIG_002": 5,
+    "CONFIG_003": 5,
+    "CONFIG_004": 5,
+    "CONFIG_005": 5,
+    "CONFIG_006": 3,  # carve-out: DB connection failed (family is otherwise 5)
+    "CONFIG_010": 5,
+    # MIGR family → 3, with two success-with-signal carve-outs at 0.
+    "MIGR_001": 3,
+    "MIGR_004": 3,
+    "MIGR_010": 3,
+    "MIGR_011": 3,
+    "MIGR_100": 3,
+    "MIGR_101": 0,  # carve-out: already applied — success-with-signal
+    "MIGR_102": 3,
+    "MIGR_103": 3,
+    "MIGR_104": 3,
+    "MIGR_105": 0,  # carve-out: no pending migrations — success-with-signal
+    "MIGR_106": 3,
+    "MIGR_107": 3,
+    # SCHEMA family → 4.
+    "SCHEMA_001": 4,
+    "SCHEMA_200": 4,
+    "SCHEMA_201": 4,
+    "SCHEMA_202": 4,
+    "SCHEMA_203": 4,
+    "SCHEMA_204": 4,
+    # SYNC family → 5.
+    "SYNC_001": 5,
+    "SYNC_300": 5,
+    "SYNC_301": 5,
+    "SYNC_302": 5,
+    "SYNC_303": 5,
+    # DIFFER family → 5, with DIFFER_402 carved out to 1 (generic advisory).
+    "DIFFER_400": 5,
+    "DIFFER_401": 5,
+    "DIFFER_402": 1,  # carve-out: ambiguous-change advisory (family is otherwise 5)
+    "DIFF_001": 5,
+    # VALID family → 5.
+    "VALID_001": 5,
+    "VALID_500": 5,
+    "VALID_501": 5,
+    "VALID_502": 5,
+    "VERIFY_001": 5,
+    # ROLLBACK family → 8 (irreversible / inconsistent state).
+    "ROLLBACK_001": 8,
+    "ROLLBACK_600": 8,
+    "ROLLBACK_601": 8,
+    "ROLLBACK_602": 8,
+    # SQL family → 1 (generic execution failure).
+    "SQL_001": 1,
+    "SQL_700": 1,
+    "SQL_701": 1,
+    "SQL_702": 1,
+    "SQL_703": 1,
+    # GIT / PGGIT / GRANT → 7.
+    "GIT_001": 7,
+    "GIT_002": 7,
+    "GIT_800": 7,
+    "GIT_801": 7,
+    "GIT_802": 7,
+    "GRANT_001": 7,
+    "PGGIT_900": 7,
+    "PGGIT_901": 7,
+    # GEN → 3 (migration generation belongs with the MIGR family number).
+    "GEN_001": 3,
+    # PRECON family → 5, with PRECON_1001 carved out to 2 (no tracking table).
+    "PRECON_1000": 5,
+    "PRECON_1001": 2,  # carve-out: tracking table absent (family is otherwise 5)
+    # HOOK family → 1 (generic; a hook failure is not a confiture-domain error).
+    "HOOK_1100": 1,
+    "HOOK_1101": 1,
+    # POOL / LOCK → 6 (contention).
+    "POOL_1200": 6,
+    "POOL_1201": 6,
+    "LOCK_1300": 6,
+    "LOCK_1301": 6,
+    # ANON family → 5.
+    "ANON_1400": 5,
+    "ANON_1401": 5,
+    # LINT family → 5, with LINT_1501 carved out to 0 (non-blocking advisory).
+    "LINT_1500": 5,
+    "LINT_1501": 0,  # carve-out: lint warning — informational, non-blocking
+    # REBUILD → 4 (schema family number).
+    "REBUILD_001": 4,
+    # RESTORE / SEED → 5.
+    "RESTORE_001": 5,
+    "SEED_001": 5,
+}
+
+
+# Human-readable meaning of each integer exit code in the canonical convention.
+# This is the operator-facing summary; the per-code mapping lives in
+# CANONICAL_EXIT_CODES above. Codes 0–8 are in use; 9 is reserved.
+EXIT_CODE_MEANINGS: dict[int, str] = {
+    0: "Success (including success-with-signal: already applied, nothing pending, advisories)",
+    1: "Generic failure (SQL/hook execution, ambiguous-change advisory, status: pending)",
+    2: "Tracking table absent — confiture not initialized on this database yet",
+    3: "Database connection failed — host/auth/network unreachable",
+    4: "Schema / DDL / build error",
+    5: "Configuration invalid, or validation / sync / lint / precondition failure",
+    6: "Lock or connection-pool contention — another writer holds the lock",
+    7: "Git / pgGit / grant-accompaniment error",
+    8: "Irreversible rollback, or inconsistent state after rollback",
+}
+
+
+def render_exit_codes_doc() -> str:
+    """Render the canonical exit-code reference as Markdown.
+
+    The output is generated from the HAND-AUTHORED ``CANONICAL_EXIT_CODES`` and
+    ``EXIT_CODE_MEANINGS`` — never from the registry — so the human-facing doc
+    can never drift from the frozen contract. ``docs/reference/exit-codes.md``
+    embeds this between generated-section markers; a coverage test asserts every
+    in-use code has a row.
+
+    Returns:
+        Markdown containing the summary table and the per-code breakdown.
+    """
+    used_codes = sorted(set(CANONICAL_EXIT_CODES.values()))
+
+    lines: list[str] = []
+    lines.append("| Exit | Meaning |")
+    lines.append("|------|---------|")
+    for code in used_codes:
+        lines.append(f"| {code} | {EXIT_CODE_MEANINGS.get(code, '(reserved)')} |")
+
+    lines.append("")
+    lines.append("### Symbolic codes per exit code")
+    lines.append("")
+    for code in used_codes:
+        symbols = sorted(c for c, ec in CANONICAL_EXIT_CODES.items() if ec == code)
+        lines.append(f"- **{code}** — {EXIT_CODE_MEANINGS.get(code, '(reserved)')}")
+        lines.append(f"  - {', '.join(symbols)}")
+
+    return "\n".join(lines)

--- a/python/confiture/core/error_codes.py
+++ b/python/confiture/core/error_codes.py
@@ -989,7 +989,5 @@ def render_error_codebook() -> str:
     for d in sorted(ERROR_CODE_REGISTRY.all_codes(), key=_sort_key):
         message = d.message_template.replace("|", "\\|").replace("\n", " ")
         hint = (d.resolution_hint or "—").replace("|", "\\|").replace("\n", " ")
-        lines.append(
-            f"| `{d.code}` | {d.exit_code} | {d.severity.value} | {message} | {hint} |"
-        )
+        lines.append(f"| `{d.code}` | {d.exit_code} | {d.severity.value} | {message} | {hint} |")
     return "\n".join(lines)

--- a/python/confiture/core/error_codes.py
+++ b/python/confiture/core/error_codes.py
@@ -968,3 +968,28 @@ def render_exit_codes_doc() -> str:
         lines.append(f"  - {', '.join(symbols)}")
 
     return "\n".join(lines)
+
+
+def render_error_codebook() -> str:
+    """Render the full symbolic error-code codebook as Markdown (issue #145).
+
+    Generated from ``ERROR_CODE_REGISTRY`` so the published codebook can never
+    drift from the codes the CLI actually emits in ``--format json``. One table
+    row per code: symbolic code, exit code, severity, message template, and the
+    resolution hint surfaced as the envelope's ``actionable`` field.
+    """
+
+    def _sort_key(d: ErrorCodeDefinition) -> tuple[str, int]:
+        family, _, number = d.code.partition("_")
+        return (family, int(number) if number.isdigit() else 0)
+
+    lines: list[str] = []
+    lines.append("| Code | Exit | Severity | Message | Actionable |")
+    lines.append("|------|:----:|----------|---------|------------|")
+    for d in sorted(ERROR_CODE_REGISTRY.all_codes(), key=_sort_key):
+        message = d.message_template.replace("|", "\\|").replace("\n", " ")
+        hint = (d.resolution_hint or "—").replace("|", "\\|").replace("\n", " ")
+        lines.append(
+            f"| `{d.code}` | {d.exit_code} | {d.severity.value} | {message} | {hint} |"
+        )
+    return "\n".join(lines)

--- a/python/confiture/core/error_handler.py
+++ b/python/confiture/core/error_handler.py
@@ -172,6 +172,15 @@ def handle_cli_error(error: Exception) -> int:
                 return 1
         return 1
 
+    # Lock contention maps to LOCK_1300 (exit 6 per #146) even though
+    # LockAcquisitionError is not a ConfiturError (issue #147).
+    from confiture.core.locking import LockAcquisitionError
+
+    if isinstance(error, LockAcquisitionError):
+        from confiture.core.error_codes import ERROR_CODE_REGISTRY
+
+        return ERROR_CODE_REGISTRY.get("LOCK_1300").exit_code
+
     # For other exceptions, return generic error code
     return 1
 

--- a/python/confiture/core/linting/libraries/replica.py
+++ b/python/confiture/core/linting/libraries/replica.py
@@ -1,0 +1,131 @@
+"""Lint rule: replica-aware forward-compatibility (REPLICA001, issue #139).
+
+Classifies each DDL operation in the migrations tree and flags those that are
+not forward-compatible under streaming replication, with the multi-step
+remediation. Severity follows the #139 policy (warn by default, error when the
+project declares replicas; a config bypass downgrades errors to warnings).
+
+One engine (`_iter_findings`) feeds two surfaces: the `confiture lint` rule
+(`Replica001ForwardCompat`, LintViolations) and `migrate preflight`
+(`replica_preflight_issues`, the #148 PreflightIssue / PFLIGHT_REPLICA_* shape).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from confiture.core.linting.schema_linter import LintViolation, RuleSeverity
+from confiture.core.replica.classifier import DdlOperation, OperationClassifier
+from confiture.core.replica.safety import (
+    ReplicaVerdict,
+    classify_replica_safety,
+    replica_severity,
+)
+
+if TYPE_CHECKING:
+    from confiture.models.results import PreflightIssue
+
+RULE_ID = "replica_001"
+RULE_NAME = "replica-forward-compat"
+
+# Operation class name → stable PFLIGHT_REPLICA_* code for the preflight surface.
+REPLICA_CODE_BY_OP = {
+    "AddColumn": "PFLIGHT_REPLICA_ADD_COLUMN",
+    "DropColumn": "PFLIGHT_REPLICA_DROP_COLUMN",
+    "RenameColumn": "PFLIGHT_REPLICA_RENAME_COLUMN",
+    "ChangeColumnType": "PFLIGHT_REPLICA_CHANGE_TYPE",
+    "AddConstraint": "PFLIGHT_REPLICA_ADD_CONSTRAINT",
+    "CreateIndex": "PFLIGHT_REPLICA_CREATE_INDEX",
+    "Other": "PFLIGHT_REPLICA_UNCLASSIFIED",
+}
+
+
+@dataclass(frozen=True)
+class ReplicaFinding:
+    """A single replica-unsafe (or unclassifiable) operation in a migration."""
+
+    op: DdlOperation
+    verdict: ReplicaVerdict
+    severity: str  # "error" | "warning"
+    migration_file: Path
+
+    @property
+    def code(self) -> str:
+        return REPLICA_CODE_BY_OP.get(type(self.op).__name__, "PFLIGHT_REPLICA_UNCLASSIFIED")
+
+    @property
+    def message(self) -> str:
+        msg = self.verdict.reason or "Operation is not replica-forward-compatible."
+        if self.verdict.multi_step:
+            msg += f" Multi-step fix: {self.verdict.multi_step}."
+        return msg
+
+
+def _iter_findings(
+    migrations_dir: Path, *, has_replicas: bool, bypass: bool
+) -> Iterator[ReplicaFinding]:
+    """Yield one finding per replica-unsafe / unclassifiable operation."""
+    if not migrations_dir.exists():
+        return
+    classifier = OperationClassifier()
+    for migration in sorted(migrations_dir.glob("*.up.sql")):
+        text = migration.read_text()
+        for op in classifier.classify(text):
+            verdict = classify_replica_safety(op)
+            if verdict.safety == "safe":
+                continue
+            severity = replica_severity(verdict, has_replicas=has_replicas, bypass=bypass)
+            yield ReplicaFinding(
+                op=op, verdict=verdict, severity=severity, migration_file=migration
+            )
+
+
+class Replica001ForwardCompat:
+    """Flag replica-unsafe single-step DDL with multi-step guidance (`confiture lint`)."""
+
+    category = "replica"  # rule-selection tag for `confiture lint --replica-safe`
+
+    def __init__(self, *, has_replicas: bool = False, bypass: bool = False) -> None:
+        self.has_replicas = has_replicas
+        self.bypass = bypass
+
+    def check(self, migrations_dir: Path) -> list[LintViolation]:
+        """Return one LintViolation per replica-unsafe / unclassifiable operation."""
+        return [
+            LintViolation(
+                rule_id=RULE_ID,
+                rule_name=RULE_NAME,
+                severity=RuleSeverity(f.severity),
+                object_type="migration",
+                object_name=f.op.table or f.migration_file.name,
+                message=f.message,
+                file_path=str(f.migration_file),
+                line_number=f.op.line,
+            )
+            for f in _iter_findings(
+                migrations_dir, has_replicas=self.has_replicas, bypass=self.bypass
+            )
+        ]
+
+
+def replica_preflight_issues(
+    migrations_dir: Path, *, has_replicas: bool, bypass: bool
+) -> list[PreflightIssue]:
+    """Return the same findings as PreflightIssues (#148 shape) for preflight."""
+    from confiture.models.results import PreflightIssue
+
+    return [
+        PreflightIssue(
+            severity=f.severity,
+            code=f.code,
+            message=f.message,
+            migration=f.op.table,
+            file=f.migration_file.name,
+            actionable=f.verdict.multi_step,
+            details={"operation": type(f.op).__name__},
+        )
+        for f in _iter_findings(migrations_dir, has_replicas=has_replicas, bypass=bypass)
+    ]

--- a/python/confiture/core/locking.py
+++ b/python/confiture/core/locking.py
@@ -15,16 +15,104 @@ PostgreSQL advisory locks are:
 import contextlib
 import hashlib
 import logging
+import os
+import socket
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import psycopg
 
 logger = logging.getLogger(__name__)
+
+# Diagnostic metadata table written under the advisory lock (issue #147).
+# Correctness never depends on it — the advisory lock is the mutex; this row is
+# best-effort identity for contenders to read.
+LOCK_HOLDER_TABLE = "confiture_lock_holder"
+
+
+@dataclass(frozen=True)
+class LockIdentity:
+    """Identity of a process acquiring the migration lock (issue #147).
+
+    ``acquired_at`` is intentionally absent here — it is set by the database
+    (server clock) when the metadata row is written, not by the client.
+    """
+
+    pid: int
+    hostname: str
+    command: str
+    user: str | None = None
+
+
+@dataclass(frozen=True)
+class LockHolder:
+    """Who holds the migration lock, merged from metadata + pg_stat_activity.
+
+    ``held_for_seconds`` is computed at read time (``now() - acquired_at``).
+    ``live`` reflects whether the holder pid is still in ``pg_stat_activity`` —
+    a stale metadata row (holder crashed) reads ``live=False``.
+    """
+
+    pid: int | None
+    hostname: str | None
+    user: str | None
+    command: str | None
+    acquired_at: str | None
+    held_for_seconds: int | None
+    live: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Public holder contract (the #145 envelope's details.holder)."""
+        return {
+            "pid": self.pid,
+            "hostname": self.hostname,
+            "user": self.user,
+            "command": self.command,
+            "acquired_at": self.acquired_at,
+            "held_for_seconds": self.held_for_seconds,
+        }
+
+
+def _holder_phrase(holder: "LockHolder | None") -> str:
+    """A short ' Held by ...' clause for the human error message (#147).
+
+    Empty when no identity is available (graceful degradation).
+    """
+    if holder is None or holder.pid is None:
+        return " Holder identity unavailable (no metadata recorded)."
+    parts = [f" Held by pid {holder.pid}"]
+    if holder.hostname:
+        parts.append(f" on {holder.hostname}")
+    if holder.command:
+        parts.append(f' running "{holder.command}"')
+    if holder.held_for_seconds is not None:
+        parts.append(f"; acquired {holder.held_for_seconds}s ago")
+    if not holder.live:
+        parts.append(" (holder process is gone — likely a stale lock)")
+    return "".join(parts) + "."
+
+
+def collect_lock_identity(command: str | None) -> LockIdentity:
+    """Collect this process's identity for the lock metadata row.
+
+    Args:
+        command: The confiture command being run (e.g. "confiture migrate up").
+            Passed explicitly by the CLI — never derived from argv, so a DSN
+            never leaks into the lock metadata. Falls back to "confiture".
+
+    Returns:
+        A LockIdentity with pid, hostname, and command. ``user`` is left to the
+        DB session (filled in at read time); ``acquired_at`` is DB-set.
+    """
+    return LockIdentity(
+        pid=os.getpid(),
+        hostname=socket.gethostname(),
+        command=command or "confiture",
+    )
 
 
 class LockMode(Enum):
@@ -54,6 +142,7 @@ class LockConfig:
     timeout_ms: int = 30000  # 30 seconds default
     lock_id: int | None = None  # Custom lock ID (auto-generated if None)
     mode: LockMode = field(default=LockMode.BLOCKING)
+    command: str | None = None  # confiture command for the lock-holder metadata (#147)
 
 
 class LockAcquisitionError(Exception):
@@ -61,11 +150,19 @@ class LockAcquisitionError(Exception):
 
     Attributes:
         timeout: True if the error was due to timeout, False otherwise
+        holder: Identity of the current lock holder (issue #147), or None when
+            unavailable (no metadata table / lock just released).
     """
 
-    def __init__(self, message: str, timeout: bool = False):
+    def __init__(
+        self,
+        message: str,
+        timeout: bool = False,
+        holder: "LockHolder | None" = None,
+    ):
         super().__init__(message)
         self.timeout = timeout
+        self.holder = holder
 
 
 class MigrationLock:
@@ -198,6 +295,8 @@ class MigrationLock:
         logger.info(
             f"Acquired migration lock (namespace={self.DEFAULT_LOCK_NAMESPACE}, id={lock_id})"
         )
+        # Best-effort diagnostic identity (#147) — never blocks the migration.
+        self._write_holder_metadata(lock_id)
 
     def _acquire_blocking(self, lock_id: int) -> None:
         """Acquire lock with timeout.
@@ -231,11 +330,12 @@ class MigrationLock:
                 # Rollback the failed transaction to clear the error state
                 with contextlib.suppress(Exception):
                     self.connection.rollback()
+                holder = self._safe_read_lock_holder()
                 raise LockAcquisitionError(
-                    f"Could not acquire migration lock within {timeout_sec}s. "
-                    "Another migration may be running. "
+                    f"Could not acquire migration lock within {timeout_sec}s.{_holder_phrase(holder)} "
                     "Use --no-lock to bypass (dangerous in multi-pod environments).",
                     timeout=True,
+                    holder=holder,
                 ) from e
 
     def _acquire_non_blocking(self, lock_id: int) -> None:
@@ -259,20 +359,13 @@ class MigrationLock:
             acquired = result[0] if result else False
 
             if not acquired:
-                # Get information about who holds the lock
-                holder = self.get_lock_holder()
-                holder_info = ""
-                if holder:
-                    holder_info = (
-                        f" Held by PID {holder['pid']}"
-                        f" ({holder['application'] or 'unknown app'})"
-                        f" since {holder['started_at']}"
-                    )
-
+                # Identify who holds the lock (issue #147).
+                holder = self._safe_read_lock_holder()
                 raise LockAcquisitionError(
-                    f"Migration lock is held by another process.{holder_info} "
+                    f"Migration lock is held by another process.{_holder_phrase(holder)} "
                     "Try again later or use blocking mode with --lock-timeout.",
                     timeout=False,
+                    holder=holder,
                 )
 
     def _release_lock(self) -> None:
@@ -308,6 +401,126 @@ class MigrationLock:
             logger.warning(f"Error releasing lock (id={lock_id}): {e}")
         finally:
             self._lock_held = False
+            # Best-effort: clear the diagnostic identity row (#147).
+            self._clear_holder_metadata(lock_id)
+
+    # ------------------------------------------------------------------ #
+    # Lock-holder identity metadata (issue #147) — diagnostic, best-effort #
+    # ------------------------------------------------------------------ #
+
+    def _write_holder_metadata(self, lock_id: int) -> None:
+        """Record who holds the lock so contenders can read it.
+
+        Best-effort: a metadata write failure (missing privileges, etc.) is
+        logged and swallowed — identity is a diagnostic nicety, never a blocker.
+        """
+        identity = collect_lock_identity(self.config.command)
+        try:
+            with self.connection.cursor() as cur:
+                cur.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {LOCK_HOLDER_TABLE} (
+                        lock_id BIGINT PRIMARY KEY,
+                        pid INT,
+                        hostname TEXT,
+                        usename TEXT,
+                        command TEXT,
+                        acquired_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                    )
+                    """
+                )
+                cur.execute(
+                    f"""
+                    INSERT INTO {LOCK_HOLDER_TABLE}
+                        (lock_id, pid, hostname, usename, command, acquired_at)
+                    VALUES (%s, %s, %s, current_user, %s, now())
+                    ON CONFLICT (lock_id) DO UPDATE SET
+                        pid = EXCLUDED.pid,
+                        hostname = EXCLUDED.hostname,
+                        usename = EXCLUDED.usename,
+                        command = EXCLUDED.command,
+                        acquired_at = now()
+                    """,
+                    (lock_id, identity.pid, identity.hostname, identity.command),
+                )
+            # Commit so contenders on other connections can see the row. Safe:
+            # the lock is acquired before any migration work, so nothing but the
+            # (idempotent) initialize + lock + this row is pending here. The
+            # session-scoped advisory lock survives the commit.
+            self.connection.commit()
+        except Exception as e:  # noqa: BLE001 — diagnostics must never block
+            logger.warning(f"Could not write lock-holder metadata (id={lock_id}): {e}")
+            with contextlib.suppress(Exception):
+                self.connection.rollback()
+
+    def _clear_holder_metadata(self, lock_id: int) -> None:
+        """Remove this lock's identity row on release (best-effort)."""
+        try:
+            with self.connection.cursor() as cur:
+                cur.execute(
+                    f"DELETE FROM {LOCK_HOLDER_TABLE} WHERE lock_id = %s",
+                    (lock_id,),
+                )
+            self.connection.commit()
+        except Exception as e:  # noqa: BLE001 — diagnostics must never block
+            logger.debug(f"Could not clear lock-holder metadata (id={lock_id}): {e}")
+            with contextlib.suppress(Exception):
+                self.connection.rollback()
+
+    def _safe_read_lock_holder(self) -> "LockHolder | None":
+        """read_lock_holder() that never raises (used on the error path)."""
+        try:
+            return self.read_lock_holder()
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Could not read lock-holder metadata: {e}")
+            with contextlib.suppress(Exception):
+                self.connection.rollback()
+            return None
+
+    def read_lock_holder(self) -> "LockHolder | None":
+        """Return the current lock holder, merging metadata + live activity.
+
+        Reads the ``confiture_lock_holder`` row (exact command/acquired_at) and
+        cross-checks ``pg_stat_activity`` for the pid's liveness. Returns None
+        when no identity is recorded (older lock, or no metadata table) — the
+        graceful-degradation path the issue requires.
+        """
+        lock_id = self._get_lock_id()
+        with self.connection.cursor() as cur:
+            # `live` is derived from pg_locks (is the advisory lock actually
+            # held?), not from pid matching: h.pid is the *client* os.getpid(),
+            # not a backend pid. A crashed holder auto-releases the advisory
+            # lock, so a row whose lock is no longer held is a stale row.
+            cur.execute(
+                f"""
+                SELECT
+                    h.pid,
+                    h.hostname,
+                    h.usename,
+                    h.command,
+                    h.acquired_at,
+                    EXTRACT(EPOCH FROM (now() - h.acquired_at))::bigint AS held_for_seconds,
+                    EXISTS (
+                        SELECT 1 FROM pg_locks
+                        WHERE locktype = 'advisory' AND classid = %s AND objid = %s
+                    ) AS live
+                FROM {LOCK_HOLDER_TABLE} h
+                WHERE h.lock_id = %s
+                """,
+                (self.DEFAULT_LOCK_NAMESPACE, lock_id, lock_id),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return LockHolder(
+            pid=row[0],
+            hostname=row[1],
+            user=row[2],
+            command=row[3],
+            acquired_at=row[4].isoformat() if row[4] else None,
+            held_for_seconds=int(row[5]) if row[5] is not None else None,
+            live=bool(row[6]),
+        )
 
     def is_locked(self) -> bool:
         """Check if migration lock is currently held (by any process).

--- a/python/confiture/core/preflight.py
+++ b/python/confiture/core/preflight.py
@@ -17,6 +17,20 @@ from confiture.core._migrator.discovery import (
 from confiture.models.results import MigrationPreflightInfo, PreflightResult
 
 
+def preflight_exit_code(summary: dict[str, int], *, strict: bool) -> int:
+    """Exit code for a completed preflight report (issue #148).
+
+    Any error-severity issue → 7 (preflight failure, per #146). Under ``strict``,
+    warnings also fail (→ 7). Otherwise 0. A clean run and a warnings-only
+    non-strict run both exit 0.
+    """
+    if summary.get("errors", 0) > 0:
+        return 7
+    if strict and summary.get("warnings", 0) > 0:
+        return 7
+    return 0
+
+
 def run_preflight(
     migrations_dir: Path,
     *,
@@ -72,6 +86,7 @@ def run_preflight(
                 name=name,
                 has_down=down_file.exists(),
                 non_transactional_statements=non_txn,
+                filename=up_file.name,
             )
         )
 
@@ -88,6 +103,7 @@ def run_preflight(
                 version=version,
                 name=name,
                 has_down=True,
+                filename=py_file.name,
             )
         )
 

--- a/python/confiture/core/replica/__init__.py
+++ b/python/confiture/core/replica/__init__.py
@@ -1,0 +1,1 @@
+"""Replica-aware forward-compatibility analysis (issue #139)."""

--- a/python/confiture/core/replica/classifier.py
+++ b/python/confiture/core/replica/classifier.py
@@ -1,0 +1,349 @@
+"""Classify migration DDL into replica-safety-relevant operations (issue #139).
+
+Reuses the two-tier parsing strategy of ``core/idempotency/`` — pglast primary,
+regex fallback — adding no new SQL parser. The output carries exactly the
+attributes the replica-safety matrix needs (nullability, DEFAULT presence,
+CONCURRENTLY, constraint kind/validation, type change).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+
+from confiture.core.idempotency.ast_detector import is_pglast_available
+
+# pglast availability, resolved at import (tests monkeypatch this to force the
+# regex backend, mirroring the idempotency CONFITURE_IDEMPOTENCY_FORCE_REGEX
+# escape hatch).
+_HAS_PGLAST = is_pglast_available()
+_FORCE_REGEX_ENV = "CONFITURE_REPLICA_FORCE_REGEX"
+
+# AlterTableType subtype values (pglast.enums.parsenodes.AlterTableType).
+_AT_ADD_COLUMN = 0
+_AT_DROP_COLUMN = 14
+_AT_ALTER_COLUMN_TYPE = 25
+_AT_ADD_CONSTRAINT = 17
+
+# ConstrType values (pglast.enums.parsenodes.ConstrType).
+_CONSTR_NOTNULL = 1
+_CONSTR_DEFAULT = 2
+_CONSTR_KIND = {5: "check", 6: "primary_key", 7: "unique", 9: "foreign_key"}
+
+_RENAME_COLUMN = 6  # ObjectType.OBJECT_COLUMN
+
+
+# ---------------------------------------------------------------------------
+# Typed operations (the replica-safety matrix domain)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DdlOperation:
+    """Base for a classified DDL operation. Attributes shared by all variants."""
+
+    table: str | None = None
+    migration_version: str | None = None
+    line: int | None = None
+
+
+@dataclass(frozen=True)
+class AddColumn(DdlOperation):
+    column: str | None = None
+    nullable: bool = True
+    has_default: bool = False
+
+
+@dataclass(frozen=True)
+class DropColumn(DdlOperation):
+    column: str | None = None
+
+
+@dataclass(frozen=True)
+class RenameColumn(DdlOperation):
+    old: str | None = None
+    new: str | None = None
+
+
+@dataclass(frozen=True)
+class ChangeColumnType(DdlOperation):
+    column: str | None = None
+
+
+@dataclass(frozen=True)
+class AddConstraint(DdlOperation):
+    kind: str | None = None
+    not_valid: bool = False
+
+
+@dataclass(frozen=True)
+class CreateIndex(DdlOperation):
+    concurrently: bool = False
+
+
+@dataclass(frozen=True)
+class CreateTable(DdlOperation):
+    pass
+
+
+@dataclass(frozen=True)
+class Other(DdlOperation):
+    """An operation the classifier could not map (e.g. dynamic SQL)."""
+
+    reason: str | None = None
+
+
+def _use_ast() -> bool:
+    if os.environ.get(_FORCE_REGEX_ENV, "").lower() in {"1", "true", "yes"}:
+        return False
+    return _HAS_PGLAST
+
+
+class OperationClassifier:
+    """Parse migration SQL into a list of typed :class:`DdlOperation`."""
+
+    def classify(self, sql: str) -> list[DdlOperation]:
+        """Return the ordered DDL operations in ``sql``.
+
+        Uses pglast when available, else a regex fallback; both backends are
+        parity-tested for the supported operations.
+        """
+        if _use_ast():
+            try:
+                return self._classify_ast(sql)
+            except Exception:  # noqa: BLE001 — fall back to regex on any parse hiccup
+                return self._classify_regex(sql)
+        return self._classify_regex(sql)
+
+    # ------------------------------------------------------------------ #
+    # pglast backend
+    # ------------------------------------------------------------------ #
+
+    def _classify_ast(self, sql: str) -> list[DdlOperation]:
+        import pglast  # noqa: PLC0415
+
+        ops: list[DdlOperation] = []
+        for raw in pglast.parse_sql(sql):
+            node = raw.stmt
+            name = type(node).__name__
+            if name == "AlterTableStmt":
+                ops.extend(self._ast_alter_table(node))
+            elif name == "RenameStmt":
+                op = self._ast_rename(node)
+                if op is not None:
+                    ops.append(op)
+            elif name == "IndexStmt":
+                ops.append(
+                    CreateIndex(
+                        table=_relname(node.relation),
+                        concurrently=bool(node.concurrent),
+                    )
+                )
+            elif name == "CreateStmt":
+                ops.append(CreateTable(table=_relname(node.relation)))
+        return ops
+
+    def _ast_alter_table(self, node: object) -> list[DdlOperation]:
+        table = _relname(getattr(node, "relation", None))
+        ops: list[DdlOperation] = []
+        for cmd in getattr(node, "cmds", None) or ():
+            subtype = _enum_int(cmd.subtype)
+            if subtype == _AT_ADD_COLUMN:
+                coldef = cmd.def_
+                column = getattr(coldef, "colname", None)
+                nullable = not _column_is_not_null(coldef)
+                has_default = _column_has_default(coldef)
+                ops.append(
+                    AddColumn(
+                        table=table, column=column, nullable=nullable, has_default=has_default
+                    )
+                )
+            elif subtype == _AT_DROP_COLUMN:
+                ops.append(DropColumn(table=table, column=cmd.name))
+            elif subtype == _AT_ALTER_COLUMN_TYPE:
+                ops.append(ChangeColumnType(table=table, column=cmd.name))
+            elif subtype == _AT_ADD_CONSTRAINT:
+                constraint = cmd.def_
+                kind = _CONSTR_KIND.get(_enum_int(getattr(constraint, "contype", None)) or -1)
+                not_valid = bool(getattr(constraint, "skip_validation", False))
+                ops.append(AddConstraint(table=table, kind=kind, not_valid=not_valid))
+        return ops
+
+    def _ast_rename(self, node: object) -> DdlOperation | None:
+        if _enum_int(getattr(node, "renameType", None)) != _RENAME_COLUMN:
+            return None
+        return RenameColumn(
+            table=_relname(getattr(node, "relation", None)),
+            old=getattr(node, "subname", None),
+            new=getattr(node, "newname", None),
+        )
+
+    # ------------------------------------------------------------------ #
+    # regex backend (fallback / parity)
+    # ------------------------------------------------------------------ #
+
+    def _classify_regex(self, sql: str) -> list[DdlOperation]:
+        ops: list[DdlOperation] = []
+        for stmt in _split_statements(sql):
+            op = self._regex_one(stmt)
+            if op is not None:
+                ops.append(op)
+        return ops
+
+    def _regex_one(self, stmt: str) -> DdlOperation | None:
+        s = stmt.strip()
+        if not s:
+            return None
+        lower = s.lower()
+
+        m = _RE_ADD_COLUMN.match(s)
+        if m:
+            rest = m.group("rest").lower()
+            return AddColumn(
+                table=_norm(m.group("table")),
+                column=_norm(m.group("col")),
+                nullable="not null" not in rest,
+                has_default="default" in rest,
+            )
+        m = _RE_DROP_COLUMN.match(s)
+        if m:
+            return DropColumn(table=_norm(m.group("table")), column=_norm(m.group("col")))
+        m = _RE_RENAME_COLUMN.match(s)
+        if m:
+            return RenameColumn(
+                table=_norm(m.group("table")),
+                old=_norm(m.group("old")),
+                new=_norm(m.group("new")),
+            )
+        m = _RE_ALTER_TYPE.match(s)
+        if m:
+            return ChangeColumnType(table=_norm(m.group("table")), column=_norm(m.group("col")))
+        m = _RE_ADD_CONSTRAINT.match(s)
+        if m:
+            return AddConstraint(
+                table=_norm(m.group("table")),
+                kind=_constraint_kind_from_text(s),
+                not_valid="not valid" in lower,
+            )
+        m = _RE_CREATE_INDEX.match(s)
+        if m:
+            return CreateIndex(
+                table=_norm(m.group("table")),
+                concurrently=m.group("conc") is not None,
+            )
+        m = _RE_CREATE_TABLE.match(s)
+        if m:
+            return CreateTable(table=_norm(m.group("table")))
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_IDENT = r'(?P<{name}>"?[\w.]+"?)'
+
+
+def _norm(ident: str | None) -> str | None:
+    if ident is None:
+        return None
+    return ident.strip().strip('"').lower()
+
+
+def _relname(relation: object) -> str | None:
+    if relation is None:
+        return None
+    relname = getattr(relation, "relname", None)
+    if not relname:
+        return None
+    schema = getattr(relation, "schemaname", None)
+    return f"{str(schema).lower()}.{str(relname).lower()}" if schema else str(relname).lower()
+
+
+def _enum_int(value: object) -> int | None:
+    if value is None:
+        return None
+    inner = getattr(value, "value", value)
+    try:
+        return int(inner)
+    except (TypeError, ValueError):
+        return None
+
+
+def _column_is_not_null(coldef: object) -> bool:
+    if bool(getattr(coldef, "is_not_null", False)):
+        return True
+    for c in getattr(coldef, "constraints", None) or ():
+        if _enum_int(getattr(c, "contype", None)) == _CONSTR_NOTNULL:
+            return True
+    return False
+
+
+def _column_has_default(coldef: object) -> bool:
+    if getattr(coldef, "raw_default", None) is not None:
+        return True
+    for c in getattr(coldef, "constraints", None) or ():
+        if _enum_int(getattr(c, "contype", None)) == _CONSTR_DEFAULT:
+            return True
+    return False
+
+
+def _constraint_kind_from_text(stmt: str) -> str | None:
+    low = stmt.lower()
+    if " check " in low or low.rstrip().endswith("check") or re.search(r"\bcheck\s*\(", low):
+        return "check"
+    if "primary key" in low:
+        return "primary_key"
+    if "unique" in low:
+        return "unique"
+    if "foreign key" in low or "references" in low:
+        return "foreign_key"
+    return None
+
+
+def _split_statements(sql: str) -> list[str]:
+    """Naive top-level split on ';' (regex fallback only)."""
+    # Strip line comments to avoid splitting on ';' inside them.
+    no_comments = re.sub(r"--[^\n]*", "", sql)
+    return no_comments.split(";")
+
+
+_RE_ADD_COLUMN = re.compile(
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
+    + r"\s+ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?" + _IDENT.format(name="col")
+    + r"\s+(?P<rest>.*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+_RE_DROP_COLUMN = re.compile(
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
+    + r"\s+DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="col"),
+    re.IGNORECASE,
+)
+_RE_RENAME_COLUMN = re.compile(
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
+    + r"\s+RENAME\s+COLUMN\s+" + _IDENT.format(name="old")
+    + r"\s+TO\s+" + _IDENT.format(name="new"),
+    re.IGNORECASE,
+)
+_RE_ALTER_TYPE = re.compile(
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
+    + r"\s+ALTER\s+COLUMN\s+" + _IDENT.format(name="col")
+    + r"\s+(?:SET\s+DATA\s+)?TYPE\s+",
+    re.IGNORECASE,
+)
+_RE_ADD_CONSTRAINT = re.compile(
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
+    + r"\s+ADD\s+CONSTRAINT\s+",
+    re.IGNORECASE,
+)
+_RE_CREATE_INDEX = re.compile(
+    r"^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?P<conc>CONCURRENTLY\s+)?"
+    r"(?:IF\s+NOT\s+EXISTS\s+)?\S+\s+ON\s+(?:ONLY\s+)?" + _IDENT.format(name="table"),
+    re.IGNORECASE,
+)
+_RE_CREATE_TABLE = re.compile(
+    r"^\s*CREATE\s+(?:UNLOGGED\s+|TEMPORARY\s+|TEMP\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    + _IDENT.format(name="table"),
+    re.IGNORECASE,
+)

--- a/python/confiture/core/replica/classifier.py
+++ b/python/confiture/core/replica/classifier.py
@@ -310,30 +310,40 @@ def _split_statements(sql: str) -> list[str]:
 
 
 _RE_ADD_COLUMN = re.compile(
-    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
-    + r"\s+ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?" + _IDENT.format(name="col")
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?"
+    + _IDENT.format(name="table")
+    + r"\s+ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    + _IDENT.format(name="col")
     + r"\s+(?P<rest>.*)$",
     re.IGNORECASE | re.DOTALL,
 )
 _RE_DROP_COLUMN = re.compile(
-    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
-    + r"\s+DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="col"),
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?"
+    + _IDENT.format(name="table")
+    + r"\s+DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?"
+    + _IDENT.format(name="col"),
     re.IGNORECASE,
 )
 _RE_RENAME_COLUMN = re.compile(
-    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
-    + r"\s+RENAME\s+COLUMN\s+" + _IDENT.format(name="old")
-    + r"\s+TO\s+" + _IDENT.format(name="new"),
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?"
+    + _IDENT.format(name="table")
+    + r"\s+RENAME\s+COLUMN\s+"
+    + _IDENT.format(name="old")
+    + r"\s+TO\s+"
+    + _IDENT.format(name="new"),
     re.IGNORECASE,
 )
 _RE_ALTER_TYPE = re.compile(
-    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
-    + r"\s+ALTER\s+COLUMN\s+" + _IDENT.format(name="col")
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?"
+    + _IDENT.format(name="table")
+    + r"\s+ALTER\s+COLUMN\s+"
+    + _IDENT.format(name="col")
     + r"\s+(?:SET\s+DATA\s+)?TYPE\s+",
     re.IGNORECASE,
 )
 _RE_ADD_CONSTRAINT = re.compile(
-    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?" + _IDENT.format(name="table")
+    r"^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?"
+    + _IDENT.format(name="table")
     + r"\s+ADD\s+CONSTRAINT\s+",
     re.IGNORECASE,
 )

--- a/python/confiture/core/replica/safety.py
+++ b/python/confiture/core/replica/safety.py
@@ -1,0 +1,111 @@
+"""Replica-safety verdicts for classified DDL operations (issue #139).
+
+Maps each :class:`DdlOperation` to a forward-compatibility verdict under
+streaming replication, with the exact multi-step remediation when unsafe. The
+verdict table is the single source the rule, the preflight surface, and the docs
+all read from — no copy-paste between code and the "why replicas need this" guide.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from confiture.core.replica.classifier import (
+    AddColumn,
+    AddConstraint,
+    ChangeColumnType,
+    CreateIndex,
+    CreateTable,
+    DdlOperation,
+    DropColumn,
+    Other,
+    RenameColumn,
+)
+
+# Severity policy threshold: replicas declared → unsafe ops are errors.
+# (Pure policy; see replica_severity below.)
+
+
+@dataclass(frozen=True)
+class ReplicaVerdict:
+    """The replica-safety verdict for a single operation."""
+
+    safety: str  # "safe" | "unsafe" | "depends"
+    reason: str | None = None
+    multi_step: str | None = None
+
+
+def classify_replica_safety(op: DdlOperation) -> ReplicaVerdict:
+    """Verdict for one operation, per the issue's replica-safety matrix.
+
+    The lag window is the crux: a replica serving reads on the *old* schema
+    while the primary already has the *new* one. ``ADD COLUMN NOT NULL`` /
+    ``DEFAULT`` stays unsafe regardless of PG's fast-default optimization
+    (OD-13) — a reader on the old schema still errors on the new column.
+    """
+    if isinstance(op, AddColumn):
+        if op.nullable and not op.has_default:
+            return ReplicaVerdict("safe")
+        return ReplicaVerdict(
+            "unsafe",
+            reason="NOT NULL and/or DEFAULT breaks readers still on the old schema",
+            multi_step="add the column nullable → backfill → SET NOT NULL in a later release",
+        )
+    if isinstance(op, DropColumn):
+        return ReplicaVerdict(
+            "unsafe",
+            reason="readers on the old schema still SELECT the column",
+            multi_step="deprecate (stop using) → wait one release → drop the column",
+        )
+    if isinstance(op, RenameColumn):
+        return ReplicaVerdict(
+            "unsafe",
+            reason="readers reference the old column name during the lag window",
+            multi_step="add the new column → dual-write → migrate readers → drop the old column",
+        )
+    if isinstance(op, ChangeColumnType):
+        return ReplicaVerdict(
+            "unsafe",
+            reason="readers on the old type break when the column type changes",
+            multi_step="add a new column → backfill → swap readers → drop the old column",
+        )
+    if isinstance(op, AddConstraint):
+        if op.not_valid:
+            return ReplicaVerdict("safe")
+        return ReplicaVerdict(
+            "unsafe",
+            reason="immediate validation locks and may reject existing rows",
+            multi_step="ADD CONSTRAINT ... NOT VALID → backfill → VALIDATE CONSTRAINT later",
+        )
+    if isinstance(op, CreateIndex):
+        if op.concurrently:
+            return ReplicaVerdict("safe")
+        return ReplicaVerdict(
+            "unsafe",
+            reason="a non-concurrent index blocks writes; the lock propagates to replicas",
+            multi_step="use CREATE INDEX CONCURRENTLY in its own non-transactional migration",
+        )
+    if isinstance(op, CreateTable):
+        return ReplicaVerdict("safe")
+    if isinstance(op, Other):
+        return ReplicaVerdict(
+            "depends",
+            reason=f"could not classify ({op.reason or 'unrecognized'}); review manually",
+        )
+    return ReplicaVerdict("depends", reason="unclassified operation; review manually")
+
+
+def replica_severity(verdict: ReplicaVerdict, *, has_replicas: bool, bypass: bool) -> str:
+    """Severity an unsafe verdict should carry, per OD-12 (owner-accepted).
+
+    Precedence: ``bypass`` always wins (downgrade to warning); otherwise replicas
+    being declared decides error-vs-warning. ``depends`` is always a warning
+    (never a hard block on SQL the parser couldn't classify).
+
+    Returns one of "error" | "warning".
+    """
+    if verdict.safety == "depends":
+        return "warning"
+    if bypass:
+        return "warning"
+    return "error" if has_replicas else "warning"

--- a/python/confiture/exceptions.py
+++ b/python/confiture/exceptions.py
@@ -581,6 +581,44 @@ class MigrationOverwriteError(MigrationError):
         self.filepath = filepath
 
 
+class DatabaseNotInitializedError(ConfiturError):
+    """The tracking table is absent — confiture is not initialized on this DB.
+
+    The fresh-database signal: a command that needs the tracking table (e.g.
+    ``migrate current``) found it missing. Defaults to ``PRECON_1001``, which
+    exits 2 per the #146 convention (a distinct, low-numbered "not initialized
+    yet" signal, separate from connection failures and config errors).
+
+    Note: distinct from ``confiture.core.preconditions.PreconditionError``,
+    which is the migration-runtime precondition failure (a different concern).
+
+    Example:
+        >>> raise DatabaseNotInitializedError("Tracking table absent")
+    """
+
+    def __init__(
+        self,
+        message: str = "Database not initialized",
+        *,
+        error_code: str | None = None,
+        severity: ErrorSeverity | None = None,
+        context: dict[str, Any] | None = None,
+        resolution_hint: str | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            error_code=error_code or "PRECON_1001",
+            severity=severity,
+            context=context,
+            resolution_hint=(
+                resolution_hint
+                or "Run 'confiture migrate up' to initialize the tracking table, "
+                "or 'confiture migrate baseline --through <version>' if the schema "
+                "is already applied."
+            ),
+        )
+
+
 class ExternalGeneratorError(ConfiturError):
     """External migration generator command failed
 
@@ -806,6 +844,7 @@ __all__ = [
     "GitError",
     "NotAGitRepositoryError",
     "ExternalGeneratorError",
+    "DatabaseNotInitializedError",
     "RebuildError",
     "RestoreError",
     "SeedError",

--- a/python/confiture/models/results.py
+++ b/python/confiture/models/results.py
@@ -406,6 +406,35 @@ class MigrateDownResult:
 
 
 @dataclass
+class DownToResult:
+    """Result of `migrate down-to <revision>` (issue #142).
+
+    Serializes to the issue's plan+result shape ``{from, to, rolled_back,
+    skipped, errors}``. ``rolled_back`` is newest → oldest. ``skipped`` holds
+    versions in the computed set that were unexpectedly not applied; ``errors``
+    holds runtime SQL failures during execution (distinct from the up-front
+    missing-`.down.sql` refusal, which aborts before any execution).
+    """
+
+    from_: str | None
+    to: str
+    rolled_back: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    noop: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the issue's `{from, to, rolled_back, skipped, errors}` shape."""
+        return {
+            "from": self.from_,
+            "to": self.to,
+            "rolled_back": self.rolled_back,
+            "skipped": self.skipped,
+            "errors": self.errors,
+        }
+
+
+@dataclass
 class MigrateRebuildResult:
     """Result of migrate rebuild operation.
 

--- a/python/confiture/models/results.py
+++ b/python/confiture/models/results.py
@@ -723,6 +723,7 @@ class MigrationPreflightInfo:
     has_down: bool
     non_transactional_statements: list[str] = field(default_factory=list)
     checksum: str | None = None
+    filename: str | None = None  # source filename, for issue attribution (#148)
 
     @property
     def reversible(self) -> bool:
@@ -808,6 +809,172 @@ class PreflightResult:
             "migrations": [m.to_dict() for m in self.migrations],
             "duplicate_versions": self.duplicate_versions,
             "checksum_mismatches": self.checksum_mismatches,
+        }
+
+    @property
+    def issues(self) -> list[PreflightIssue]:
+        """Per-check, per-migration issues in the unified shape (#148).
+
+        Fans the existing reversibility / transactionality / duplicate-version /
+        checksum checks into ``PreflightIssue``s. One issue per (check, migration).
+        """
+        out: list[PreflightIssue] = []
+        for m in self.irreversible:
+            out.append(
+                PreflightIssue.of(
+                    "PFLIGHT_MISSING_DOWN",
+                    f"Migration {m.version} ({m.name}) is not reversible: "
+                    f"no matching .down.sql.",
+                    migration=m.version,
+                    file=m.filename,
+                )
+            )
+        for m in self.non_transactional:
+            out.append(
+                PreflightIssue.of(
+                    "PFLIGHT_NON_TRANSACTIONAL",
+                    f"Migration {m.version} ({m.name}) has non-transactional "
+                    f"statement(s): {', '.join(m.non_transactional_statements)}.",
+                    migration=m.version,
+                    file=m.filename,
+                    details={"statements": list(m.non_transactional_statements)},
+                )
+            )
+        for version, files in self.duplicate_versions.items():
+            out.append(
+                PreflightIssue.of(
+                    "PFLIGHT_DUPLICATE_VERSION",
+                    f"Duplicate migration version {version}: {', '.join(files)}.",
+                    migration=version,
+                    details={"files": list(files)},
+                )
+            )
+        for version in self.checksum_mismatches:
+            out.append(
+                PreflightIssue.of(
+                    "PFLIGHT_CHECKSUM_MISMATCH",
+                    f"Checksum mismatch for applied migration {version} "
+                    f"(file changed after it was applied).",
+                    migration=version,
+                )
+            )
+        return out
+
+    @property
+    def summary(self) -> dict[str, int]:
+        """Issue counts by severity + the number of migrations analyzed (#148)."""
+        issues = self.issues
+        return {
+            "errors": sum(1 for i in issues if i.severity == "error"),
+            "warnings": sum(1 for i in issues if i.severity == "warning"),
+            "info": sum(1 for i in issues if i.severity == "info"),
+            "migrations_checked": len(self.migrations),
+        }
+
+    def to_report_dict(self, *, strict: bool = False) -> dict[str, Any]:
+        """The structured preflight report: ``{ok, summary, issues[]}`` (#148).
+
+        ``ok`` is False if there are error-severity issues, or — under
+        ``strict`` — any warnings.
+        """
+        summary = self.summary
+        ok = summary["errors"] == 0 and not (strict and summary["warnings"] > 0)
+        return {
+            "ok": ok,
+            "summary": summary,
+            "issues": [i.to_dict() for i in self.issues],
+        }
+
+
+# Default severity + actionable text per PFLIGHT_* code (issue #148). Single
+# source the codebook doc reads. These are preflight-report issue codes (carried
+# in the report's issues[]), distinct from the ConfiturError registry codes — the
+# command's exit code is computed from the summary (preflight_exit_code), not
+# per issue code.
+PFLIGHT_CODES: dict[str, tuple[str, str]] = {
+    "PFLIGHT_MISSING_DOWN": (
+        "error",
+        "Add a matching .down.sql sibling, or mark the migration explicitly "
+        "non-reversible.",
+    ),
+    "PFLIGHT_NON_TRANSACTIONAL": (
+        "warning",
+        "Run with --allow-non-transactional to apply it in autocommit, or split "
+        "the statement out of the transactional migration.",
+    ),
+    "PFLIGHT_DUPLICATE_VERSION": (
+        "error",
+        "Rename files to use unique version prefixes.",
+    ),
+    "PFLIGHT_CHECKSUM_MISMATCH": (
+        "error",
+        "Restore the original migration file, or re-apply with --force if the "
+        "change is intentional.",
+    ),
+    "PFLIGHT_REPLAY_FAILED": (
+        "error",
+        "Fix the failing migration SQL; see details for the database error.",
+    ),
+    "PFLIGHT_LIVE_DEPENDENTS": (
+        "warning",
+        "Review the live dependents before replacing the target object.",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class PreflightIssue:
+    """A single preflight finding — the unified inner issue object (#148).
+
+    Same shape as #145's ``error`` and #144's ``issues[]`` (see
+    shared-issue-schema.md): severity/code/message always present; the rest
+    present-but-nullable.
+    """
+
+    severity: str
+    code: str
+    message: str
+    migration: str | None = None
+    file: str | None = None
+    line: int | None = None
+    actionable: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def of(
+        cls,
+        code: str,
+        message: str,
+        *,
+        migration: str | None = None,
+        file: str | None = None,
+        line: int | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> PreflightIssue:
+        """Build an issue, pulling default severity + actionable from PFLIGHT_CODES."""
+        severity, actionable = PFLIGHT_CODES.get(code, ("error", None))
+        return cls(
+            severity=severity,
+            code=code,
+            message=message,
+            migration=migration,
+            file=file,
+            line=line,
+            actionable=actionable,
+            details=details or {},
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the unified inner issue object."""
+        return {
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+            "migration": self.migration,
+            "file": self.file,
+            "line": self.line,
+            "actionable": self.actionable,
+            "details": self.details,
         }
 
 

--- a/python/confiture/models/results.py
+++ b/python/confiture/models/results.py
@@ -103,6 +103,31 @@ class StatusResult:
         }
 
 
+@dataclass(frozen=True)
+class CurrentRevision:
+    """The latest applied migration revision (issue #141).
+
+    Returned by ``MigratorSession.current_revision()`` and rendered by
+    ``confiture migrate current``. ``None`` from that method means the tracking
+    table exists but is empty (no migrations applied yet) — distinct from an
+    absent table, which raises ``PreconditionError`` (PRECON_1001).
+    """
+
+    version: str
+    name: str
+    applied_at: str | None
+    checksum: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the `migrate current --format json` payload."""
+        return {
+            "revision": self.version,
+            "name": self.name,
+            "applied_at": self.applied_at,
+            "checksum": self.checksum,
+        }
+
+
 @dataclass
 class BuildResult:
     """Result of schema build operation.

--- a/python/confiture/models/results.py
+++ b/python/confiture/models/results.py
@@ -823,8 +823,7 @@ class PreflightResult:
             out.append(
                 PreflightIssue.of(
                     "PFLIGHT_MISSING_DOWN",
-                    f"Migration {m.version} ({m.name}) is not reversible: "
-                    f"no matching .down.sql.",
+                    f"Migration {m.version} ({m.name}) is not reversible: no matching .down.sql.",
                     migration=m.version,
                     file=m.filename,
                 )
@@ -894,8 +893,7 @@ class PreflightResult:
 PFLIGHT_CODES: dict[str, tuple[str, str]] = {
     "PFLIGHT_MISSING_DOWN": (
         "error",
-        "Add a matching .down.sql sibling, or mark the migration explicitly "
-        "non-reversible.",
+        "Add a matching .down.sql sibling, or mark the migration explicitly non-reversible.",
     ),
     "PFLIGHT_NON_TRANSACTIONAL": (
         "warning",

--- a/tests/integration/test_cli_error_handling.py
+++ b/tests/integration/test_cli_error_handling.py
@@ -10,7 +10,7 @@ class TestCliExitCodes:
     """Test that CLI commands exit with correct codes."""
 
     def test_build_with_nonexistent_env(self) -> None:
-        """Test that build with nonexistent environment exits with code 2."""
+        """Test that build with a nonexistent environment exits as config-invalid."""
         result = subprocess.run(
             ["confiture", "build", "--env", "nonexistent"],
             capture_output=True,
@@ -19,8 +19,8 @@ class TestCliExitCodes:
 
         # Should exit with error code (not 0)
         assert result.returncode != 0
-        # Configuration error should exit with code 2
-        assert result.returncode in [1, 2]  # 2 is preferred for config errors
+        # #146: configuration errors exit 5 (config invalid)
+        assert result.returncode in [1, 5]
 
     def test_help_command_exits_success(self) -> None:
         """Test that help command exits with success code."""

--- a/tests/integration/test_down_to.py
+++ b/tests/integration/test_down_to.py
@@ -1,0 +1,229 @@
+"""Integration tests for `migrate down-to` and MigratorSession.down_to (#142).
+
+Uses an isolated tracking table and uniquely-named target tables so the tests
+neither depend on nor pollute the shared confiture_test state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import psycopg
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.migrator import Migrator
+from confiture.exceptions import MigrationError, RollbackError
+
+runner = CliRunner()
+_TABLE = "tb_downto_it"
+_VERSIONS = [
+    ("20260101000001", "a"),
+    ("20260102000002", "b"),
+    ("20260103000003", "c"),
+    ("20260104000004", "d"),
+]
+
+
+def _tname(name: str) -> str:
+    return f"tb_dt_{name}"
+
+
+def _write_migrations(migrations_dir: Path, *, omit_down: set[str] | None = None) -> None:
+    omit_down = omit_down or set()
+    for version, name in _VERSIONS:
+        tbl = _tname(name)
+        (migrations_dir / f"{version}_{name}.up.sql").write_text(f"CREATE TABLE {tbl} (id int);")
+        if name not in omit_down:
+            (migrations_dir / f"{version}_{name}.down.sql").write_text(f"DROP TABLE {tbl};")
+
+
+@pytest.fixture
+def conn(test_db_url: str):
+    c = psycopg.connect(test_db_url)
+
+    def _clean() -> None:
+        with c.cursor() as cur:
+            cur.execute(f"DROP TABLE IF EXISTS {_TABLE} CASCADE")
+            for _v, n in _VERSIONS:
+                cur.execute(f"DROP TABLE IF EXISTS {_tname(n)} CASCADE")
+        c.commit()
+
+    _clean()
+    try:
+        yield c
+    finally:
+        _clean()
+        c.close()
+
+
+@pytest.fixture
+def project(tmp_path: Path, test_db_url: str):
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": test_db_url,
+                "include_dirs": ["db/schema"],
+                "migration": {"tracking_table": _TABLE},
+            }
+        )
+    )
+    return cfg, migrations_dir
+
+
+def _apply_all(cfg: Path, migrations_dir: Path) -> None:
+    with Migrator.from_config(str(cfg), migrations_dir=migrations_dir) as s:
+        s.up()
+
+
+def _table_exists(conn: psycopg.Connection, name: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass(%s)", (name,))
+        return cur.fetchone()[0] is not None
+
+
+# ── session API ───────────────────────────────────────────────────────────────
+
+
+def test_down_to_rolls_back_to_target(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+
+    with Migrator.from_config(str(cfg), migrations_dir=md) as s:
+        result = s.down_to("20260102000002")
+    assert result.to == "20260102000002"
+    assert result.from_ == "20260104000004"
+    assert result.rolled_back == ["20260104000004", "20260103000003"]
+
+    # c and d rolled back (tables dropped); a and b remain.
+    assert _table_exists(conn, _tname("a"))
+    assert _table_exists(conn, _tname("b"))
+    assert not _table_exists(conn, _tname("c"))
+    assert not _table_exists(conn, _tname("d"))
+
+    with Migrator.from_config(str(cfg), migrations_dir=md) as s:
+        assert s.current_revision().version == "20260102000002"  # reuses #141
+
+
+def test_down_to_noop_when_already_there(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+    with Migrator.from_config(str(cfg), migrations_dir=md) as s:
+        result = s.down_to("20260104000004")
+    assert result.rolled_back == []
+    assert result.noop
+
+
+def test_down_to_missing_down_raises_before_applying(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+    # Remove c's .down.sql after applying → reaching past it is irreversible.
+    (md / "20260103000003_c.down.sql").unlink()
+
+    with Migrator.from_config(str(cfg), migrations_dir=md) as s:
+        before = s.current_revision().version
+        with pytest.raises(RollbackError) as e:
+            s.down_to("20260101000001")
+    assert e.value.error_code == "ROLLBACK_600"
+    assert "20260103000003" in str(e.value)
+    # NOTHING rolled back — atomic refusal.
+    with Migrator.from_config(str(cfg), migrations_dir=md) as s:
+        assert s.current_revision().version == before
+    assert _table_exists(conn, _tname("c"))
+    assert _table_exists(conn, _tname("d"))
+
+
+def test_down_to_unknown_revision_raises(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+    with Migrator.from_config(str(cfg), migrations_dir=md) as s:
+        with pytest.raises(MigrationError) as e:
+            s.down_to("nope")
+    assert e.value.error_code == "MIGR_100"
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def test_down_to_json_plan_and_result(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+    r = runner.invoke(
+        app,
+        ["migrate", "down-to", "20260102000002", "-c", str(cfg),
+         "--migrations-dir", str(md), "--format", "json"],
+    )
+    assert r.exit_code == 0, r.output
+    p = json.loads(r.stdout)
+    assert p["from"] == "20260104000004"
+    assert p["to"] == "20260102000002"
+    assert p["rolled_back"] == ["20260104000004", "20260103000003"]
+    assert p["skipped"] == []
+    assert p["errors"] == []
+
+
+def test_down_to_unknown_revision_exits_3(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+    r = runner.invoke(
+        app,
+        ["migrate", "down-to", "nope", "-c", str(cfg), "--migrations-dir", str(md)],
+    )
+    assert r.exit_code == 3, r.output
+
+
+def test_down_to_irreversible_aborts_exit_8(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+    (md / "20260103000003_c.down.sql").unlink()
+    r = runner.invoke(
+        app,
+        ["migrate", "down-to", "20260101000001", "-c", str(cfg), "--migrations-dir", str(md)],
+    )
+    assert r.exit_code == 8, r.output  # ROLLBACK_600 → 8
+    # DB unchanged — atomic-refusal guarantee.
+    assert _table_exists(conn, _tname("c"))
+    assert _table_exists(conn, _tname("d"))
+
+
+def test_down_to_dry_run_does_not_apply(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+    r = runner.invoke(
+        app,
+        ["migrate", "down-to", "20260102000002", "-c", str(cfg),
+         "--migrations-dir", str(md), "--dry-run", "--format", "json"],
+    )
+    assert r.exit_code == 0, r.output
+    p = json.loads(r.stdout)
+    assert p["rolled_back"] == ["20260104000004", "20260103000003"]
+    # Nothing actually rolled back.
+    assert _table_exists(conn, _tname("c"))
+    assert _table_exists(conn, _tname("d"))
+
+
+def test_down_to_noop_cli(conn, project) -> None:
+    cfg, md = project
+    _write_migrations(md)
+    _apply_all(cfg, md)
+    r = runner.invoke(
+        app,
+        ["migrate", "down-to", "20260104000004", "-c", str(cfg), "--migrations-dir", str(md)],
+    )
+    assert r.exit_code == 0, r.output
+    assert "already at" in r.output.lower()

--- a/tests/integration/test_down_to.py
+++ b/tests/integration/test_down_to.py
@@ -162,8 +162,17 @@ def test_down_to_json_plan_and_result(conn, project) -> None:
     _apply_all(cfg, md)
     r = runner.invoke(
         app,
-        ["migrate", "down-to", "20260102000002", "-c", str(cfg),
-         "--migrations-dir", str(md), "--format", "json"],
+        [
+            "migrate",
+            "down-to",
+            "20260102000002",
+            "-c",
+            str(cfg),
+            "--migrations-dir",
+            str(md),
+            "--format",
+            "json",
+        ],
     )
     assert r.exit_code == 0, r.output
     p = json.loads(r.stdout)
@@ -206,8 +215,18 @@ def test_down_to_dry_run_does_not_apply(conn, project) -> None:
     _apply_all(cfg, md)
     r = runner.invoke(
         app,
-        ["migrate", "down-to", "20260102000002", "-c", str(cfg),
-         "--migrations-dir", str(md), "--dry-run", "--format", "json"],
+        [
+            "migrate",
+            "down-to",
+            "20260102000002",
+            "-c",
+            str(cfg),
+            "--migrations-dir",
+            str(md),
+            "--dry-run",
+            "--format",
+            "json",
+        ],
     )
     assert r.exit_code == 0, r.output
     p = json.loads(r.stdout)

--- a/tests/integration/test_down_to.py
+++ b/tests/integration/test_down_to.py
@@ -41,9 +41,17 @@ def _write_migrations(migrations_dir: Path, *, omit_down: set[str] | None = None
             (migrations_dir / f"{version}_{name}.down.sql").write_text(f"DROP TABLE {tbl};")
 
 
+def _connect(url):
+    """Connect, or skip when no DB is reachable (mirrors test_db_connection)."""
+    try:
+        return psycopg.connect(url)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+
 @pytest.fixture
 def conn(test_db_url: str):
-    c = psycopg.connect(test_db_url)
+    c = _connect(test_db_url)
 
     def _clean() -> None:
         with c.cursor() as cur:

--- a/tests/integration/test_down_to_schema.py
+++ b/tests/integration/test_down_to_schema.py
@@ -30,9 +30,17 @@ def _validator() -> Draft202012Validator:
     )
 
 
+def _connect(url):
+    """Connect, or skip when no DB is reachable (mirrors test_db_connection)."""
+    try:
+        return psycopg.connect(url)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+
 @pytest.fixture
 def conn(test_db_url: str):
-    c = psycopg.connect(test_db_url)
+    c = _connect(test_db_url)
 
     def _clean() -> None:
         with c.cursor() as cur:

--- a/tests/integration/test_down_to_schema.py
+++ b/tests/integration/test_down_to_schema.py
@@ -83,8 +83,17 @@ def test_down_to_payload_validates(conn, project) -> None:
     cfg, md = project
     r = runner.invoke(
         app,
-        ["migrate", "down-to", "20260101000001", "-c", str(cfg),
-         "--migrations-dir", str(md), "--format", "json"],
+        [
+            "migrate",
+            "down-to",
+            "20260101000001",
+            "-c",
+            str(cfg),
+            "--migrations-dir",
+            str(md),
+            "--format",
+            "json",
+        ],
     )
     assert r.exit_code == 0, r.output
     _validator().validate(json.loads(r.stdout))

--- a/tests/integration/test_down_to_schema.py
+++ b/tests/integration/test_down_to_schema.py
@@ -1,0 +1,90 @@
+"""Validate `migrate down-to --format json` output against its schema (#142)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import psycopg
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.migrator import Migrator
+
+runner = CliRunner()
+_TABLE = "tb_downto_schema_it"
+_SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "docs" / "reference" / "json-schemas"
+_VERSIONS = [("20260101000001", "a"), ("20260102000002", "b"), ("20260103000003", "c")]
+
+
+def _tname(name: str) -> str:
+    return f"tb_dts_{name}"
+
+
+def _validator() -> Draft202012Validator:
+    return Draft202012Validator(
+        json.loads((_SCHEMAS_DIR / "migrate-down-to.schema.json").read_text())
+    )
+
+
+@pytest.fixture
+def conn(test_db_url: str):
+    c = psycopg.connect(test_db_url)
+
+    def _clean() -> None:
+        with c.cursor() as cur:
+            cur.execute(f"DROP TABLE IF EXISTS {_TABLE} CASCADE")
+            for _v, n in _VERSIONS:
+                cur.execute(f"DROP TABLE IF EXISTS {_tname(n)} CASCADE")
+        c.commit()
+
+    _clean()
+    try:
+        yield c
+    finally:
+        _clean()
+        c.close()
+
+
+@pytest.fixture
+def project(tmp_path: Path, test_db_url: str):
+    md = tmp_path / "migrations"
+    md.mkdir()
+    for version, name in _VERSIONS:
+        tbl = _tname(name)
+        (md / f"{version}_{name}.up.sql").write_text(f"CREATE TABLE {tbl} (id int);")
+        (md / f"{version}_{name}.down.sql").write_text(f"DROP TABLE {tbl};")
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": test_db_url,
+                "include_dirs": ["db/schema"],
+                "migration": {"tracking_table": _TABLE},
+            }
+        )
+    )
+    with Migrator.from_config(str(cfg), migrations_dir=md) as s:
+        s.up()
+    return cfg, md
+
+
+def test_schema_valid_draft_2020_12() -> None:
+    Draft202012Validator.check_schema(
+        json.loads((_SCHEMAS_DIR / "migrate-down-to.schema.json").read_text())
+    )
+
+
+def test_down_to_payload_validates(conn, project) -> None:
+    cfg, md = project
+    r = runner.invoke(
+        app,
+        ["migrate", "down-to", "20260101000001", "-c", str(cfg),
+         "--migrations-dir", str(md), "--format", "json"],
+    )
+    assert r.exit_code == 0, r.output
+    _validator().validate(json.loads(r.stdout))

--- a/tests/integration/test_lock_contention_identity.py
+++ b/tests/integration/test_lock_contention_identity.py
@@ -70,8 +70,18 @@ def holder_connection(test_db_url: str):
 def test_contention_json_surfaces_holder(holder_connection, cfg, migrations_dir) -> None:
     result = runner.invoke(
         app,
-        ["migrate", "up", "-c", str(cfg), "--migrations-dir", str(migrations_dir),
-         "--lock-timeout", "500", "--format", "json"],
+        [
+            "migrate",
+            "up",
+            "-c",
+            str(cfg),
+            "--migrations-dir",
+            str(migrations_dir),
+            "--lock-timeout",
+            "500",
+            "--format",
+            "json",
+        ],
     )
     assert result.exit_code == 6, result.output  # LOCK_1300 → 6
     # migrate up prints human progress preamble before the error envelope in
@@ -88,8 +98,16 @@ def test_contention_json_surfaces_holder(holder_connection, cfg, migrations_dir)
 def test_contention_human_names_holder(holder_connection, cfg, migrations_dir) -> None:
     result = runner.invoke(
         app,
-        ["migrate", "up", "-c", str(cfg), "--migrations-dir", str(migrations_dir),
-         "--lock-timeout", "500"],
+        [
+            "migrate",
+            "up",
+            "-c",
+            str(cfg),
+            "--migrations-dir",
+            str(migrations_dir),
+            "--lock-timeout",
+            "500",
+        ],
     )
     assert result.exit_code == 6, result.output
     # Human output names the holder (command + pid).

--- a/tests/integration/test_lock_contention_identity.py
+++ b/tests/integration/test_lock_contention_identity.py
@@ -1,0 +1,97 @@
+"""Lock-contention identity surfacing via the migrate CLI (issue #147, Phase 2).
+
+Writer A holds the migration lock on a real connection; the second writer hits
+contention and must surface A's identity in stderr (human) and the #145
+envelope (JSON).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import psycopg
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.locking import LOCK_HOLDER_TABLE, LockConfig, MigrationLock
+
+runner = CliRunner()
+_TABLE = "tb_lockid_it"
+
+
+@pytest.fixture
+def cfg(tmp_path: Path, test_db_url: str) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": test_db_url,
+                "include_dirs": ["db/schema"],
+                "migration": {"tracking_table": _TABLE},
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    (d / "20260101000001_a.up.sql").write_text("SELECT 1;")
+    (d / "20260101000001_a.down.sql").write_text("SELECT 1;")
+    return d
+
+
+@pytest.fixture
+def holder_connection(test_db_url: str):
+    """A connection that holds the real migration lock + writes its identity."""
+    conn = psycopg.connect(test_db_url)
+    # Use the real (db-derived) lock id so the CLI's lock collides with ours.
+    lock = MigrationLock(conn, LockConfig(command="confiture migrate up"))
+    acquired = lock.acquire()
+    acquired.__enter__()
+    try:
+        yield conn
+    finally:
+        acquired.__exit__(None, None, None)
+        with conn.cursor() as cur:
+            cur.execute(f"DROP TABLE IF EXISTS {LOCK_HOLDER_TABLE} CASCADE")
+            cur.execute(f"DROP TABLE IF EXISTS {_TABLE} CASCADE")
+        conn.commit()
+        conn.close()
+
+
+def test_contention_json_surfaces_holder(holder_connection, cfg, migrations_dir) -> None:
+    result = runner.invoke(
+        app,
+        ["migrate", "up", "-c", str(cfg), "--migrations-dir", str(migrations_dir),
+         "--lock-timeout", "500", "--format", "json"],
+    )
+    assert result.exit_code == 6, result.output  # LOCK_1300 → 6
+    # migrate up prints human progress preamble before the error envelope in
+    # JSON mode (pre-existing); the envelope is the final JSON document.
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "LOCK_1300"
+    holder = payload["error"]["details"]["holder"]
+    assert holder["pid"] == os.getpid()
+    assert holder["command"] == "confiture migrate up"
+    assert holder["held_for_seconds"] >= 0
+
+
+def test_contention_human_names_holder(holder_connection, cfg, migrations_dir) -> None:
+    result = runner.invoke(
+        app,
+        ["migrate", "up", "-c", str(cfg), "--migrations-dir", str(migrations_dir),
+         "--lock-timeout", "500"],
+    )
+    assert result.exit_code == 6, result.output
+    # Human output names the holder (command + pid).
+    assert "confiture migrate up" in result.output
+    assert str(os.getpid()) in result.output

--- a/tests/integration/test_lock_contention_identity.py
+++ b/tests/integration/test_lock_contention_identity.py
@@ -23,6 +23,14 @@ runner = CliRunner()
 _TABLE = "tb_lockid_it"
 
 
+def _connect(url):
+    """Connect, or skip when no DB is reachable (mirrors test_db_connection)."""
+    try:
+        return psycopg.connect(url)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+
 @pytest.fixture
 def cfg(tmp_path: Path, test_db_url: str) -> Path:
     p = tmp_path / "env.yaml"
@@ -51,7 +59,7 @@ def migrations_dir(tmp_path: Path) -> Path:
 @pytest.fixture
 def holder_connection(test_db_url: str):
     """A connection that holds the real migration lock + writes its identity."""
-    conn = psycopg.connect(test_db_url)
+    conn = _connect(test_db_url)
     # Use the real (db-derived) lock id so the CLI's lock collides with ours.
     lock = MigrationLock(conn, LockConfig(command="confiture migrate up"))
     acquired = lock.acquire()

--- a/tests/integration/test_lock_holder_metadata.py
+++ b/tests/integration/test_lock_holder_metadata.py
@@ -21,6 +21,14 @@ from confiture.core.locking import (
 _LOCK_ID = 920147001
 
 
+def _connect(url: str) -> psycopg.Connection:
+    """Connect, or skip the test when no DB is reachable (mirrors test_db_connection)."""
+    try:
+        return psycopg.connect(url)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+
 def _clean(conn: psycopg.Connection) -> None:
     with conn.cursor() as cur:
         cur.execute(f"DELETE FROM {LOCK_HOLDER_TABLE} WHERE lock_id = %s", (_LOCK_ID,))
@@ -29,8 +37,8 @@ def _clean(conn: psycopg.Connection) -> None:
 
 @pytest.fixture
 def conns(test_db_url: str):
-    a = psycopg.connect(test_db_url)
-    b = psycopg.connect(test_db_url)
+    a = _connect(test_db_url)
+    b = _connect(test_db_url)
     try:
         # ensure the table exists for cleanup, ignore if not yet created
         with a.cursor() as cur:
@@ -87,7 +95,7 @@ def test_contention_attaches_holder(conns) -> None:
 
 def test_read_holder_none_without_table(test_db_url) -> None:
     """Graceful degradation: no metadata table → holder is None, no raise."""
-    conn = psycopg.connect(test_db_url)
+    conn = _connect(test_db_url)
     try:
         with conn.cursor() as cur:
             cur.execute(f"DROP TABLE IF EXISTS {LOCK_HOLDER_TABLE} CASCADE")
@@ -105,7 +113,7 @@ def test_crash_safety_stale_row_recognized(test_db_url, conns) -> None:
 
     # Holder acquires + writes (committed) metadata, then "crashes" — closes the
     # connection WITHOUT releasing. The advisory lock auto-drops; the row stays.
-    crasher = psycopg.connect(test_db_url)
+    crasher = _connect(test_db_url)
     crasher_lock = MigrationLock(crasher, LockConfig(lock_id=_LOCK_ID, command="x"))
     crasher_lock._acquire_lock()
     crasher.close()

--- a/tests/integration/test_lock_holder_metadata.py
+++ b/tests/integration/test_lock_holder_metadata.py
@@ -50,9 +50,7 @@ def conns(test_db_url: str):
 
 def test_identity_written_on_acquire(conns) -> None:
     conn_a, conn_b = conns
-    lock_a = MigrationLock(
-        conn_a, LockConfig(lock_id=_LOCK_ID, command="confiture migrate up")
-    )
+    lock_a = MigrationLock(conn_a, LockConfig(lock_id=_LOCK_ID, command="confiture migrate up"))
     with lock_a.acquire():
         reader = MigrationLock(conn_b, LockConfig(lock_id=_LOCK_ID))
         holder = reader.read_lock_holder()
@@ -76,13 +74,9 @@ def test_identity_cleared_on_release(conns) -> None:
 
 def test_contention_attaches_holder(conns) -> None:
     conn_a, conn_b = conns
-    lock_a = MigrationLock(
-        conn_a, LockConfig(lock_id=_LOCK_ID, command="confiture migrate up")
-    )
+    lock_a = MigrationLock(conn_a, LockConfig(lock_id=_LOCK_ID, command="confiture migrate up"))
     with lock_a.acquire():
-        lock_b = MigrationLock(
-            conn_b, LockConfig(lock_id=_LOCK_ID, mode=LockMode.NON_BLOCKING)
-        )
+        lock_b = MigrationLock(conn_b, LockConfig(lock_id=_LOCK_ID, mode=LockMode.NON_BLOCKING))
         with pytest.raises(LockAcquisitionError) as e:
             lock_b._acquire_lock()
     assert e.value.holder is not None
@@ -122,8 +116,6 @@ def test_crash_safety_stale_row_recognized(test_db_url, conns) -> None:
     assert holder.live is False  # advisory lock gone → recognized as stale
 
     # Crash-safety: a new acquirer succeeds because the advisory lock released.
-    new_lock = MigrationLock(
-        reader_conn, LockConfig(lock_id=_LOCK_ID, mode=LockMode.NON_BLOCKING)
-    )
+    new_lock = MigrationLock(reader_conn, LockConfig(lock_id=_LOCK_ID, mode=LockMode.NON_BLOCKING))
     with new_lock.acquire():
         pass  # no LockAcquisitionError → advisory-lock crash-safety preserved

--- a/tests/integration/test_lock_holder_metadata.py
+++ b/tests/integration/test_lock_holder_metadata.py
@@ -1,0 +1,129 @@
+"""Integration tests for lock-holder identity metadata (issue #147, Phase 1)."""
+
+from __future__ import annotations
+
+import os
+import socket
+
+import psycopg
+import pytest
+
+from confiture.core.locking import (
+    LOCK_HOLDER_TABLE,
+    LockAcquisitionError,
+    LockConfig,
+    LockMode,
+    MigrationLock,
+)
+
+# Isolated test lock id (advisory locks on confiture_test otherwise share the
+# db-derived id). Distinct per module so we don't collide with the real lock.
+_LOCK_ID = 920147001
+
+
+def _clean(conn: psycopg.Connection) -> None:
+    with conn.cursor() as cur:
+        cur.execute(f"DELETE FROM {LOCK_HOLDER_TABLE} WHERE lock_id = %s", (_LOCK_ID,))
+    conn.commit()
+
+
+@pytest.fixture
+def conns(test_db_url: str):
+    a = psycopg.connect(test_db_url)
+    b = psycopg.connect(test_db_url)
+    try:
+        # ensure the table exists for cleanup, ignore if not yet created
+        with a.cursor() as cur:
+            cur.execute(
+                f"CREATE TABLE IF NOT EXISTS {LOCK_HOLDER_TABLE} ("
+                "lock_id BIGINT PRIMARY KEY, pid INT, hostname TEXT, usename TEXT, "
+                "command TEXT, acquired_at TIMESTAMPTZ NOT NULL DEFAULT now())"
+            )
+        a.commit()
+        _clean(a)
+        yield a, b
+    finally:
+        _clean(a)
+        a.close()
+        b.close()
+
+
+def test_identity_written_on_acquire(conns) -> None:
+    conn_a, conn_b = conns
+    lock_a = MigrationLock(
+        conn_a, LockConfig(lock_id=_LOCK_ID, command="confiture migrate up")
+    )
+    with lock_a.acquire():
+        reader = MigrationLock(conn_b, LockConfig(lock_id=_LOCK_ID))
+        holder = reader.read_lock_holder()
+        assert holder is not None
+        assert holder.pid == os.getpid()
+        assert holder.hostname == socket.gethostname()
+        assert holder.command == "confiture migrate up"
+        assert holder.acquired_at is not None
+        assert holder.held_for_seconds is not None and holder.held_for_seconds >= 0
+        assert holder.live  # advisory lock is genuinely held
+
+
+def test_identity_cleared_on_release(conns) -> None:
+    conn_a, conn_b = conns
+    lock_a = MigrationLock(conn_a, LockConfig(lock_id=_LOCK_ID, command="x"))
+    with lock_a.acquire():
+        pass
+    reader = MigrationLock(conn_b, LockConfig(lock_id=_LOCK_ID))
+    assert reader.read_lock_holder() is None  # row cleared on release
+
+
+def test_contention_attaches_holder(conns) -> None:
+    conn_a, conn_b = conns
+    lock_a = MigrationLock(
+        conn_a, LockConfig(lock_id=_LOCK_ID, command="confiture migrate up")
+    )
+    with lock_a.acquire():
+        lock_b = MigrationLock(
+            conn_b, LockConfig(lock_id=_LOCK_ID, mode=LockMode.NON_BLOCKING)
+        )
+        with pytest.raises(LockAcquisitionError) as e:
+            lock_b._acquire_lock()
+    assert e.value.holder is not None
+    assert e.value.holder.command == "confiture migrate up"
+    assert e.value.holder.pid == os.getpid()
+    assert e.value.holder.held_for_seconds >= 0
+
+
+def test_read_holder_none_without_table(test_db_url) -> None:
+    """Graceful degradation: no metadata table → holder is None, no raise."""
+    conn = psycopg.connect(test_db_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"DROP TABLE IF EXISTS {LOCK_HOLDER_TABLE} CASCADE")
+        conn.commit()
+        reader = MigrationLock(conn, LockConfig(lock_id=_LOCK_ID))
+        assert reader._safe_read_lock_holder() is None
+    finally:
+        conn.close()
+
+
+def test_crash_safety_stale_row_recognized(test_db_url, conns) -> None:
+    """A crashed holder auto-releases the advisory lock; the lingering metadata
+    row is recognized as stale (not live), and a new acquirer still succeeds."""
+    _conn_a, reader_conn = conns
+
+    # Holder acquires + writes (committed) metadata, then "crashes" — closes the
+    # connection WITHOUT releasing. The advisory lock auto-drops; the row stays.
+    crasher = psycopg.connect(test_db_url)
+    crasher_lock = MigrationLock(crasher, LockConfig(lock_id=_LOCK_ID, command="x"))
+    crasher_lock._acquire_lock()
+    crasher.close()
+
+    reader = MigrationLock(reader_conn, LockConfig(lock_id=_LOCK_ID))
+    holder = reader.read_lock_holder()
+    assert holder is not None  # stale row lingers
+    assert holder.live is False  # advisory lock gone → recognized as stale
+
+    # Crash-safety: a new acquirer succeeds because the advisory lock released.
+    new_lock = MigrationLock(
+        reader_conn, LockConfig(lock_id=_LOCK_ID, mode=LockMode.NON_BLOCKING)
+    )
+    with new_lock.acquire():
+        pass  # no LockAcquisitionError → advisory-lock crash-safety preserved

--- a/tests/integration/test_migrate_current.py
+++ b/tests/integration/test_migrate_current.py
@@ -46,6 +46,14 @@ def _insert(
     conn.commit()
 
 
+def _connect(url):
+    """Connect, or skip when no DB is reachable (mirrors test_db_connection)."""
+    try:
+        return psycopg.connect(url)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+
 @pytest.fixture
 def cfg(tmp_path: Path, test_db_url: str) -> Path:
     p = tmp_path / "env.yaml"
@@ -64,7 +72,7 @@ def cfg(tmp_path: Path, test_db_url: str) -> Path:
 
 @pytest.fixture
 def conn(test_db_url: str):
-    c = psycopg.connect(test_db_url)
+    c = _connect(test_db_url)
     try:
         _drop(c)
         yield c

--- a/tests/integration/test_migrate_current.py
+++ b/tests/integration/test_migrate_current.py
@@ -34,7 +34,9 @@ def _create_empty(conn: psycopg.Connection) -> None:
     conn.commit()
 
 
-def _insert(conn: psycopg.Connection, version: str, name: str, applied_at: datetime, checksum=None) -> None:
+def _insert(
+    conn: psycopg.Connection, version: str, name: str, applied_at: datetime, checksum=None
+) -> None:
     with conn.cursor() as cur:
         cur.execute(
             f"INSERT INTO {_TABLE} (slug, version, name, applied_at, checksum) "

--- a/tests/integration/test_migrate_current.py
+++ b/tests/integration/test_migrate_current.py
@@ -1,0 +1,159 @@
+"""Integration tests for `migrate current` and MigratorSession.current_revision (#141).
+
+Each test uses an isolated tracking table (dropped up front) so it does not
+depend on or pollute the shared tb_confiture state in confiture_test.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import psycopg
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.migrator import Migrator
+from confiture.exceptions import DatabaseNotInitializedError
+
+runner = CliRunner()
+_TABLE = "tb_current_it"
+
+
+def _drop(conn: psycopg.Connection) -> None:
+    with conn.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS {_TABLE} CASCADE")
+    conn.commit()
+
+
+def _create_empty(conn: psycopg.Connection) -> None:
+    Migrator(connection=conn, migration_table=_TABLE).initialize()
+    conn.commit()
+
+
+def _insert(conn: psycopg.Connection, version: str, name: str, applied_at: datetime, checksum=None) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {_TABLE} (slug, version, name, applied_at, checksum) "
+            f"VALUES (%s, %s, %s, %s, %s)",
+            (f"{version}_{name}", version, name, applied_at, checksum),
+        )
+    conn.commit()
+
+
+@pytest.fixture
+def cfg(tmp_path: Path, test_db_url: str) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": test_db_url,
+                "include_dirs": ["db/schema"],
+                "migration": {"tracking_table": _TABLE},
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def conn(test_db_url: str):
+    c = psycopg.connect(test_db_url)
+    try:
+        _drop(c)
+        yield c
+    finally:
+        _drop(c)
+        c.close()
+
+
+def _seed_three(conn: psycopg.Connection) -> str:
+    _create_empty(conn)
+    base = datetime(2026, 5, 31, 14, 0, 0, tzinfo=UTC)
+    _insert(conn, "20260531_1400_a", "a", base, "sha256:aaa")
+    _insert(conn, "20260531_1415_b", "b", base + timedelta(minutes=15), "sha256:bbb")
+    _insert(conn, "20260531_1430_c", "c", base + timedelta(minutes=30), "sha256:ccc")
+    return "20260531_1430_c"
+
+
+# ── session API ───────────────────────────────────────────────────────────────
+
+
+def test_current_revision_returns_latest(conn, cfg) -> None:
+    latest = _seed_three(conn)
+    with Migrator.from_config(str(cfg)) as s:
+        cur = s.current_revision()
+    assert cur is not None
+    assert cur.version == latest
+    assert cur.applied_at is not None
+    assert cur.checksum == "sha256:ccc"
+
+
+def test_current_revision_none_when_empty(conn, cfg) -> None:
+    _create_empty(conn)
+    with Migrator.from_config(str(cfg)) as s:
+        assert s.current_revision() is None
+
+
+def test_current_revision_raises_when_table_absent(conn, cfg) -> None:
+    # conn fixture dropped the table; do not create it.
+    with Migrator.from_config(str(cfg)) as s:
+        with pytest.raises(DatabaseNotInitializedError) as e:
+            s.current_revision()
+    assert e.value.error_code == "PRECON_1001"
+    assert e.value.exit_code == 2
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def test_current_human_prints_bare_revision(conn, cfg) -> None:
+    latest = _seed_three(conn)
+    r = runner.invoke(app, ["migrate", "current", "-c", str(cfg)])
+    assert r.exit_code == 0, r.output
+    assert r.output.strip() == latest
+
+
+def test_current_json(conn, cfg) -> None:
+    latest = _seed_three(conn)
+    r = runner.invoke(app, ["migrate", "current", "-c", str(cfg), "--format", "json"])
+    assert r.exit_code == 0, r.output
+    payload = json.loads(r.stdout)
+    assert payload["revision"] == latest
+    assert payload["applied_at"] is not None
+    assert payload["checksum"] == "sha256:ccc"
+
+
+def test_current_empty_table_exit0_null(conn, cfg) -> None:
+    _create_empty(conn)
+    r = runner.invoke(app, ["migrate", "current", "-c", str(cfg), "--format", "json"])
+    assert r.exit_code == 0, r.output
+    assert json.loads(r.stdout)["revision"] is None
+
+
+def test_current_absent_table_exit2(conn, cfg) -> None:
+    r = runner.invoke(app, ["migrate", "current", "-c", str(cfg)])
+    assert r.exit_code == 2, r.output
+
+
+def test_current_absent_table_json_envelope(conn, cfg) -> None:
+    r = runner.invoke(app, ["migrate", "current", "-c", str(cfg), "--format", "json"])
+    assert r.exit_code == 2, r.output
+    payload = json.loads(r.stdout)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "PRECON_1001"
+
+
+def test_current_baseline_null_checksum(conn, cfg) -> None:
+    """A row applied without a checksum (e.g. via baseline) emits checksum: null."""
+    _create_empty(conn)
+    _insert(conn, "20260101_0000_base", "base", datetime(2026, 1, 1, tzinfo=UTC), None)
+    r = runner.invoke(app, ["migrate", "current", "-c", str(cfg), "--format", "json"])
+    assert r.exit_code == 0, r.output
+    payload = json.loads(r.stdout)
+    assert payload["revision"] == "20260101_0000_base"
+    assert payload["checksum"] is None

--- a/tests/integration/test_migrate_current_schema.py
+++ b/tests/integration/test_migrate_current_schema.py
@@ -26,6 +26,14 @@ def _validator() -> Draft202012Validator:
     )
 
 
+def _connect(url):
+    """Connect, or skip when no DB is reachable (mirrors test_db_connection)."""
+    try:
+        return psycopg.connect(url)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+
 @pytest.fixture
 def cfg(tmp_path: Path, test_db_url: str):
     p = tmp_path / "env.yaml"
@@ -44,7 +52,7 @@ def cfg(tmp_path: Path, test_db_url: str):
 
 @pytest.fixture
 def conn(test_db_url: str):
-    c = psycopg.connect(test_db_url)
+    c = _connect(test_db_url)
     with c.cursor() as cur:
         cur.execute(f"DROP TABLE IF EXISTS {_TABLE} CASCADE")
     c.commit()

--- a/tests/integration/test_migrate_current_schema.py
+++ b/tests/integration/test_migrate_current_schema.py
@@ -1,0 +1,87 @@
+"""Validate `migrate current --format json` output against its schema (#141)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import psycopg
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.migrator import Migrator
+
+runner = CliRunner()
+_TABLE = "tb_current_schema_it"
+_SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "docs" / "reference" / "json-schemas"
+
+
+def _validator() -> Draft202012Validator:
+    return Draft202012Validator(
+        json.loads((_SCHEMAS_DIR / "migrate-current.schema.json").read_text())
+    )
+
+
+@pytest.fixture
+def cfg(tmp_path: Path, test_db_url: str):
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": test_db_url,
+                "include_dirs": ["db/schema"],
+                "migration": {"tracking_table": _TABLE},
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def conn(test_db_url: str):
+    c = psycopg.connect(test_db_url)
+    with c.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS {_TABLE} CASCADE")
+    c.commit()
+    try:
+        yield c
+    finally:
+        with c.cursor() as cur:
+            cur.execute(f"DROP TABLE IF EXISTS {_TABLE} CASCADE")
+        c.commit()
+        c.close()
+
+
+def test_schema_valid_draft_2020_12() -> None:
+    Draft202012Validator.check_schema(
+        json.loads((_SCHEMAS_DIR / "migrate-current.schema.json").read_text())
+    )
+
+
+def test_applied_payload_validates(conn, cfg) -> None:
+    Migrator(connection=conn, migration_table=_TABLE).initialize()
+    with conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {_TABLE} (slug, version, name, applied_at, checksum) "
+            f"VALUES (%s, %s, %s, %s, %s)",
+            ("v1_a", "v1", "a", datetime(2026, 5, 31, tzinfo=UTC), "sha256:x"),
+        )
+    conn.commit()
+    r = runner.invoke(app, ["migrate", "current", "-c", str(cfg), "--format", "json"])
+    assert r.exit_code == 0, r.output
+    _validator().validate(json.loads(r.stdout))
+
+
+def test_empty_payload_validates(conn, cfg) -> None:
+    Migrator(connection=conn, migration_table=_TABLE).initialize()
+    conn.commit()
+    r = runner.invoke(app, ["migrate", "current", "-c", str(cfg), "--format", "json"])
+    assert r.exit_code == 0, r.output
+    payload = json.loads(r.stdout)
+    _validator().validate(payload)
+    assert payload["revision"] is None

--- a/tests/integration/test_replica_lint_surfaces.py
+++ b/tests/integration/test_replica_lint_surfaces.py
@@ -1,0 +1,107 @@
+"""Surface tests: `confiture lint --replica-safe` and `migrate preflight` (#139)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+def _config(tmp_path: Path, *, replicas: list[str] | None = None, bypass: bool = False) -> Path:
+    return _write_cfg(tmp_path / "env.yaml", replicas=replicas, bypass=bypass)
+
+
+def _write_cfg(path: Path, *, replicas=None, bypass=False) -> Path:
+    body: dict = {
+        "name": "test",
+        "database_url": "postgresql://localhost/app",
+        "include_dirs": ["db/schema"],
+    }
+    if replicas:
+        body["infrastructure"] = {"replicas": replicas}
+    if bypass:
+        body["migration"] = {"allow_unsafe_under_replication": True}
+    path.write_text(yaml.safe_dump(body))
+    return path
+
+
+# ── preflight surface ─────────────────────────────────────────────────────────
+
+
+def test_preflight_emits_replica_issue_with_replicas(tmp_path: Path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260531_1200_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    (migs / "20260531_1200_drop.down.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    cfg = _config(tmp_path, replicas=["read-1"])
+
+    r = runner.invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(migs), "-c", str(cfg), "--format", "json"],
+    )
+    assert r.exit_code == 7, r.output
+    codes = {i["code"] for i in json.loads(r.stdout)["issues"]}
+    assert "PFLIGHT_REPLICA_DROP_COLUMN" in codes
+
+
+def test_preflight_replica_warns_without_replicas(tmp_path: Path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260531_1200_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    (migs / "20260531_1200_drop.down.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json"]
+    )
+    # No replicas declared → warning, exit 0; the issue is still reported.
+    assert r.exit_code == 0, r.output
+    payload = json.loads(r.stdout)
+    replica = [i for i in payload["issues"] if i["code"].startswith("PFLIGHT_REPLICA")]
+    assert replica and replica[0]["severity"] == "warning"
+
+
+def test_preflight_replica_bypass_downgrades(tmp_path: Path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260531_1200_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    (migs / "20260531_1200_drop.down.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    cfg = _config(tmp_path, replicas=["read-1"], bypass=True)
+
+    r = runner.invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(migs), "-c", str(cfg), "--format", "json"],
+    )
+    assert r.exit_code == 0, r.output  # bypass downgrades to warning
+
+
+# ── lint surface ──────────────────────────────────────────────────────────────
+
+
+def _standard_project(tmp_path: Path, *, replicas: list[str]) -> Path:
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    (tmp_path / "db" / "schema" / "01_t.sql").write_text("CREATE TABLE t (id int PRIMARY KEY);\n")
+    envs = tmp_path / "db" / "environments"
+    envs.mkdir(parents=True)
+    _write_cfg(envs / "local.yaml", replicas=replicas)
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260531_1200_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    (migs / "20260531_1200_drop.down.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    return tmp_path
+
+
+def test_lint_replica_safe_flag_errors_with_replicas(tmp_path: Path) -> None:
+    proj = _standard_project(tmp_path, replicas=["read-1"])
+    r = runner.invoke(
+        app,
+        ["lint", "--replica-safe", "--env", "local", "--project-dir", str(proj),
+         "--migrations-dir", str(proj / "db" / "migrations")],
+    )
+    assert r.exit_code != 0
+    assert "replica_001" in r.output

--- a/tests/integration/test_replica_lint_surfaces.py
+++ b/tests/integration/test_replica_lint_surfaces.py
@@ -100,8 +100,16 @@ def test_lint_replica_safe_flag_errors_with_replicas(tmp_path: Path) -> None:
     proj = _standard_project(tmp_path, replicas=["read-1"])
     r = runner.invoke(
         app,
-        ["lint", "--replica-safe", "--env", "local", "--project-dir", str(proj),
-         "--migrations-dir", str(proj / "db" / "migrations")],
+        [
+            "lint",
+            "--replica-safe",
+            "--env",
+            "local",
+            "--project-dir",
+            str(proj),
+            "--migrations-dir",
+            str(proj / "db" / "migrations"),
+        ],
     )
     assert r.exit_code != 0
     assert "replica_001" in r.output

--- a/tests/integration/test_validate_config_cli.py
+++ b/tests/integration/test_validate_config_cli.py
@@ -1,0 +1,107 @@
+"""CLI tests for `confiture validate-config` (issue #144, Phase 2).
+
+Offline — no database. Run as integration only because they exercise the full
+CLI; none of them connect.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+def _project(tmp_path: Path, *, n_migrations=3, database_url="postgresql://localhost/app") -> Path:
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    for i in range(n_migrations):
+        v = f"2026010100000{i}"
+        (migs / f"{v}_m{i}.up.sql").write_text("SELECT 1;")
+        (migs / f"{v}_m{i}.down.sql").write_text("SELECT 1;")
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {"name": "test", "database_url": database_url, "include_dirs": ["db/schema"]}
+        )
+    )
+    return cfg
+
+
+def test_valid_config_exit_0(tmp_path: Path) -> None:
+    cfg = _project(tmp_path)
+    r = runner.invoke(
+        app,
+        ["validate-config", "-c", str(cfg), "--migrations-path", str(tmp_path / "db" / "migrations")],
+    )
+    assert r.exit_code == 0, r.output
+
+
+def test_invalid_config_exit_5(tmp_path: Path) -> None:
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(yaml.safe_dump({"name": "test", "include_dirs": ["db/schema"]}))  # no database_url
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    r = runner.invoke(
+        app, ["validate-config", "-c", str(cfg), "--migrations-path", str(tmp_path / "none")]
+    )
+    assert r.exit_code == 5, r.output
+    assert "CONFIG_001" in r.output
+
+
+def test_json_output_shape(tmp_path: Path) -> None:
+    cfg = _project(tmp_path)
+    r = runner.invoke(
+        app,
+        ["validate-config", "-c", str(cfg), "--migrations-path",
+         str(tmp_path / "db" / "migrations"), "--format", "json"],
+    )
+    assert r.exit_code == 0, r.output
+    p = json.loads(r.stdout)
+    assert p["valid"] is True
+    assert p["config_source"] == "yaml-file"
+    assert p["migration_count"] == 3
+    assert p["issues"] == []
+    assert set(p.keys()) == {"valid", "config_source", "migrations_path", "migration_count", "issues"}
+
+
+def test_flags_source_without_yaml(tmp_path: Path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    r = runner.invoke(
+        app,
+        ["validate-config", "--database-url", "postgresql://x/y",
+         "--migrations-path", str(migs), "--format", "json"],
+    )
+    assert r.exit_code == 0, r.output
+    assert json.loads(r.stdout)["config_source"] == "flags"
+
+
+def test_flags_bad_dsn_exit_5(tmp_path: Path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    r = runner.invoke(
+        app,
+        ["validate-config", "--database-url", "not-a-dsn",
+         "--migrations-path", str(migs), "--format", "json"],
+    )
+    assert r.exit_code == 5, r.output
+    assert any(i["code"] == "CONFIG_003" for i in json.loads(r.stdout)["issues"])
+
+
+def test_never_connects(tmp_path: Path, monkeypatch) -> None:
+    cfg = _project(tmp_path)
+    monkeypatch.setattr(
+        "psycopg.connect", lambda *a, **k: pytest.fail("validate-config must never connect!")
+    )
+    r = runner.invoke(
+        app,
+        ["validate-config", "-c", str(cfg), "--migrations-path", str(tmp_path / "db" / "migrations")],
+    )
+    assert r.exit_code == 0, r.output

--- a/tests/integration/test_validate_config_cli.py
+++ b/tests/integration/test_validate_config_cli.py
@@ -39,14 +39,22 @@ def test_valid_config_exit_0(tmp_path: Path) -> None:
     cfg = _project(tmp_path)
     r = runner.invoke(
         app,
-        ["validate-config", "-c", str(cfg), "--migrations-path", str(tmp_path / "db" / "migrations")],
+        [
+            "validate-config",
+            "-c",
+            str(cfg),
+            "--migrations-path",
+            str(tmp_path / "db" / "migrations"),
+        ],
     )
     assert r.exit_code == 0, r.output
 
 
 def test_invalid_config_exit_5(tmp_path: Path) -> None:
     cfg = tmp_path / "env.yaml"
-    cfg.write_text(yaml.safe_dump({"name": "test", "include_dirs": ["db/schema"]}))  # no database_url
+    cfg.write_text(
+        yaml.safe_dump({"name": "test", "include_dirs": ["db/schema"]})
+    )  # no database_url
     (tmp_path / "db" / "schema").mkdir(parents=True)
     r = runner.invoke(
         app, ["validate-config", "-c", str(cfg), "--migrations-path", str(tmp_path / "none")]
@@ -59,8 +67,15 @@ def test_json_output_shape(tmp_path: Path) -> None:
     cfg = _project(tmp_path)
     r = runner.invoke(
         app,
-        ["validate-config", "-c", str(cfg), "--migrations-path",
-         str(tmp_path / "db" / "migrations"), "--format", "json"],
+        [
+            "validate-config",
+            "-c",
+            str(cfg),
+            "--migrations-path",
+            str(tmp_path / "db" / "migrations"),
+            "--format",
+            "json",
+        ],
     )
     assert r.exit_code == 0, r.output
     p = json.loads(r.stdout)
@@ -68,7 +83,13 @@ def test_json_output_shape(tmp_path: Path) -> None:
     assert p["config_source"] == "yaml-file"
     assert p["migration_count"] == 3
     assert p["issues"] == []
-    assert set(p.keys()) == {"valid", "config_source", "migrations_path", "migration_count", "issues"}
+    assert set(p.keys()) == {
+        "valid",
+        "config_source",
+        "migrations_path",
+        "migration_count",
+        "issues",
+    }
 
 
 def test_flags_source_without_yaml(tmp_path: Path) -> None:
@@ -76,8 +97,15 @@ def test_flags_source_without_yaml(tmp_path: Path) -> None:
     migs.mkdir()
     r = runner.invoke(
         app,
-        ["validate-config", "--database-url", "postgresql://x/y",
-         "--migrations-path", str(migs), "--format", "json"],
+        [
+            "validate-config",
+            "--database-url",
+            "postgresql://x/y",
+            "--migrations-path",
+            str(migs),
+            "--format",
+            "json",
+        ],
     )
     assert r.exit_code == 0, r.output
     assert json.loads(r.stdout)["config_source"] == "flags"
@@ -88,8 +116,15 @@ def test_flags_bad_dsn_exit_5(tmp_path: Path) -> None:
     migs.mkdir()
     r = runner.invoke(
         app,
-        ["validate-config", "--database-url", "not-a-dsn",
-         "--migrations-path", str(migs), "--format", "json"],
+        [
+            "validate-config",
+            "--database-url",
+            "not-a-dsn",
+            "--migrations-path",
+            str(migs),
+            "--format",
+            "json",
+        ],
     )
     assert r.exit_code == 5, r.output
     assert any(i["code"] == "CONFIG_003" for i in json.loads(r.stdout)["issues"])
@@ -102,6 +137,12 @@ def test_never_connects(tmp_path: Path, monkeypatch) -> None:
     )
     r = runner.invoke(
         app,
-        ["validate-config", "-c", str(cfg), "--migrations-path", str(tmp_path / "db" / "migrations")],
+        [
+            "validate-config",
+            "-c",
+            str(cfg),
+            "--migrations-path",
+            str(tmp_path / "db" / "migrations"),
+        ],
     )
     assert r.exit_code == 0, r.output

--- a/tests/integration/test_validate_config_schema.py
+++ b/tests/integration/test_validate_config_schema.py
@@ -1,0 +1,67 @@
+"""Validate `validate-config --format json` output against its schema (#144)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+_SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "docs" / "reference" / "json-schemas"
+
+
+def _validator() -> Draft202012Validator:
+    issue = json.loads((_SCHEMAS_DIR / "issue-object.schema.json").read_text())
+    registry = Registry().with_resource(
+        uri="issue-object.schema.json",
+        resource=Resource.from_contents(issue, default_specification=DRAFT202012),
+    )
+    return Draft202012Validator(
+        json.loads((_SCHEMAS_DIR / "validate-config.schema.json").read_text()), registry=registry
+    )
+
+
+def test_schema_valid_draft_2020_12() -> None:
+    Draft202012Validator.check_schema(
+        json.loads((_SCHEMAS_DIR / "validate-config.schema.json").read_text())
+    )
+
+
+def test_valid_report_validates(tmp_path: Path) -> None:
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260101000000_a.up.sql").write_text("SELECT 1;")
+    (migs / "20260101000000_a.down.sql").write_text("SELECT 1;")
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {"name": "t", "database_url": "postgresql://localhost/app", "include_dirs": ["db/schema"]}
+        )
+    )
+    r = runner.invoke(
+        app, ["validate-config", "-c", str(cfg), "--migrations-path", str(migs), "--format", "json"]
+    )
+    assert r.exit_code == 0, r.output
+    _validator().validate(json.loads(r.stdout))
+
+
+def test_invalid_report_validates(tmp_path: Path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    r = runner.invoke(
+        app,
+        ["validate-config", "--database-url", "not-a-dsn",
+         "--migrations-path", str(migs), "--format", "json"],
+    )
+    assert r.exit_code == 5, r.output
+    payload = json.loads(r.stdout)
+    _validator().validate(payload)
+    assert payload["valid"] is False

--- a/tests/integration/test_validate_config_schema.py
+++ b/tests/integration/test_validate_config_schema.py
@@ -43,7 +43,11 @@ def test_valid_report_validates(tmp_path: Path) -> None:
     cfg = tmp_path / "env.yaml"
     cfg.write_text(
         yaml.safe_dump(
-            {"name": "t", "database_url": "postgresql://localhost/app", "include_dirs": ["db/schema"]}
+            {
+                "name": "t",
+                "database_url": "postgresql://localhost/app",
+                "include_dirs": ["db/schema"],
+            }
         )
     )
     r = runner.invoke(
@@ -58,8 +62,15 @@ def test_invalid_report_validates(tmp_path: Path) -> None:
     migs.mkdir()
     r = runner.invoke(
         app,
-        ["validate-config", "--database-url", "not-a-dsn",
-         "--migrations-path", str(migs), "--format", "json"],
+        [
+            "validate-config",
+            "--database-url",
+            "not-a-dsn",
+            "--migrations-path",
+            str(migs),
+            "--format",
+            "json",
+        ],
     )
     assert r.exit_code == 5, r.output
     payload = json.loads(r.stdout)

--- a/tests/integration/test_verify_rename.py
+++ b/tests/integration/test_verify_rename.py
@@ -21,9 +21,7 @@ runner = CliRunner()
 def _cfg(tmp_path: Path, test_db_url: str) -> Path:
     p = tmp_path / "env.yaml"
     p.write_text(
-        yaml.safe_dump(
-            {"name": "test", "database_url": test_db_url, "include_dirs": ["db/schema"]}
-        )
+        yaml.safe_dump({"name": "test", "database_url": test_db_url, "include_dirs": ["db/schema"]})
     )
     return p
 

--- a/tests/integration/test_verify_rename.py
+++ b/tests/integration/test_verify_rename.py
@@ -1,0 +1,76 @@
+"""Tests for the verify → verify-checksums rename + deprecation (issue #143).
+
+The checksum logic is unchanged (pure passthrough); these cover the rename
+mechanics: the canonical command, the deprecated alias's stderr warning, and the
+cross-referential help.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+def _cfg(tmp_path: Path, test_db_url: str) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {"name": "test", "database_url": test_db_url, "include_dirs": ["db/schema"]}
+        )
+    )
+    return p
+
+
+# ── help cross-references (no DB) ─────────────────────────────────────────────
+
+
+def test_migrate_verify_help_points_to_checksums() -> None:
+    out = runner.invoke(app, ["migrate", "verify", "--help"]).output
+    assert "verify-checksums" in out
+    assert "runtime correctness" in out.lower()
+
+
+def test_verify_checksums_help_points_to_migrate_verify() -> None:
+    out = runner.invoke(app, ["verify-checksums", "--help"]).output
+    assert "migrate verify" in out
+    assert "integrity" in out.lower()
+
+
+# ── deprecation alias ─────────────────────────────────────────────────────────
+
+
+def test_deprecated_verify_alias_warns(tmp_path: Path, test_db_url: str) -> None:
+    # The warning prints before any DB work, so it's present regardless of the
+    # checksum outcome. (CliRunner merges streams — see test-conventions.md.)
+    result = runner.invoke(app, ["verify", "-c", str(_cfg(tmp_path, test_db_url))])
+    assert "deprecated" in result.output.lower()
+    assert "verify-checksums" in result.output
+
+
+def test_verify_checksums_does_not_warn(tmp_path: Path, test_db_url: str) -> None:
+    result = runner.invoke(app, ["verify-checksums", "-c", str(_cfg(tmp_path, test_db_url))])
+    assert "deprecated" not in result.output.lower()
+
+
+def test_alias_warning_on_stderr_not_stdout(tmp_path: Path, test_db_url: str) -> None:
+    # True stream separation needs real FDs → subprocess (test-conventions.md).
+    proc = subprocess.run(
+        ["confiture", "verify", "-c", str(_cfg(tmp_path, test_db_url))],
+        capture_output=True,
+        text=True,
+    )
+    assert "deprecated" not in proc.stdout  # stdout stays clean for pipes
+    assert "deprecated" in proc.stderr.lower()  # warning lands on stderr
+
+
+def test_verify_checksums_is_registered() -> None:
+    # Distinct from the deprecated alias; both are invokable.
+    top_help = runner.invoke(app, ["--help"]).output
+    assert "verify-checksums" in top_help

--- a/tests/unit/json_schemas/test_error_envelope_schema.py
+++ b/tests/unit/json_schemas/test_error_envelope_schema.py
@@ -1,0 +1,73 @@
+"""Validate the #145 error envelope against its published JSON Schema.
+
+The envelope schema $refs issue-object.schema.json, so the registry resolves
+both relative URIs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import psycopg
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+SCHEMAS_DIR = Path(__file__).resolve().parents[3] / "docs" / "reference" / "json-schemas"
+_UNREACHABLE = "postgresql://localhost:1/nope"
+
+
+def _load(name: str) -> dict:
+    return json.loads((SCHEMAS_DIR / name).read_text())
+
+
+def _envelope_validator() -> Draft202012Validator:
+    issue = _load("issue-object.schema.json")
+    registry = Registry().with_resource(
+        uri="issue-object.schema.json",
+        resource=Resource.from_contents(issue, default_specification=DRAFT202012),
+    )
+    return Draft202012Validator(_load("error-envelope.schema.json"), registry=registry)
+
+
+def test_envelope_schema_is_valid_draft_2020_12() -> None:
+    Draft202012Validator.check_schema(_load("error-envelope.schema.json"))
+    Draft202012Validator.check_schema(_load("issue-object.schema.json"))
+
+
+def test_real_connection_failure_envelope_validates(tmp_path: Path) -> None:
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("connection refused"),
+    ):
+        result = CliRunner().invoke(
+            app,
+            ["migrate", "up", "--database-url", _UNREACHABLE,
+             "--migrations-dir", str(migrations_dir), "--format", "json"],
+        )
+    assert result.exit_code == 3, result.output
+    payload = json.loads(result.stdout)
+    _envelope_validator().validate(payload)
+    assert payload["error"]["code"] == "CONFIG_006"
+
+
+def test_real_duplicate_version_envelope_validates(tmp_path: Path) -> None:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    for name in ("20260101000001_a", "20260101000001_b"):
+        (d / f"{name}.up.sql").write_text("SELECT 1;")
+        (d / f"{name}.down.sql").write_text("SELECT 1;")
+    result = CliRunner().invoke(
+        app,
+        ["migrate", "up", "--database-url", _UNREACHABLE,
+         "--migrations-dir", str(d), "--format", "json"],
+    )
+    assert result.exit_code == 3, result.output
+    _envelope_validator().validate(json.loads(result.stdout))

--- a/tests/unit/json_schemas/test_error_envelope_schema.py
+++ b/tests/unit/json_schemas/test_error_envelope_schema.py
@@ -49,8 +49,16 @@ def test_real_connection_failure_envelope_validates(tmp_path: Path) -> None:
     ):
         result = CliRunner().invoke(
             app,
-            ["migrate", "up", "--database-url", _UNREACHABLE,
-             "--migrations-dir", str(migrations_dir), "--format", "json"],
+            [
+                "migrate",
+                "up",
+                "--database-url",
+                _UNREACHABLE,
+                "--migrations-dir",
+                str(migrations_dir),
+                "--format",
+                "json",
+            ],
         )
     assert result.exit_code == 3, result.output
     payload = json.loads(result.stdout)
@@ -66,8 +74,16 @@ def test_real_duplicate_version_envelope_validates(tmp_path: Path) -> None:
         (d / f"{name}.down.sql").write_text("SELECT 1;")
     result = CliRunner().invoke(
         app,
-        ["migrate", "up", "--database-url", _UNREACHABLE,
-         "--migrations-dir", str(d), "--format", "json"],
+        [
+            "migrate",
+            "up",
+            "--database-url",
+            _UNREACHABLE,
+            "--migrations-dir",
+            str(d),
+            "--format",
+            "json",
+        ],
     )
     assert result.exit_code == 3, result.output
     _envelope_validator().validate(json.loads(result.stdout))

--- a/tests/unit/json_schemas/test_preflight_schema.py
+++ b/tests/unit/json_schemas/test_preflight_schema.py
@@ -31,9 +31,13 @@ def _load(schemas_dir: Path, name: str) -> dict:
 
 
 def _build_registry(schemas_dir: Path) -> Registry:
-    """Registry including the preflight $defs file as well as common."""
+    """Registry including the preflight $defs + shared issue object (#148)."""
     registry: Registry = Registry()
-    for filename in ("_common.schema.json", "_preflight_defs.schema.json"):
+    for filename in (
+        "_common.schema.json",
+        "_preflight_defs.schema.json",
+        "issue-object.schema.json",
+    ):
         content = _load(schemas_dir, filename)
         resource = Resource.from_contents(content, default_specification=DRAFT202012)
         registry = registry.with_resource(uri=filename, resource=resource)
@@ -69,8 +73,10 @@ def test_preflight_no_against_validates(tmp_path, schemas_dir):
 
     registry = _build_registry(schemas_dir)
     Draft202012Validator(_load(schemas_dir, PREFLIGHT_SCHEMA), registry=registry).validate(payload)
-    assert payload["hints"] == []
-    assert "safe_to_deploy" in payload
+    # #148: structured report shape, not the old flat PreflightResult.to_dict().
+    assert payload["ok"] is True
+    assert payload["summary"]["migrations_checked"] == 1
+    assert payload["issues"] == []
 
 
 def test_preflight_against_validates(tmp_path, schemas_dir):

--- a/tests/unit/test_cli_error_paths.py
+++ b/tests/unit/test_cli_error_paths.py
@@ -71,7 +71,7 @@ database_url: postgresql://localhost/test
             app, ["build", "--env", "nonexistent", "--project-dir", str(tmp_path)]
         )
 
-        assert result.exit_code in (1, 2)  # 2 if ConfigurationError (CONFIG_001)
+        assert result.exit_code in (1, 5)  # 5 if ConfigurationError (#146: CONFIG → 5)
         assert "File not found" in result.output or "Error" in result.output
 
     def test_build_with_custom_output(self, tmp_path):

--- a/tests/unit/test_cli_fail_boundary.py
+++ b/tests/unit/test_cli_fail_boundary.py
@@ -1,0 +1,65 @@
+"""Tests for the JSON-aware CLI error boundary fail() (issue #145).
+
+Uses capsys for real FD-level stdout/stderr separation, per
+.phases/.../test-conventions.md (CliRunner cannot separate the streams).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import typer
+
+from confiture.cli.error_json import fail
+from confiture.exceptions import ConfigurationError, MigrationConflictError
+
+
+def test_fail_emits_json_to_stdout_and_exits_with_code(capsys) -> None:
+    with pytest.raises(typer.Exit) as exc:
+        fail(
+            MigrationConflictError("dup", conflicting_files=["a", "b"]),
+            json_mode=True,
+            output_file=None,
+        )
+    assert exc.value.exit_code == 3  # MIGR_106 → 3 (#146)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "MIGR_106"
+    assert payload["error"]["details"] == {"conflicting_files": ["a", "b"]}
+    assert captured.err == ""  # nothing on stderr in JSON mode
+
+
+def test_fail_human_mode_writes_stderr_not_stdout(capsys) -> None:
+    with pytest.raises(typer.Exit) as exc:
+        fail(
+            ConfigurationError("bad config", error_code="CONFIG_006"),
+            json_mode=False,
+            output_file=None,
+        )
+    assert exc.value.exit_code == 3  # CONFIG_006 → 3 (#146)
+    captured = capsys.readouterr()
+    assert captured.out == ""  # nothing on stdout in human mode
+    assert "bad config" in captured.err
+
+
+def test_fail_json_exit_code_for_config_invalid(capsys) -> None:
+    with pytest.raises(typer.Exit) as exc:
+        fail(
+            ConfigurationError("missing field", error_code="CONFIG_001"),
+            json_mode=True,
+            output_file=None,
+        )
+    assert exc.value.exit_code == 5  # CONFIG_001 → 5 (#146)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "CONFIG_001"
+
+
+def test_fail_wraps_non_confiture_exception(capsys) -> None:
+    with pytest.raises(typer.Exit) as exc:
+        fail(RuntimeError("unexpected"), json_mode=True, output_file=None)
+    assert exc.value.exit_code == 1  # generic
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    assert "unexpected" in payload["error"]["message"]

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -1,0 +1,124 @@
+"""Unit tests for the connection-free ConfigValidator (issue #144, Phase 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from confiture.core.config_validator import ConfigValidator
+
+
+def _project(tmp_path: Path, *, include="db/schema", database_url="postgresql://localhost/app", n_migrations=3) -> Path:
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    for i in range(n_migrations):
+        v = f"2026010100000{i}"
+        (migs / f"{v}_m{i}.up.sql").write_text("SELECT 1;")
+        (migs / f"{v}_m{i}.down.sql").write_text("SELECT 1;")
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {"name": "test", "database_url": database_url, "include_dirs": [include]}
+        )
+    )
+    return cfg
+
+
+# ── schema + path ─────────────────────────────────────────────────────────────
+
+
+def test_valid_config_reports_valid(tmp_path: Path) -> None:
+    cfg = _project(tmp_path)
+    report = ConfigValidator.from_config(cfg, migrations_path=tmp_path / "db" / "migrations").validate()
+    assert report.valid
+    assert report.issues == []
+    assert report.migration_count == 3
+    assert report.config_source == "yaml-file"
+
+
+def test_missing_required_field(tmp_path: Path) -> None:
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(yaml.safe_dump({"name": "test", "include_dirs": ["db/schema"]}))  # no database_url
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    report = ConfigValidator.from_config(cfg, migrations_path=tmp_path / "missing").validate()
+    assert not report.valid
+    assert any(i.code == "CONFIG_001" for i in report.issues)
+
+
+def test_nonexistent_include_dir(tmp_path: Path) -> None:
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {"name": "test", "database_url": "postgresql://localhost/app", "include_dirs": ["db/nope"]}
+        )
+    )
+    report = ConfigValidator.from_config(cfg, migrations_path=tmp_path).validate()
+    assert not report.valid
+    assert any("does not exist" in i.message for i in report.issues)
+
+
+def test_missing_config_file(tmp_path: Path) -> None:
+    report = ConfigValidator.from_config(tmp_path / "nope.yaml", migrations_path=tmp_path).validate()
+    assert not report.valid
+    assert any(i.code == "CONFIG_004" for i in report.issues)
+
+
+def test_invalid_yaml(tmp_path: Path) -> None:
+    cfg = tmp_path / "broken.yaml"
+    cfg.write_text("database_url: [unterminated\n  : :")
+    report = ConfigValidator.from_config(cfg, migrations_path=tmp_path).validate()
+    assert not report.valid
+    assert any(i.code == "CONFIG_002" for i in report.issues)
+
+
+def test_never_connects(monkeypatch, tmp_path: Path) -> None:
+    cfg = _project(tmp_path)
+    monkeypatch.setattr(
+        "psycopg.connect", lambda *a, **k: pytest.fail("validate-config must never connect!")
+    )
+    ConfigValidator.from_config(cfg, migrations_path=tmp_path / "db" / "migrations").validate()
+
+
+# ── migrations tree ───────────────────────────────────────────────────────────
+
+
+def test_duplicate_version_detected(tmp_path: Path) -> None:
+    cfg = _project(tmp_path, n_migrations=0)
+    migs = tmp_path / "db" / "migrations"
+    for name in ("a", "b"):
+        (migs / f"20260101000001_{name}.up.sql").write_text("SELECT 1;")
+        (migs / f"20260101000001_{name}.down.sql").write_text("SELECT 1;")
+    report = ConfigValidator.from_config(cfg, migrations_path=migs).validate()
+    assert not report.valid
+    assert any(i.code == "MIGR_106" for i in report.issues)
+
+
+def test_dsn_format_only_no_connect(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("psycopg.connect", lambda *a, **k: pytest.fail("connected!"))
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    report = ConfigValidator.from_flags(database_url="not-a-dsn", migrations_path=migs).validate()
+    assert not report.valid
+    assert any(i.code == "CONFIG_003" for i in report.issues)
+    assert report.config_source == "flags"
+
+
+def test_flags_valid_dsn(tmp_path: Path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    report = ConfigValidator.from_flags(
+        database_url="postgresql://localhost/app", migrations_path=migs
+    ).validate()
+    assert report.valid
+    assert report.config_source == "flags"
+
+
+def test_report_to_dict_shape(tmp_path: Path) -> None:
+    cfg = _project(tmp_path)
+    report = ConfigValidator.from_config(cfg, migrations_path=tmp_path / "db" / "migrations").validate()
+    d = report.to_dict()
+    assert set(d.keys()) == {"valid", "config_source", "migrations_path", "migration_count", "issues"}
+    assert d["valid"] is True

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -10,7 +10,13 @@ import yaml
 from confiture.core.config_validator import ConfigValidator
 
 
-def _project(tmp_path: Path, *, include="db/schema", database_url="postgresql://localhost/app", n_migrations=3) -> Path:
+def _project(
+    tmp_path: Path,
+    *,
+    include="db/schema",
+    database_url="postgresql://localhost/app",
+    n_migrations=3,
+) -> Path:
     (tmp_path / "db" / "schema").mkdir(parents=True)
     migs = tmp_path / "db" / "migrations"
     migs.mkdir(parents=True)
@@ -20,9 +26,7 @@ def _project(tmp_path: Path, *, include="db/schema", database_url="postgresql://
         (migs / f"{v}_m{i}.down.sql").write_text("SELECT 1;")
     cfg = tmp_path / "env.yaml"
     cfg.write_text(
-        yaml.safe_dump(
-            {"name": "test", "database_url": database_url, "include_dirs": [include]}
-        )
+        yaml.safe_dump({"name": "test", "database_url": database_url, "include_dirs": [include]})
     )
     return cfg
 
@@ -32,7 +36,9 @@ def _project(tmp_path: Path, *, include="db/schema", database_url="postgresql://
 
 def test_valid_config_reports_valid(tmp_path: Path) -> None:
     cfg = _project(tmp_path)
-    report = ConfigValidator.from_config(cfg, migrations_path=tmp_path / "db" / "migrations").validate()
+    report = ConfigValidator.from_config(
+        cfg, migrations_path=tmp_path / "db" / "migrations"
+    ).validate()
     assert report.valid
     assert report.issues == []
     assert report.migration_count == 3
@@ -41,7 +47,9 @@ def test_valid_config_reports_valid(tmp_path: Path) -> None:
 
 def test_missing_required_field(tmp_path: Path) -> None:
     cfg = tmp_path / "env.yaml"
-    cfg.write_text(yaml.safe_dump({"name": "test", "include_dirs": ["db/schema"]}))  # no database_url
+    cfg.write_text(
+        yaml.safe_dump({"name": "test", "include_dirs": ["db/schema"]})
+    )  # no database_url
     (tmp_path / "db" / "schema").mkdir(parents=True)
     report = ConfigValidator.from_config(cfg, migrations_path=tmp_path / "missing").validate()
     assert not report.valid
@@ -52,7 +60,11 @@ def test_nonexistent_include_dir(tmp_path: Path) -> None:
     cfg = tmp_path / "env.yaml"
     cfg.write_text(
         yaml.safe_dump(
-            {"name": "test", "database_url": "postgresql://localhost/app", "include_dirs": ["db/nope"]}
+            {
+                "name": "test",
+                "database_url": "postgresql://localhost/app",
+                "include_dirs": ["db/nope"],
+            }
         )
     )
     report = ConfigValidator.from_config(cfg, migrations_path=tmp_path).validate()
@@ -61,7 +73,9 @@ def test_nonexistent_include_dir(tmp_path: Path) -> None:
 
 
 def test_missing_config_file(tmp_path: Path) -> None:
-    report = ConfigValidator.from_config(tmp_path / "nope.yaml", migrations_path=tmp_path).validate()
+    report = ConfigValidator.from_config(
+        tmp_path / "nope.yaml", migrations_path=tmp_path
+    ).validate()
     assert not report.valid
     assert any(i.code == "CONFIG_004" for i in report.issues)
 
@@ -118,7 +132,15 @@ def test_flags_valid_dsn(tmp_path: Path) -> None:
 
 def test_report_to_dict_shape(tmp_path: Path) -> None:
     cfg = _project(tmp_path)
-    report = ConfigValidator.from_config(cfg, migrations_path=tmp_path / "db" / "migrations").validate()
+    report = ConfigValidator.from_config(
+        cfg, migrations_path=tmp_path / "db" / "migrations"
+    ).validate()
     d = report.to_dict()
-    assert set(d.keys()) == {"valid", "config_source", "migrations_path", "migration_count", "issues"}
+    assert set(d.keys()) == {
+        "valid",
+        "config_source",
+        "migrations_path",
+        "migration_count",
+        "issues",
+    }
     assert d["valid"] is True

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -12,7 +12,7 @@ from confiture.core.connection import (
     load_config,
     load_migration_module,
 )
-from confiture.exceptions import MigrationError
+from confiture.exceptions import ConfigurationError, MigrationError
 
 
 class TestLoadConfig:
@@ -40,7 +40,7 @@ class TestLoadConfig:
         """Test loading non-existent config file."""
         nonexistent_file = tmp_path / "nonexistent.yaml"
 
-        with pytest.raises(MigrationError, match="Configuration file not found"):
+        with pytest.raises(ConfigurationError, match="Configuration file not found"):
             load_config(nonexistent_file)
 
     def test_load_config_invalid_yaml(self, tmp_path):
@@ -48,7 +48,7 @@ class TestLoadConfig:
         config_file = tmp_path / "invalid.yaml"
         config_file.write_text("{ invalid: yaml: content: : : }")
 
-        with pytest.raises(MigrationError, match="Invalid YAML configuration"):
+        with pytest.raises(ConfigurationError, match="Invalid YAML configuration"):
             load_config(config_file)
 
     def test_load_config_empty_file(self, tmp_path):
@@ -130,7 +130,7 @@ class TestCreateConnection:
 
         config = {"database": {"host": "invalid-host"}}
 
-        with pytest.raises(MigrationError, match="Failed to connect to database"):
+        with pytest.raises(ConfigurationError, match="Failed to connect to database"):
             create_connection(config)
 
 

--- a/tests/unit/test_error_codebook.py
+++ b/tests/unit/test_error_codebook.py
@@ -1,0 +1,53 @@
+"""Codebook coverage tests for the structured error contract (issue #145).
+
+Confirms the common failure modes the issue lists are each a registered code,
+that every code carries an `actionable` resolution hint (the envelope field), and
+that the published codebook doc stays generated from the registry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from confiture.core.error_codes import ERROR_CODE_REGISTRY, render_error_codebook
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CODEBOOK_DOC = _REPO_ROOT / "docs" / "reference" / "error-codes.md"
+
+# The common failure modes the issue enumerates, each mapped to its stable code.
+REQUIRED_COMMON = {
+    "MIGR_106",  # duplicate version
+    "ROLLBACK_600",  # irreversible / missing down
+    "LOCK_1300",  # lock contention
+    "CONFIG_006",  # connection failed
+    "MIGR_011",  # checksum mismatch
+    "PRECON_1001",  # not initialized / no tracking table
+}
+
+
+def test_required_common_codes_registered() -> None:
+    have = {d.code for d in ERROR_CODE_REGISTRY.all_codes()}
+    assert have >= REQUIRED_COMMON
+
+
+def test_every_code_has_actionable_hint() -> None:
+    """Every registered code carries a resolution hint (envelope `actionable`)."""
+    missing = [d.code for d in ERROR_CODE_REGISTRY.all_codes() if not d.resolution_hint]
+    assert missing == [], f"codes without a resolution_hint: {missing}"
+
+
+def test_codebook_doc_lists_required_common_codes() -> None:
+    doc = _CODEBOOK_DOC.read_text()
+    for code in REQUIRED_COMMON:
+        assert f"`{code}`" in doc, f"{code} missing from error-codes.md"
+
+
+def test_codebook_doc_embeds_current_generated_table() -> None:
+    doc = _CODEBOOK_DOC.read_text()
+    begin = "<!-- BEGIN GENERATED: codebook -->"
+    end = "<!-- END GENERATED -->"
+    assert begin in doc and end in doc, "codebook generated-section markers missing"
+    embedded = doc.split(begin, 1)[1].split(end, 1)[0].strip()
+    assert embedded == render_error_codebook().strip(), (
+        "error-codes.md codebook is stale; regenerate from render_error_codebook()"
+    )

--- a/tests/unit/test_error_codes.py
+++ b/tests/unit/test_error_codes.py
@@ -230,7 +230,7 @@ class TestGlobalErrorCodeRegistry:
         # CONFIG_001 should be defined
         definition = ERROR_CODE_REGISTRY.get("CONFIG_001")
         assert definition.code == "CONFIG_001"
-        assert definition.exit_code == 2  # Configuration error exit code
+        assert definition.exit_code == 5  # #146: CONFIG family → config invalid (5)
 
     def test_global_registry_has_migr_codes(self) -> None:
         """Test that MIGR category codes are registered."""

--- a/tests/unit/test_error_codes_populated.py
+++ b/tests/unit/test_error_codes_populated.py
@@ -37,7 +37,7 @@ def test_config_010_registered():
 
     definition = ERROR_CODE_REGISTRY.get("CONFIG_010")
     assert definition.code == "CONFIG_010"
-    assert definition.exit_code == 2
+    assert definition.exit_code == 5  # #146: CONFIG family → 5 (config invalid)
 
 
 # ── C-2: ConfigurationError guard raises with CONFIG_001 ──────────────────────
@@ -65,7 +65,7 @@ def test_migrator_session_guard_has_config_error_code():
         session.status()
 
     assert exc_info.value.error_code == "CONFIG_001"
-    assert exc_info.value.exit_code == 2
+    assert exc_info.value.exit_code == 5  # #146: CONFIG family → 5 (config invalid)
 
 
 def test_migrator_session_up_guard_has_config_error_code():
@@ -150,7 +150,7 @@ def test_from_config_missing_file_uses_config_004():
         Migrator.from_config("/nonexistent/path/config.yaml")
 
     assert exc_info.value.error_code == "CONFIG_004"
-    assert exc_info.value.exit_code == 2
+    assert exc_info.value.exit_code == 5  # #146: CONFIG family → 5 (config invalid)
 
 
 # ── C-5: error_code is always present as non-None string ─────────────────────

--- a/tests/unit/test_error_envelope.py
+++ b/tests/unit/test_error_envelope.py
@@ -43,7 +43,16 @@ def test_migration_version_promoted_to_migration_field() -> None:
 def test_inner_object_always_has_all_keys() -> None:
     env = emit_error_json(ConfiturError("plain", error_code="CONFIG_001"))
     inner = env["error"]
-    for key in ("severity", "code", "message", "actionable", "details", "migration", "file", "line"):
+    for key in (
+        "severity",
+        "code",
+        "message",
+        "actionable",
+        "details",
+        "migration",
+        "file",
+        "line",
+    ):
         assert key in inner, f"missing required key {key}"
 
 
@@ -65,9 +74,7 @@ def test_critical_severity_folds_to_error() -> None:
 
 
 def test_details_are_json_serializable_paths_become_str() -> None:
-    err = MigrationConflictError(
-        "dup", conflicting_files=[Path("a.sql"), Path("b.sql")]
-    )
+    err = MigrationConflictError("dup", conflicting_files=[Path("a.sql"), Path("b.sql")])
     details = emit_error_json(err)["error"]["details"]
     assert details["conflicting_files"] == ["a.sql", "b.sql"]
 

--- a/tests/unit/test_error_envelope.py
+++ b/tests/unit/test_error_envelope.py
@@ -1,0 +1,85 @@
+"""Tests for the structured error envelope serializer (issue #145).
+
+The `error` object IS the unified inner issue object from
+.phases/.../shared-issue-schema.md: {severity, code, message, actionable,
+details, migration, file, line}. Required keys are always present (nullable).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from confiture.cli.error_json import coerce_to_confiture_error, emit_error_json
+from confiture.exceptions import ConfiturError, MigrationConflictError, MigrationError
+
+
+def test_envelope_shape_for_duplicate_version() -> None:
+    err = MigrationConflictError(
+        "Migration version 20260531_1430 is defined twice: foo.sql and bar.sql.",
+        conflicting_files=["foo.sql", "bar.sql"],
+    )
+    env = emit_error_json(err)
+    assert env == {
+        "ok": False,
+        "error": {
+            "code": "MIGR_106",
+            "message": "Migration version 20260531_1430 is defined twice: foo.sql and bar.sql.",
+            "severity": "error",
+            "details": {"conflicting_files": ["foo.sql", "bar.sql"]},
+            "migration": None,
+            "file": None,
+            "line": None,
+            "actionable": err.resolution_hint,
+        },
+    }
+
+
+def test_migration_version_promoted_to_migration_field() -> None:
+    err = MigrationError("boom", version="20260531_1430", migration_name="add_bio")
+    env = emit_error_json(err)
+    assert env["error"]["migration"] == "20260531_1430"
+
+
+def test_inner_object_always_has_all_keys() -> None:
+    env = emit_error_json(ConfiturError("plain", error_code="CONFIG_001"))
+    inner = env["error"]
+    for key in ("severity", "code", "message", "actionable", "details", "migration", "file", "line"):
+        assert key in inner, f"missing required key {key}"
+
+
+def test_file_and_line_promoted_from_context() -> None:
+    err = ConfiturError(
+        "bad",
+        error_code="LINT_1500",
+        context={"file": "db/schema/10_tables/users.sql", "line": 42, "rule": "R1"},
+    )
+    inner = emit_error_json(err)["error"]
+    assert inner["file"] == "db/schema/10_tables/users.sql"
+    assert inner["line"] == 42
+    assert inner["details"] == {"rule": "R1"}  # file/line promoted out of details
+
+
+def test_critical_severity_folds_to_error() -> None:
+    err = ConfiturError("severe", error_code="ROLLBACK_600")  # CRITICAL severity
+    assert emit_error_json(err)["error"]["severity"] == "error"
+
+
+def test_details_are_json_serializable_paths_become_str() -> None:
+    err = MigrationConflictError(
+        "dup", conflicting_files=[Path("a.sql"), Path("b.sql")]
+    )
+    details = emit_error_json(err)["error"]["details"]
+    assert details["conflicting_files"] == ["a.sql", "b.sql"]
+
+
+def test_non_confiture_exception_coerced_to_envelope() -> None:
+    err = coerce_to_confiture_error(KeyError("surprise"))
+    env = emit_error_json(err)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "INTERNAL_ERROR"
+    assert err.exit_code == 1  # generic failure
+
+
+def test_coerce_passes_through_confiture_error() -> None:
+    original = MigrationError("x", error_code="MIGR_100")
+    assert coerce_to_confiture_error(original) is original

--- a/tests/unit/test_error_handler.py
+++ b/tests/unit/test_error_handler.py
@@ -103,8 +103,8 @@ class TestHandleCliError:
 
         exit_code = handle_cli_error(error)
 
-        # CONFIG_001 should map to exit code 2
-        assert exit_code == 2
+        # CONFIG_001 maps to exit code 5 (#146: CONFIG family → config-invalid)
+        assert exit_code == 5
 
     def test_handle_confiture_error_without_code(self) -> None:
         """Test handling ConfiturError without error code."""
@@ -140,7 +140,7 @@ class TestHandleCliError:
     def test_exit_code_mapping(self) -> None:
         """Test that different error codes map to correct exit codes."""
         test_cases = [
-            ("CONFIG_001", 2),  # Configuration error
+            ("CONFIG_001", 5),  # Configuration error (#146: config invalid → 5)
             ("MIGR_100", 3),  # Migration error
             ("SCHEMA_200", 4),  # Schema error
         ]

--- a/tests/unit/test_exit_code_convention.py
+++ b/tests/unit/test_exit_code_convention.py
@@ -1,0 +1,99 @@
+"""Convention test for the stabilized exit-code contract (issue #146).
+
+This module asserts the live ``ERROR_CODE_REGISTRY`` against the HAND-AUTHORED
+``CANONICAL_EXIT_CODES`` table. The two are deliberately independent sources:
+``CANONICAL_EXIT_CODES`` is written from ``docs/reference/exit-codes.md``, the
+registry is the runtime data ``ConfiturError.exit_code`` reads. The redundancy
+is the enforcement mechanism — a drift between them fails here, not in
+production. Deriving one from the other would make this test a tautology.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from confiture.core.error_codes import (
+    CANONICAL_EXIT_CODES,
+    ERROR_CODE_REGISTRY,
+    render_exit_codes_doc,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXIT_CODES_DOC = _REPO_ROOT / "docs" / "reference" / "exit-codes.md"
+
+
+@pytest.mark.parametrize(
+    "definition",
+    ERROR_CODE_REGISTRY.all_codes(),
+    ids=lambda d: d.code,
+)
+def test_registry_exit_code_matches_canonical(definition) -> None:
+    """Every registered error code exits with its canonical number."""
+    assert definition.code in CANONICAL_EXIT_CODES, (
+        f"{definition.code} is registered but missing from CANONICAL_EXIT_CODES; "
+        f"add it to the hand-authored contract (and docs/reference/exit-codes.md)"
+    )
+    assert definition.exit_code == CANONICAL_EXIT_CODES[definition.code], (
+        f"{definition.code}: registry says {definition.exit_code}, "
+        f"canonical says {CANONICAL_EXIT_CODES[definition.code]}"
+    )
+
+
+def test_canonical_table_covers_exactly_the_registry() -> None:
+    """The contract and the registry describe the same set of codes.
+
+    A newly added registry code must also be added to CANONICAL_EXIT_CODES
+    (and the doc) — it cannot silently skip the convention. A stale canonical
+    entry for a removed code is likewise caught here.
+    """
+    canonical = set(CANONICAL_EXIT_CODES)
+    registered = {d.code for d in ERROR_CODE_REGISTRY.all_codes()}
+    assert canonical == registered, (
+        f"only in canonical: {sorted(canonical - registered)}; "
+        f"only in registry: {sorted(registered - canonical)}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_exit"),
+    [
+        ("MIGR_101", 0),  # already applied — success-with-signal
+        ("MIGR_105", 0),  # no pending migrations — success-with-signal
+        ("LINT_1501", 0),  # lint warning — informational, non-blocking
+        ("DIFFER_402", 1),  # ambiguous-change advisory (DIFFER family is 5)
+        ("PRECON_1001", 2),  # tracking table absent (PRECON family is 5)
+        ("CONFIG_006", 3),  # DB connection failed (CONFIG family is 5)
+    ],
+)
+def test_intentional_carve_outs(code: str, expected_exit: int) -> None:
+    """Codes that deliberately differ from their family default stay put.
+
+    These are not strays to "align" during a call-site audit — each is a
+    documented carve-out in docs/reference/exit-codes.md.
+    """
+    assert ERROR_CODE_REGISTRY.get(code).exit_code == expected_exit
+    assert CANONICAL_EXIT_CODES[code] == expected_exit
+
+
+def test_exit_codes_doc_covers_every_code() -> None:
+    """The reference doc has a summary row for every in-use exit code."""
+    doc = _EXIT_CODES_DOC.read_text()
+    for code in sorted(set(CANONICAL_EXIT_CODES.values())):
+        assert f"| {code} |" in doc, f"exit code {code} undocumented in exit-codes.md"
+
+
+def test_exit_codes_doc_embeds_current_generated_section() -> None:
+    """The doc's generated block matches render_exit_codes_doc() (no drift).
+
+    If a code is added/renumbered, regenerate with ``confiture --exit-codes``
+    and paste between the BEGIN/END GENERATED markers.
+    """
+    doc = _EXIT_CODES_DOC.read_text()
+    begin = "<!-- BEGIN GENERATED: confiture --exit-codes -->"
+    end = "<!-- END GENERATED -->"
+    assert begin in doc and end in doc, "generated-section markers missing"
+    embedded = doc.split(begin, 1)[1].split(end, 1)[0].strip()
+    assert embedded == render_exit_codes_doc().strip(), (
+        "exit-codes.md generated block is stale; regenerate with "
+        "`confiture --exit-codes`"
+    )

--- a/tests/unit/test_exit_code_convention.py
+++ b/tests/unit/test_exit_code_convention.py
@@ -94,6 +94,5 @@ def test_exit_codes_doc_embeds_current_generated_section() -> None:
     assert begin in doc and end in doc, "generated-section markers missing"
     embedded = doc.split(begin, 1)[1].split(end, 1)[0].strip()
     assert embedded == render_exit_codes_doc().strip(), (
-        "exit-codes.md generated block is stale; regenerate with "
-        "`confiture --exit-codes`"
+        "exit-codes.md generated block is stale; regenerate with `confiture --exit-codes`"
     )

--- a/tests/unit/test_issue_87_migrate_exit_codes.py
+++ b/tests/unit/test_issue_87_migrate_exit_codes.py
@@ -384,7 +384,9 @@ class TestMigrateUpGenericErrors:
                 ],
             )
 
-        assert result.exit_code == 2, f"Expected exit 2, got {result.exit_code}"
+        # #146: CONFIG_001 maps to exit 5 (config invalid); the point of this
+        # test is that the exit code flows from the registry, not a literal.
+        assert result.exit_code == 5, f"Expected exit 5, got {result.exit_code}"
 
     def test_unknown_exception_exits_1(self, tmp_path):
         """Non-ConfiturError → exit 1."""
@@ -466,7 +468,9 @@ class TestMigrateDownGenericErrors:
                 ],
             )
 
-        assert result.exit_code == 2, f"Expected exit 2, got {result.exit_code}"
+        # #146: CONFIG_001 maps to exit 5 (config invalid); the point of this
+        # test is that the exit code flows from the registry, not a literal.
+        assert result.exit_code == 5, f"Expected exit 5, got {result.exit_code}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_large_tables_public_api.py
+++ b/tests/unit/test_large_tables_public_api.py
@@ -26,11 +26,16 @@ def test_batch_progress_importable():
     assert BatchProgress is not None
 
 
-def test_migrate_up_accepts_batched_flag():
+def test_migrate_up_accepts_batched_flag(monkeypatch):
     """--batched and --batch-size flags are accepted by migrate up."""
     from typer.testing import CliRunner
 
     from confiture.cli.main import app
+
+    # Clear ambient DSN env vars so a missing --config genuinely errors (this
+    # test is about flag *parsing*, not the #140 env-var fallback precedence).
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("CONFITURE_DATABASE_URL", raising=False)
 
     runner = CliRunner()
 

--- a/tests/unit/test_lock_identity.py
+++ b/tests/unit/test_lock_identity.py
@@ -1,0 +1,49 @@
+"""Unit tests for lock-holder identity collection (issue #147, Phase 1)."""
+
+from __future__ import annotations
+
+import os
+import socket
+
+from confiture.core.locking import LockHolder, LockIdentity, collect_lock_identity
+
+
+def test_collects_identity(monkeypatch) -> None:
+    monkeypatch.setattr(socket, "gethostname", lambda: "deploy-host-1")
+    monkeypatch.setattr(os, "getpid", lambda: 12345)
+    ident = collect_lock_identity(command="confiture migrate up")
+    assert ident.pid == 12345
+    assert ident.hostname == "deploy-host-1"
+    assert ident.command == "confiture migrate up"
+
+
+def test_identity_is_a_dataclass() -> None:
+    ident = LockIdentity(pid=1, hostname="h", command="c", user="u")
+    assert (ident.pid, ident.hostname, ident.command, ident.user) == (1, "h", "c", "u")
+
+
+def test_command_defaults_when_none(monkeypatch) -> None:
+    monkeypatch.setattr(os, "getpid", lambda: 9)
+    ident = collect_lock_identity(command=None)
+    # Falls back to a generic confiture label rather than leaking argv.
+    assert ident.command == "confiture"
+
+
+def test_lock_holder_held_for_seconds_and_to_dict() -> None:
+    holder = LockHolder(
+        pid=12345,
+        hostname="deploy-host-1",
+        user="deploy",
+        command="confiture migrate up",
+        acquired_at="2026-05-31T14:30:00+00:00",
+        held_for_seconds=47,
+        live=True,
+    )
+    d = holder.to_dict()
+    assert d["pid"] == 12345
+    assert d["hostname"] == "deploy-host-1"
+    assert d["command"] == "confiture migrate up"
+    assert d["acquired_at"] == "2026-05-31T14:30:00+00:00"
+    assert d["held_for_seconds"] == 47
+    # `live` is internal liveness, not part of the public holder contract.
+    assert "live" not in d

--- a/tests/unit/test_migrate_database_url_flag.py
+++ b/tests/unit/test_migrate_database_url_flag.py
@@ -7,6 +7,7 @@ connection attempt (which fails fast against an unreachable DSN → exit 3).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -25,7 +26,11 @@ _UNREACHABLE = "postgresql://localhost:1/nope"
 def test_database_url_in_help(cmd: str) -> None:
     """Every migrate subcommand documents --database-url (#140 / Phase 2)."""
     out = runner.invoke(app, ["migrate", cmd, "--help"]).output
-    assert "--database-url" in out
+    # Rich wraps long option names at narrow terminal widths (e.g. CI's 80
+    # cols), so "--database-url" may render split across lines. Collapse all
+    # whitespace before matching so the assertion is width-independent.
+    collapsed = re.sub(r"\s+", "", out)
+    assert "--database-url" in collapsed
 
 
 def test_status_database_url_only_no_config_connects(tmp_path: Path) -> None:
@@ -99,12 +104,18 @@ def test_up_malformed_database_url_exits_5(tmp_path: Path) -> None:
     assert result.exit_code == 5, result.output
 
 
-def test_env_var_honored_when_no_flag(tmp_path: Path, monkeypatch) -> None:
-    """CONFITURE_DATABASE_URL is honored when no --database-url flag is given."""
+def test_env_var_honored_as_fallback_when_config_absent(tmp_path: Path, monkeypatch) -> None:
+    """CONFITURE_DATABASE_URL is honored as a fallback when the config is absent.
+
+    Precedence: flag > existing --config > env var. Here the --config path does
+    not exist, so the env var supplies the DSN (vs. an ambient env var silently
+    overriding an *existing* config — see test_env_var_does_not_override_config).
+    """
     monkeypatch.setenv("CONFITURE_DATABASE_URL", _UNREACHABLE)
     monkeypatch.delenv("DATABASE_URL", raising=False)
     migrations_dir = tmp_path / "migrations"
     migrations_dir.mkdir()
+    missing_cfg = tmp_path / "nope.yaml"  # explicit, non-existent → env fallback applies
 
     with patch(
         "confiture.core.connection.psycopg.connect",
@@ -112,8 +123,40 @@ def test_env_var_honored_when_no_flag(tmp_path: Path, monkeypatch) -> None:
     ):
         result = runner.invoke(
             app,
-            ["migrate", "up", "--migrations-dir", str(migrations_dir)],
+            ["migrate", "up", "-c", str(missing_cfg), "--migrations-dir", str(migrations_dir)],
         )
-    # Reached the connection attempt via the env override (exit 3), not a
-    # config-file lookup (which would be exit 5 for the missing default YAML).
+    # Reached the connection attempt via the env fallback (exit 3).
     assert result.exit_code == 3, result.output
+
+
+def test_env_var_does_not_override_existing_config(tmp_path: Path, monkeypatch) -> None:
+    """An ambient env var must NOT override an existing --config (#140 / CI fix)."""
+    import yaml
+
+    monkeypatch.setenv("DATABASE_URL", _UNREACHABLE)
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": "postgresql://localhost:2/cfgdb",
+                "migration": {"tracking_table": "myschema.tb_x"},
+            }
+        )
+    )
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    captured: dict = {}
+
+    def _fake_connect(arg, *a, **k):
+        captured["dsn"] = arg
+        raise psycopg.OperationalError("refused")
+
+    with patch("confiture.core.connection.psycopg.connect", side_effect=_fake_connect):
+        runner.invoke(
+            app,
+            ["migrate", "up", "-c", str(cfg), "--migrations-dir", str(migrations_dir)],
+        )
+    # The config's DSN was used, not the ambient DATABASE_URL env var.
+    assert captured.get("dsn") == "postgresql://localhost:2/cfgdb"

--- a/tests/unit/test_migrate_database_url_flag.py
+++ b/tests/unit/test_migrate_database_url_flag.py
@@ -22,14 +22,19 @@ runner = CliRunner()
 _UNREACHABLE = "postgresql://localhost:1/nope"
 
 
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
 @pytest.mark.parametrize("cmd", ["up", "down", "status", "verify", "preflight"])
 def test_database_url_in_help(cmd: str) -> None:
     """Every migrate subcommand documents --database-url (#140 / Phase 2)."""
     out = runner.invoke(app, ["migrate", cmd, "--help"]).output
     # Rich wraps long option names at narrow terminal widths (e.g. CI's 80
-    # cols), so "--database-url" may render split across lines. Collapse all
-    # whitespace before matching so the assertion is width-independent.
-    collapsed = re.sub(r"\s+", "", out)
+    # cols) AND colorizes them when a TTY/FORCE_COLOR is detected, interleaving
+    # ANSI SGR codes mid-token (e.g. "--database\x1b[0m-url"). Strip ANSI first,
+    # then collapse whitespace, so the assertion is both width- and color-
+    # independent (CI forces color; local runs usually don't).
+    collapsed = re.sub(r"\s+", "", _ANSI.sub("", out))
     assert "--database-url" in collapsed
 
 

--- a/tests/unit/test_migrate_database_url_flag.py
+++ b/tests/unit/test_migrate_database_url_flag.py
@@ -1,0 +1,101 @@
+"""CLI wiring tests for --database-url on the migrate family (issue #140).
+
+These exercise the precedence/override plumbing without a live database:
+malformed-DSN validation, and the override-only path reaching a real
+connection attempt (which fails fast against an unreachable DSN → exit 3).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import psycopg
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+_UNREACHABLE = "postgresql://localhost:1/nope"
+
+
+@pytest.mark.parametrize("cmd", ["up", "down", "status", "verify", "preflight"])
+def test_database_url_in_help(cmd: str) -> None:
+    """Every migrate subcommand documents --database-url (#140 / Phase 2)."""
+    out = runner.invoke(app, ["migrate", cmd, "--help"]).output
+    assert "--database-url" in out
+
+
+def test_status_database_url_only_no_config_connects(tmp_path: Path) -> None:
+    """`migrate status --database-url` connects without --config.
+
+    The override is honored (no YAML required); an unreachable DSN surfaces as
+    the status command's fatal exit (3), proving the connection was attempted.
+    """
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "001_x.up.sql").write_text("SELECT 1;")
+    (migrations_dir / "001_x.down.sql").write_text("SELECT 1;")
+
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("connection refused"),
+    ):
+        result = runner.invoke(
+            app,
+            ["migrate", "status", "--database-url", _UNREACHABLE,
+             "--migrations-dir", str(migrations_dir)],
+        )
+    assert result.exit_code == 3, result.output
+
+
+def test_up_database_url_only_unreachable_exits_3(tmp_path: Path) -> None:
+    """`migrate up --database-url <unreachable>` needs no config and exits 3."""
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("connection refused"),
+    ):
+        result = runner.invoke(
+            app,
+            ["migrate", "up", "--database-url", _UNREACHABLE,
+             "--migrations-dir", str(migrations_dir)],
+        )
+    assert result.exit_code == 3, result.output
+
+
+def test_up_malformed_database_url_exits_5(tmp_path: Path) -> None:
+    """A malformed --database-url DSN is a config error (CONFIG_003 → exit 5)."""
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    result = runner.invoke(
+        app,
+        ["migrate", "up", "--database-url", "mysql://nope/db",
+         "--migrations-dir", str(migrations_dir)],
+    )
+    assert result.exit_code == 5, result.output
+
+
+def test_env_var_honored_when_no_flag(tmp_path: Path, monkeypatch) -> None:
+    """CONFITURE_DATABASE_URL is honored when no --database-url flag is given."""
+    monkeypatch.setenv("CONFITURE_DATABASE_URL", _UNREACHABLE)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("connection refused"),
+    ):
+        result = runner.invoke(
+            app,
+            ["migrate", "up", "--migrations-dir", str(migrations_dir)],
+        )
+    # Reached the connection attempt via the env override (exit 3), not a
+    # config-file lookup (which would be exit 5 for the missing default YAML).
+    assert result.exit_code == 3, result.output

--- a/tests/unit/test_migrate_database_url_flag.py
+++ b/tests/unit/test_migrate_database_url_flag.py
@@ -45,8 +45,14 @@ def test_status_database_url_only_no_config_connects(tmp_path: Path) -> None:
     ):
         result = runner.invoke(
             app,
-            ["migrate", "status", "--database-url", _UNREACHABLE,
-             "--migrations-dir", str(migrations_dir)],
+            [
+                "migrate",
+                "status",
+                "--database-url",
+                _UNREACHABLE,
+                "--migrations-dir",
+                str(migrations_dir),
+            ],
         )
     assert result.exit_code == 3, result.output
 
@@ -62,8 +68,14 @@ def test_up_database_url_only_unreachable_exits_3(tmp_path: Path) -> None:
     ):
         result = runner.invoke(
             app,
-            ["migrate", "up", "--database-url", _UNREACHABLE,
-             "--migrations-dir", str(migrations_dir)],
+            [
+                "migrate",
+                "up",
+                "--database-url",
+                _UNREACHABLE,
+                "--migrations-dir",
+                str(migrations_dir),
+            ],
         )
     assert result.exit_code == 3, result.output
 
@@ -75,8 +87,14 @@ def test_up_malformed_database_url_exits_5(tmp_path: Path) -> None:
 
     result = runner.invoke(
         app,
-        ["migrate", "up", "--database-url", "mysql://nope/db",
-         "--migrations-dir", str(migrations_dir)],
+        [
+            "migrate",
+            "up",
+            "--database-url",
+            "mysql://nope/db",
+            "--migrations-dir",
+            str(migrations_dir),
+        ],
     )
     assert result.exit_code == 5, result.output
 

--- a/tests/unit/test_migrate_exit_code_convention.py
+++ b/tests/unit/test_migrate_exit_code_convention.py
@@ -1,0 +1,99 @@
+"""Behavioral exit-code tests for the migrate family (issue #146).
+
+These assert the *canonical* exit numbers the fraisier-core adapter branches on:
+no-table=2, connect-fail=3, config-invalid=5, lock=6. They complement the
+registry-contract test in test_exit_code_convention.py by exercising the real
+CLI/connection paths that produce those numbers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import psycopg
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.connection import create_connection, load_config
+from confiture.exceptions import ConfigurationError
+
+runner = CliRunner()
+
+
+# ── connection.py translates to canonical ConfigurationError codes ────────────
+
+
+def test_load_config_missing_file_raises_config_invalid() -> None:
+    """A missing config file is a config error (CONFIG family → exit 5)."""
+    with pytest.raises(ConfigurationError) as exc_info:
+        load_config(Path("/nonexistent/path/to/config.yaml"))
+    assert exc_info.value.exit_code == 5
+
+
+def test_load_config_invalid_yaml_raises_config_002(tmp_path: Path) -> None:
+    """Malformed YAML is a config error (CONFIG_002 → exit 5)."""
+    bad = tmp_path / "broken.yaml"
+    bad.write_text("database_url: [unterminated\n  : :")
+    with pytest.raises(ConfigurationError) as exc_info:
+        load_config(bad)
+    assert exc_info.value.error_code == "CONFIG_002"
+    assert exc_info.value.exit_code == 5
+
+
+def test_create_connection_failure_raises_config_006() -> None:
+    """A failed connection carries CONFIG_006 → exit 3 (connect-fail)."""
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("connection refused"),
+    ):
+        with pytest.raises(ConfigurationError) as exc_info:
+            create_connection("postgresql://localhost:1/nope")
+    assert exc_info.value.error_code == "CONFIG_006"
+    assert exc_info.value.exit_code == 3
+
+
+# ── migrate up surfaces the canonical numbers ─────────────────────────────────
+
+
+def _write_valid_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "local.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {"name": "test", "database_url": "postgresql://localhost:1/nope"}
+        )
+    )
+    return cfg
+
+
+def test_migrate_up_broken_yaml_exits_5(tmp_path: Path) -> None:
+    """`migrate up` with a malformed config exits 5 (config invalid)."""
+    cfg = tmp_path / "broken.yaml"
+    cfg.write_text("database_url: [unterminated\n  : :")
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    result = runner.invoke(
+        app,
+        ["migrate", "up", "--config", str(cfg), "--migrations-dir", str(migrations_dir)],
+    )
+    assert result.exit_code == 5, result.output
+
+
+def test_migrate_up_connection_refused_exits_3(tmp_path: Path) -> None:
+    """`migrate up` with an unreachable database exits 3 (connect-fail)."""
+    cfg = _write_valid_config(tmp_path)
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("connection refused"),
+    ):
+        result = runner.invoke(
+            app,
+            ["migrate", "up", "--config", str(cfg), "--migrations-dir", str(migrations_dir)],
+        )
+    assert result.exit_code == 3, result.output

--- a/tests/unit/test_migrate_exit_code_convention.py
+++ b/tests/unit/test_migrate_exit_code_convention.py
@@ -61,9 +61,7 @@ def test_create_connection_failure_raises_config_006() -> None:
 def _write_valid_config(tmp_path: Path) -> Path:
     cfg = tmp_path / "local.yaml"
     cfg.write_text(
-        yaml.safe_dump(
-            {"name": "test", "database_url": "postgresql://localhost:1/nope"}
-        )
+        yaml.safe_dump({"name": "test", "database_url": "postgresql://localhost:1/nope"})
     )
     return cfg
 

--- a/tests/unit/test_migrate_json_error_envelope.py
+++ b/tests/unit/test_migrate_json_error_envelope.py
@@ -1,0 +1,130 @@
+"""Issue #145 Phase 2: migrate-family --format json failure paths emit the envelope.
+
+Per .phases/.../test-conventions.md, these assert stdout *parses* as the
+envelope (CliRunner cannot reliably separate stdout/stderr); the boundary's
+stream separation is covered by test_cli_fail_boundary.py with capsys.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import psycopg
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+_UNREACHABLE = "postgresql://localhost:1/nope"
+
+
+def _dupe_migrations(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    # Two files sharing version 20260101000001 → MIGR_106.
+    for name in ("20260101000001_a", "20260101000001_b"):
+        (d / f"{name}.up.sql").write_text("SELECT 1;")
+        (d / f"{name}.down.sql").write_text("SELECT 1;")
+    return d
+
+
+def test_up_duplicate_version_json_envelope(tmp_path: Path) -> None:
+    migrations_dir = _dupe_migrations(tmp_path)
+    result = runner.invoke(
+        app,
+        ["migrate", "up", "--database-url", _UNREACHABLE,
+         "--migrations-dir", str(migrations_dir), "--format", "json"],
+    )
+    assert result.exit_code == 3, result.output
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "MIGR_106"
+    assert payload["error"]["details"]["conflicting_files"]  # populated
+
+
+def test_up_connection_refused_json_envelope(tmp_path: Path) -> None:
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("connection refused"),
+    ):
+        result = runner.invoke(
+            app,
+            ["migrate", "up", "--database-url", _UNREACHABLE,
+             "--migrations-dir", str(migrations_dir), "--format", "json"],
+        )
+    assert result.exit_code == 3, result.output
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "CONFIG_006"
+
+
+def test_up_broken_yaml_json_envelope(tmp_path: Path) -> None:
+    cfg = tmp_path / "broken.yaml"
+    cfg.write_text("database_url: [unterminated\n  : :")
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    result = runner.invoke(
+        app,
+        ["migrate", "up", "--config", str(cfg),
+         "--migrations-dir", str(migrations_dir), "--format", "json"],
+    )
+    assert result.exit_code == 5, result.output
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "CONFIG_002"
+
+
+def test_down_connection_refused_json_envelope(tmp_path: Path) -> None:
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("connection refused"),
+    ):
+        result = runner.invoke(
+            app,
+            ["migrate", "down", "--database-url", _UNREACHABLE,
+             "--migrations-dir", str(migrations_dir), "--format", "json"],
+        )
+    assert result.exit_code == 3, result.output
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "CONFIG_006"
+
+
+def test_up_text_mode_does_not_emit_json_envelope(tmp_path: Path) -> None:
+    """Human (text) mode is unchanged — no JSON envelope on stdout."""
+    cfg = tmp_path / "broken.yaml"
+    cfg.write_text("database_url: [unterminated\n  : :")
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    result = runner.invoke(
+        app,
+        ["migrate", "up", "--config", str(cfg),
+         "--migrations-dir", str(migrations_dir), "--format", "text"],
+    )
+    assert result.exit_code == 5, result.output
+    assert not result.stdout.strip().startswith("{")  # not the JSON envelope
+
+
+def test_up_unreachable_json_envelope_has_all_inner_keys(tmp_path: Path) -> None:
+    """The inner error object carries every required key (nullable)."""
+    cfg = tmp_path / "ok.yaml"
+    cfg.write_text(yaml.safe_dump({"name": "t", "database_url": _UNREACHABLE}))
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    with patch(
+        "confiture.core.connection.psycopg.connect",
+        side_effect=psycopg.OperationalError("refused"),
+    ):
+        result = runner.invoke(
+            app,
+            ["migrate", "up", "--config", str(cfg),
+             "--migrations-dir", str(migrations_dir), "--format", "json"],
+        )
+    inner = json.loads(result.stdout)["error"]
+    for key in ("severity", "code", "message", "actionable", "details", "migration", "file", "line"):
+        assert key in inner

--- a/tests/unit/test_migrate_json_error_envelope.py
+++ b/tests/unit/test_migrate_json_error_envelope.py
@@ -36,8 +36,16 @@ def test_up_duplicate_version_json_envelope(tmp_path: Path) -> None:
     migrations_dir = _dupe_migrations(tmp_path)
     result = runner.invoke(
         app,
-        ["migrate", "up", "--database-url", _UNREACHABLE,
-         "--migrations-dir", str(migrations_dir), "--format", "json"],
+        [
+            "migrate",
+            "up",
+            "--database-url",
+            _UNREACHABLE,
+            "--migrations-dir",
+            str(migrations_dir),
+            "--format",
+            "json",
+        ],
     )
     assert result.exit_code == 3, result.output
     payload = json.loads(result.stdout)
@@ -55,8 +63,16 @@ def test_up_connection_refused_json_envelope(tmp_path: Path) -> None:
     ):
         result = runner.invoke(
             app,
-            ["migrate", "up", "--database-url", _UNREACHABLE,
-             "--migrations-dir", str(migrations_dir), "--format", "json"],
+            [
+                "migrate",
+                "up",
+                "--database-url",
+                _UNREACHABLE,
+                "--migrations-dir",
+                str(migrations_dir),
+                "--format",
+                "json",
+            ],
         )
     assert result.exit_code == 3, result.output
     payload = json.loads(result.stdout)
@@ -70,8 +86,16 @@ def test_up_broken_yaml_json_envelope(tmp_path: Path) -> None:
     migrations_dir.mkdir()
     result = runner.invoke(
         app,
-        ["migrate", "up", "--config", str(cfg),
-         "--migrations-dir", str(migrations_dir), "--format", "json"],
+        [
+            "migrate",
+            "up",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(migrations_dir),
+            "--format",
+            "json",
+        ],
     )
     assert result.exit_code == 5, result.output
     payload = json.loads(result.stdout)
@@ -87,8 +111,16 @@ def test_down_connection_refused_json_envelope(tmp_path: Path) -> None:
     ):
         result = runner.invoke(
             app,
-            ["migrate", "down", "--database-url", _UNREACHABLE,
-             "--migrations-dir", str(migrations_dir), "--format", "json"],
+            [
+                "migrate",
+                "down",
+                "--database-url",
+                _UNREACHABLE,
+                "--migrations-dir",
+                str(migrations_dir),
+                "--format",
+                "json",
+            ],
         )
     assert result.exit_code == 3, result.output
     payload = json.loads(result.stdout)
@@ -103,8 +135,16 @@ def test_up_text_mode_does_not_emit_json_envelope(tmp_path: Path) -> None:
     migrations_dir.mkdir()
     result = runner.invoke(
         app,
-        ["migrate", "up", "--config", str(cfg),
-         "--migrations-dir", str(migrations_dir), "--format", "text"],
+        [
+            "migrate",
+            "up",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(migrations_dir),
+            "--format",
+            "text",
+        ],
     )
     assert result.exit_code == 5, result.output
     assert not result.stdout.strip().startswith("{")  # not the JSON envelope
@@ -122,9 +162,26 @@ def test_up_unreachable_json_envelope_has_all_inner_keys(tmp_path: Path) -> None
     ):
         result = runner.invoke(
             app,
-            ["migrate", "up", "--config", str(cfg),
-             "--migrations-dir", str(migrations_dir), "--format", "json"],
+            [
+                "migrate",
+                "up",
+                "--config",
+                str(cfg),
+                "--migrations-dir",
+                str(migrations_dir),
+                "--format",
+                "json",
+            ],
         )
     inner = json.loads(result.stdout)["error"]
-    for key in ("severity", "code", "message", "actionable", "details", "migration", "file", "line"):
+    for key in (
+        "severity",
+        "code",
+        "message",
+        "actionable",
+        "details",
+        "migration",
+        "file",
+        "line",
+    ):
         assert key in inner

--- a/tests/unit/test_migrate_preflight_cli.py
+++ b/tests/unit/test_migrate_preflight_cli.py
@@ -314,8 +314,8 @@ def test_json_output_structure(runner, tmp_path):
     assert data["against"]["skipped"] == 0
 
 
-def test_json_output_without_against_is_flat(runner, tmp_path):
-    """Backward compat: no --against → flat PreflightResult.to_dict()."""
+def test_json_output_without_against_is_structured_report(runner, tmp_path):
+    """#148: no --against → the structured report {ok, summary, issues[]}."""
     (tmp_path / "20260428000000_a.up.sql").write_text("SELECT 1;")
     (tmp_path / "20260428000000_a.down.sql").write_text("SELECT 1;")
 
@@ -332,8 +332,10 @@ def test_json_output_without_against_is_flat(runner, tmp_path):
     )
 
     data = json.loads(result.output)
-    assert "static" not in data  # flat, not enveloped
-    assert "migrations" in data  # existing PreflightResult shape
+    assert "static" not in data  # not the --against envelope
+    assert set(data.keys()) >= {"ok", "summary", "issues"}  # structured report
+    assert data["ok"] is True
+    assert data["summary"]["migrations_checked"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_migrator_session_down_reinit.py
+++ b/tests/unit/test_migrator_session_down_reinit.py
@@ -65,7 +65,10 @@ class TestMigratorSessionDown:
         session._migrator.rollback = MagicMock()
         session._migrator._version_from_filename = MagicMock(return_value="001")
 
-        with patch("confiture.core.migrator.load_migration_class", return_value=mock_class):
+        with (
+            patch("confiture.core.migrator.load_migration_class", return_value=mock_class),
+            patch("confiture.core.migrator.MigrationLock"),  # #142: down() now locks
+        ):
             result = session.down()
 
         assert result.success is True
@@ -104,7 +107,10 @@ class TestMigratorSessionDown:
         session._migrator.rollback = MagicMock()
         session._migrator._version_from_filename = MagicMock(side_effect=lambda n: n.split("_")[0])
 
-        with patch("confiture.core.migrator.load_migration_class", side_effect=_load_class):
+        with (
+            patch("confiture.core.migrator.load_migration_class", side_effect=_load_class),
+            patch("confiture.core.migrator.MigrationLock"),  # #142: down() now locks
+        ):
             result = session.down(steps=2)
 
         assert len(result.migrations_rolled_back) == 2

--- a/tests/unit/test_operation_classifier.py
+++ b/tests/unit/test_operation_classifier.py
@@ -1,0 +1,71 @@
+"""Tests for the replica-safety DDL classifier (issue #139, Phase 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.replica.classifier import (
+    AddColumn,
+    AddConstraint,
+    ChangeColumnType,
+    CreateIndex,
+    CreateTable,
+    DropColumn,
+    OperationClassifier,
+    RenameColumn,
+)
+
+_COLUMN_CASES = [
+    ("ALTER TABLE t ADD COLUMN c int;", AddColumn(table="t", column="c", nullable=True, has_default=False)),
+    (
+        "ALTER TABLE t ADD COLUMN c int NOT NULL DEFAULT 0;",
+        AddColumn(table="t", column="c", nullable=False, has_default=True),
+    ),
+    ("ALTER TABLE t DROP COLUMN c;", DropColumn(table="t", column="c")),
+    ("ALTER TABLE t RENAME COLUMN a TO b;", RenameColumn(table="t", old="a", new="b")),
+    ("ALTER TABLE t ALTER COLUMN c TYPE bigint;", ChangeColumnType(table="t", column="c")),
+]
+
+_OTHER_CASES = [
+    ("CREATE INDEX idx ON t (c);", CreateIndex(table="t", concurrently=False)),
+    ("CREATE INDEX CONCURRENTLY idx ON t (c);", CreateIndex(table="t", concurrently=True)),
+    (
+        "ALTER TABLE t ADD CONSTRAINT ck CHECK (c > 0);",
+        AddConstraint(table="t", kind="check", not_valid=False),
+    ),
+    (
+        "ALTER TABLE t ADD CONSTRAINT ck CHECK (c > 0) NOT VALID;",
+        AddConstraint(table="t", kind="check", not_valid=True),
+    ),
+    ("CREATE TABLE t (id int);", CreateTable(table="t")),
+]
+
+
+@pytest.mark.parametrize(("sql", "expected"), _COLUMN_CASES + _OTHER_CASES)
+def test_classify(sql: str, expected) -> None:
+    assert OperationClassifier().classify(sql) == [expected]
+
+
+@pytest.mark.parametrize("sql", [c[0] for c in _COLUMN_CASES + _OTHER_CASES])
+def test_pglast_and_regex_agree(sql: str, monkeypatch) -> None:
+    via_ast = OperationClassifier().classify(sql)
+    monkeypatch.setattr("confiture.core.replica.classifier._HAS_PGLAST", False)
+    via_regex = OperationClassifier().classify(sql)
+    assert via_ast == via_regex, sql
+
+
+def test_multi_statement_preserves_order() -> None:
+    sql = "ALTER TABLE t ADD COLUMN c int; ALTER TABLE t DROP COLUMN d;"
+    ops = OperationClassifier().classify(sql)
+    assert [type(o).__name__ for o in ops] == ["AddColumn", "DropColumn"]
+
+
+def test_add_column_nullable_with_default_is_nullable() -> None:
+    [op] = OperationClassifier().classify("ALTER TABLE t ADD COLUMN c int DEFAULT 5;")
+    assert isinstance(op, AddColumn)
+    assert op.nullable is True and op.has_default is True
+
+
+def test_schema_qualified_table() -> None:
+    [op] = OperationClassifier().classify("ALTER TABLE public.t DROP COLUMN c;")
+    assert op.table == "public.t"

--- a/tests/unit/test_operation_classifier.py
+++ b/tests/unit/test_operation_classifier.py
@@ -16,7 +16,10 @@ from confiture.core.replica.classifier import (
 )
 
 _COLUMN_CASES = [
-    ("ALTER TABLE t ADD COLUMN c int;", AddColumn(table="t", column="c", nullable=True, has_default=False)),
+    (
+        "ALTER TABLE t ADD COLUMN c int;",
+        AddColumn(table="t", column="c", nullable=True, has_default=False),
+    ),
     (
         "ALTER TABLE t ADD COLUMN c int NOT NULL DEFAULT 0;",
         AddColumn(table="t", column="c", nullable=False, has_default=True),

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -599,7 +599,7 @@ class TestMigratePreflightCLI:
         runner = CliRunner()
         result = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(mdir)])
         assert result.exit_code == 0
-        assert "Safe to deploy" in result.output
+        assert "No issues" in result.output  # #148: structured report, clean run
 
     def test_table_output_unsafe(self, tmp_path: Path):
         from typer.testing import CliRunner
@@ -613,8 +613,8 @@ class TestMigratePreflightCLI:
 
         runner = CliRunner()
         result = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(mdir)])
-        assert result.exit_code == 1
-        assert "irreversible" in result.output
+        assert result.exit_code == 7  # #148: error → exit 7
+        assert "PFLIGHT_MISSING_DOWN" in result.output
 
     def test_json_output(self, tmp_path: Path):
         from typer.testing import CliRunner
@@ -632,9 +632,9 @@ class TestMigratePreflightCLI:
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["safe_to_deploy"] is True
-        assert "migrations" in data
-        assert "checksum_verified" in data
+        assert data["ok"] is True  # #148: structured report shape
+        assert "summary" in data
+        assert "issues" in data
 
     def test_json_output_unsafe(self, tmp_path: Path):
         from typer.testing import CliRunner
@@ -650,9 +650,9 @@ class TestMigratePreflightCLI:
         result = runner.invoke(
             app, ["migrate", "preflight", "--migrations-dir", str(mdir), "--format", "json"]
         )
-        assert result.exit_code == 1
+        assert result.exit_code == 7  # #148: error → exit 7
         data = json.loads(result.output)
-        assert data["safe_to_deploy"] is False
+        assert data["ok"] is False
 
     def test_duplicates_in_output(self, tmp_path: Path):
         from typer.testing import CliRunner
@@ -668,8 +668,8 @@ class TestMigratePreflightCLI:
 
         runner = CliRunner()
         result = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(mdir)])
-        assert result.exit_code == 1
-        assert "duplicate" in result.output
+        assert result.exit_code == 7  # #148: duplicate version is an error → exit 7
+        assert "PFLIGHT_DUPLICATE_VERSION" in result.output
 
     def test_non_transactional_in_output(self, tmp_path: Path):
         from typer.testing import CliRunner
@@ -683,8 +683,9 @@ class TestMigratePreflightCLI:
 
         runner = CliRunner()
         result = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(mdir)])
-        assert result.exit_code == 1
-        assert "non-transactional" in result.output
+        # #148: non-transactional is now a WARNING — exit 0 by default (use --strict to fail).
+        assert result.exit_code == 0
+        assert "PFLIGHT_NON_TRANSACTIONAL" in result.output
 
 
 # ── Phase 3: Lazy exports ────────────────────────────────────────────────

--- a/tests/unit/test_preflight_issues.py
+++ b/tests/unit/test_preflight_issues.py
@@ -1,0 +1,88 @@
+"""Unit tests for the structured preflight report model (issue #148, Phase 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from confiture.core.preflight import preflight_exit_code, run_preflight
+from confiture.models.results import PFLIGHT_CODES, PreflightIssue
+
+
+def _mig(d: Path, version: str, name: str, *, down: bool = True, body: str = "SELECT 1;") -> None:
+    (d / f"{version}_{name}.up.sql").write_text(body)
+    if down:
+        (d / f"{version}_{name}.down.sql").write_text("SELECT 1;")
+
+
+def test_missing_down_becomes_error_issue(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000001", "add_user_bio", down=False)
+    issues = run_preflight(tmp_path).issues
+    miss = [i for i in issues if i.code == "PFLIGHT_MISSING_DOWN"]
+    assert len(miss) == 1
+    assert miss[0].severity == "error"
+    assert miss[0].migration == "20260531000001"
+    assert miss[0].file.endswith("add_user_bio.up.sql")
+    assert miss[0].actionable  # populated
+
+
+def test_non_transactional_is_warning(tmp_path: Path) -> None:
+    _mig(
+        tmp_path,
+        "20260531000002",
+        "add_idx",
+        body="CREATE INDEX CONCURRENTLY idx ON t (col);",
+    )
+    nt = [i for i in run_preflight(tmp_path).issues if i.code == "PFLIGHT_NON_TRANSACTIONAL"]
+    assert nt and nt[0].severity == "warning"
+    assert nt[0].migration == "20260531000002"
+    assert nt[0].details["statements"]
+
+
+def test_summary_counts(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000001", "a", down=False)  # 1 error
+    _mig(tmp_path, "20260531000002", "b", body="CREATE INDEX CONCURRENTLY i ON t (c);")  # warn
+    _mig(tmp_path, "20260531000003", "c", body="CREATE INDEX CONCURRENTLY j ON t (c);")  # warn
+    summary = run_preflight(tmp_path).summary
+    assert summary["errors"] == 1
+    assert summary["warnings"] == 2
+    assert summary["migrations_checked"] == 3
+
+
+def test_report_dict_shape(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000001", "a", down=False)
+    report = run_preflight(tmp_path).to_report_dict()
+    assert report["ok"] is False
+    assert set(report.keys()) == {"ok", "summary", "issues"}
+    for i in report["issues"]:
+        assert {"severity", "code", "message", "migration", "file", "line", "actionable", "details"} == set(i)
+
+
+def test_report_ok_when_clean(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000001", "a")
+    assert run_preflight(tmp_path).to_report_dict()["ok"] is True
+
+
+def test_strict_marks_warnings_not_ok(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000002", "b", body="CREATE INDEX CONCURRENTLY i ON t (c);")
+    assert run_preflight(tmp_path).to_report_dict(strict=False)["ok"] is True
+    assert run_preflight(tmp_path).to_report_dict(strict=True)["ok"] is False
+
+
+def test_preflight_exit_code_policy() -> None:
+    assert preflight_exit_code({"errors": 0, "warnings": 0}, strict=False) == 0
+    assert preflight_exit_code({"errors": 1, "warnings": 0}, strict=False) == 7
+    assert preflight_exit_code({"errors": 0, "warnings": 2}, strict=False) == 0
+    assert preflight_exit_code({"errors": 0, "warnings": 2}, strict=True) == 7
+    assert preflight_exit_code({"errors": 1, "warnings": 2}, strict=True) == 7
+
+
+def test_every_pflight_code_has_severity_and_actionable() -> None:
+    for code, (severity, actionable) in PFLIGHT_CODES.items():
+        assert severity in {"error", "warning", "info"}, code
+        assert actionable, code
+
+
+def test_issue_of_pulls_defaults() -> None:
+    issue = PreflightIssue.of("PFLIGHT_MISSING_DOWN", "msg", migration="v1")
+    assert issue.severity == "error"
+    assert issue.actionable == PFLIGHT_CODES["PFLIGHT_MISSING_DOWN"][1]

--- a/tests/unit/test_preflight_issues.py
+++ b/tests/unit/test_preflight_issues.py
@@ -54,7 +54,16 @@ def test_report_dict_shape(tmp_path: Path) -> None:
     assert report["ok"] is False
     assert set(report.keys()) == {"ok", "summary", "issues"}
     for i in report["issues"]:
-        assert {"severity", "code", "message", "migration", "file", "line", "actionable", "details"} == set(i)
+        assert {
+            "severity",
+            "code",
+            "message",
+            "migration",
+            "file",
+            "line",
+            "actionable",
+            "details",
+        } == set(i)
 
 
 def test_report_ok_when_clean(tmp_path: Path) -> None:

--- a/tests/unit/test_preflight_structured.py
+++ b/tests/unit/test_preflight_structured.py
@@ -1,0 +1,76 @@
+"""CLI tests for the structured preflight report (issue #148, Phase 2).
+
+The no-``--against`` static path needs no database; these run as unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+def _mig(d: Path, version: str, name: str, *, down: bool = True, body: str = "SELECT 1;") -> None:
+    (d / f"{version}_{name}.up.sql").write_text(body)
+    if down:
+        (d / f"{version}_{name}.down.sql").write_text("SELECT 1;")
+
+
+def test_preflight_json_shape(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000001", "add_user_bio", down=False)
+    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"])
+    assert r.exit_code == 7, r.output
+    p = json.loads(r.stdout)
+    assert p["ok"] is False
+    assert p["summary"]["errors"] == 1
+    assert any(
+        i["code"] == "PFLIGHT_MISSING_DOWN" and i["severity"] == "error" for i in p["issues"]
+    )
+    assert all({"severity", "code", "message"} <= set(i) for i in p["issues"])
+
+
+def test_preflight_clean_exit_0(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000001", "a")
+    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"])
+    assert r.exit_code == 0, r.output
+    assert json.loads(r.stdout)["ok"] is True
+
+
+def test_warnings_only_exit_0_by_default(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000002", "idx", body="CREATE INDEX CONCURRENTLY i ON t (c);")
+    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"])
+    assert r.exit_code == 0, r.output
+    assert json.loads(r.stdout)["summary"]["warnings"] >= 1
+
+
+def test_strict_promotes_warnings(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000002", "idx", body="CREATE INDEX CONCURRENTLY i ON t (c);")
+    r = runner.invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--strict", "--format", "json"],
+    )
+    assert r.exit_code == 7, r.output
+
+
+def test_table_mode_renders_codes(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531000001", "add_user_bio", down=False)
+    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path)])
+    assert r.exit_code == 7, r.output
+    assert "PFLIGHT_MISSING_DOWN" in r.output
+
+
+def test_duplicate_version_is_error(tmp_path: Path) -> None:
+    # Two files share version 20260531000001.
+    (tmp_path / "20260531000001_a.up.sql").write_text("SELECT 1;")
+    (tmp_path / "20260531000001_a.down.sql").write_text("SELECT 1;")
+    (tmp_path / "20260531000001_b.up.sql").write_text("SELECT 1;")
+    (tmp_path / "20260531000001_b.down.sql").write_text("SELECT 1;")
+    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"])
+    assert r.exit_code == 7, r.output
+    p = json.loads(r.stdout)
+    assert any(i["code"] == "PFLIGHT_DUPLICATE_VERSION" for i in p["issues"])

--- a/tests/unit/test_preflight_structured.py
+++ b/tests/unit/test_preflight_structured.py
@@ -23,7 +23,9 @@ def _mig(d: Path, version: str, name: str, *, down: bool = True, body: str = "SE
 
 def test_preflight_json_shape(tmp_path: Path) -> None:
     _mig(tmp_path, "20260531000001", "add_user_bio", down=False)
-    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"])
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"]
+    )
     assert r.exit_code == 7, r.output
     p = json.loads(r.stdout)
     assert p["ok"] is False
@@ -36,14 +38,18 @@ def test_preflight_json_shape(tmp_path: Path) -> None:
 
 def test_preflight_clean_exit_0(tmp_path: Path) -> None:
     _mig(tmp_path, "20260531000001", "a")
-    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"])
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"]
+    )
     assert r.exit_code == 0, r.output
     assert json.loads(r.stdout)["ok"] is True
 
 
 def test_warnings_only_exit_0_by_default(tmp_path: Path) -> None:
     _mig(tmp_path, "20260531000002", "idx", body="CREATE INDEX CONCURRENTLY i ON t (c);")
-    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"])
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"]
+    )
     assert r.exit_code == 0, r.output
     assert json.loads(r.stdout)["summary"]["warnings"] >= 1
 
@@ -70,7 +76,9 @@ def test_duplicate_version_is_error(tmp_path: Path) -> None:
     (tmp_path / "20260531000001_a.down.sql").write_text("SELECT 1;")
     (tmp_path / "20260531000001_b.up.sql").write_text("SELECT 1;")
     (tmp_path / "20260531000001_b.down.sql").write_text("SELECT 1;")
-    r = runner.invoke(app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"])
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(tmp_path), "--format", "json"]
+    )
     assert r.exit_code == 7, r.output
     p = json.loads(r.stdout)
     assert any(i["code"] == "PFLIGHT_DUPLICATE_VERSION" for i in p["issues"])

--- a/tests/unit/test_replica_config.py
+++ b/tests/unit/test_replica_config.py
@@ -1,0 +1,39 @@
+"""Tests for replica-safety config (issue #139, Phase 3)."""
+
+from __future__ import annotations
+
+from confiture.config.environment import Environment, InfrastructureConfig, MigrationConfig
+
+
+def test_allow_unsafe_default_false() -> None:
+    assert MigrationConfig().allow_unsafe_under_replication is False
+
+
+def test_infrastructure_replicas_default_empty() -> None:
+    assert InfrastructureConfig().replicas == []
+
+
+def test_environment_has_infrastructure_default() -> None:
+    env = Environment.model_validate(
+        {
+            "name": "test",
+            "database_url": "postgresql://localhost/app",
+            "include_dirs": ["db/schema"],
+        }
+    )
+    assert env.infrastructure.replicas == []
+    assert env.migration.allow_unsafe_under_replication is False
+
+
+def test_environment_reads_replicas_and_bypass() -> None:
+    env = Environment.model_validate(
+        {
+            "name": "test",
+            "database_url": "postgresql://localhost/app",
+            "include_dirs": ["db/schema"],
+            "infrastructure": {"replicas": ["read-1", "read-2"]},
+            "migration": {"allow_unsafe_under_replication": True},
+        }
+    )
+    assert env.infrastructure.replicas == ["read-1", "read-2"]
+    assert env.migration.allow_unsafe_under_replication is True

--- a/tests/unit/test_replica_corpus.py
+++ b/tests/unit/test_replica_corpus.py
@@ -1,0 +1,53 @@
+"""Acceptance corpus: one case per replica-safety matrix row (issue #139, Phase 4).
+
+End-to-end through the classifier + verdict, asserting safety, severity (under
+replicas-declared), and multi-step remediation — the regression guard against
+classifier/verdict drift the issue requires.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.replica.classifier import OperationClassifier
+from confiture.core.replica.safety import classify_replica_safety, replica_severity
+
+# (sql, expected_safety, expected_severity_with_replicas)
+CORPUS = {
+    "add_column_nullable": ("ALTER TABLE t ADD COLUMN c int;", "safe", None),
+    "add_column_not_null_default": (
+        "ALTER TABLE t ADD COLUMN c int NOT NULL DEFAULT 0;",
+        "unsafe",
+        "error",
+    ),
+    "drop_column": ("ALTER TABLE t DROP COLUMN c;", "unsafe", "error"),
+    "rename_column": ("ALTER TABLE t RENAME COLUMN a TO b;", "unsafe", "error"),
+    "change_type": ("ALTER TABLE t ALTER COLUMN c TYPE bigint;", "unsafe", "error"),
+    "add_constraint_immediate": (
+        "ALTER TABLE t ADD CONSTRAINT ck CHECK (c > 0);",
+        "unsafe",
+        "error",
+    ),
+    "add_constraint_not_valid": (
+        "ALTER TABLE t ADD CONSTRAINT ck CHECK (c > 0) NOT VALID;",
+        "safe",
+        None,
+    ),
+    "create_index": ("CREATE INDEX idx ON t (c);", "unsafe", "error"),
+    "create_index_concurrently": ("CREATE INDEX CONCURRENTLY idx ON t (c);", "safe", None),
+    "create_table": ("CREATE TABLE t (id int);", "safe", None),
+}
+
+
+@pytest.mark.parametrize("name", list(CORPUS))
+def test_corpus_row(name: str) -> None:
+    sql, safety, sev = CORPUS[name]
+    [op] = OperationClassifier().classify(sql)
+    verdict = classify_replica_safety(op)
+    assert verdict.safety == safety, name
+    if safety == "safe":
+        return
+    assert verdict.multi_step, name  # remediation present for unsafe
+    assert replica_severity(verdict, has_replicas=True, bypass=False) == sev, name
+    # Warn (not error) when no replicas are declared (soft default).
+    assert replica_severity(verdict, has_replicas=False, bypass=False) == "warning", name

--- a/tests/unit/test_replica_rule.py
+++ b/tests/unit/test_replica_rule.py
@@ -1,0 +1,57 @@
+"""Tests for the Replica001ForwardCompat lint rule (issue #139, Phase 2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from confiture.core.linting.libraries.replica import Replica001ForwardCompat
+from confiture.core.linting.schema_linter import RuleSeverity
+
+
+def _mig(tmp_path: Path, name: str, body: str) -> None:
+    (tmp_path / f"{name}.up.sql").write_text(body)
+
+
+def test_unsafe_drop_column_flagged(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531_1200_drop", "ALTER TABLE t DROP COLUMN c;")
+    violations = Replica001ForwardCompat(has_replicas=True).check(tmp_path)
+    assert len(violations) == 1
+    assert violations[0].rule_id == "replica_001"
+    assert violations[0].severity == RuleSeverity.ERROR
+    assert "deprecate" in violations[0].message
+
+
+def test_safe_add_nullable_no_violation(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531_1200_add", "ALTER TABLE t ADD COLUMN c int;")
+    assert Replica001ForwardCompat(has_replicas=True).check(tmp_path) == []
+
+
+def test_concurrently_index_is_safe(tmp_path: Path) -> None:
+    _mig(tmp_path, "m", "CREATE INDEX CONCURRENTLY idx ON t (c);")
+    assert Replica001ForwardCompat(has_replicas=True).check(tmp_path) == []
+
+
+def test_warns_by_default_without_replicas(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531_1200_drop", "ALTER TABLE t DROP COLUMN c;")
+    violations = Replica001ForwardCompat(has_replicas=False).check(tmp_path)
+    assert len(violations) == 1
+    assert violations[0].severity == RuleSeverity.WARNING
+
+
+def test_bypass_downgrades(tmp_path: Path) -> None:
+    _mig(tmp_path, "20260531_1200_drop", "ALTER TABLE t DROP COLUMN c;")
+    violations = Replica001ForwardCompat(has_replicas=True, bypass=True).check(tmp_path)
+    assert violations[0].severity == RuleSeverity.WARNING
+
+
+def test_create_table_no_violation(tmp_path: Path) -> None:
+    _mig(tmp_path, "m", "CREATE TABLE t (id int);")
+    assert Replica001ForwardCompat(has_replicas=True).check(tmp_path) == []
+
+
+def test_rule_has_category_tag() -> None:
+    assert Replica001ForwardCompat.category == "replica"
+
+
+def test_empty_dir_no_violations(tmp_path: Path) -> None:
+    assert Replica001ForwardCompat().check(tmp_path / "nope") == []

--- a/tests/unit/test_replica_safety.py
+++ b/tests/unit/test_replica_safety.py
@@ -1,0 +1,74 @@
+"""Tests for the replica-safety verdict matrix + policy (issue #139, Phase 2/3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.replica.classifier import (
+    AddColumn,
+    AddConstraint,
+    ChangeColumnType,
+    CreateIndex,
+    CreateTable,
+    DropColumn,
+    Other,
+    RenameColumn,
+)
+from confiture.core.replica.safety import (
+    ReplicaVerdict,
+    classify_replica_safety,
+    replica_severity,
+)
+
+_MATRIX = [
+    (AddColumn(nullable=True, has_default=False), "safe"),
+    (AddColumn(nullable=False, has_default=True), "unsafe"),
+    (AddColumn(nullable=True, has_default=True), "unsafe"),
+    (DropColumn(), "unsafe"),
+    (RenameColumn(), "unsafe"),
+    (ChangeColumnType(), "unsafe"),
+    (AddConstraint(kind="check", not_valid=False), "unsafe"),
+    (AddConstraint(kind="check", not_valid=True), "safe"),
+    (CreateIndex(concurrently=False), "unsafe"),
+    (CreateIndex(concurrently=True), "safe"),
+    (CreateTable(), "safe"),
+    (Other(reason="dynamic"), "depends"),
+]
+
+
+@pytest.mark.parametrize(("op", "safety"), _MATRIX)
+def test_matrix(op, safety: str) -> None:
+    assert classify_replica_safety(op).safety == safety
+
+
+@pytest.mark.parametrize(("op", "safety"), [(o, s) for o, s in _MATRIX if s == "unsafe"])
+def test_unsafe_ops_carry_multi_step(op, safety: str) -> None:
+    assert classify_replica_safety(op).multi_step  # remediation text present
+
+
+def test_verdict_is_dataclass() -> None:
+    v = ReplicaVerdict("safe")
+    assert v.reason is None and v.multi_step is None
+
+
+# ── severity policy (OD-12) ───────────────────────────────────────────────────
+
+
+def test_severity_warns_by_default_no_replicas() -> None:
+    v = classify_replica_safety(DropColumn())
+    assert replica_severity(v, has_replicas=False, bypass=False) == "warning"
+
+
+def test_severity_errors_when_replicas_declared() -> None:
+    v = classify_replica_safety(DropColumn())
+    assert replica_severity(v, has_replicas=True, bypass=False) == "error"
+
+
+def test_bypass_downgrades_even_with_replicas() -> None:
+    v = classify_replica_safety(DropColumn())
+    assert replica_severity(v, has_replicas=True, bypass=True) == "warning"
+
+
+def test_depends_is_always_warning() -> None:
+    v = classify_replica_safety(Other(reason="dynamic"))
+    assert replica_severity(v, has_replicas=True, bypass=False) == "warning"

--- a/tests/unit/test_resolve_database_url.py
+++ b/tests/unit/test_resolve_database_url.py
@@ -1,0 +1,56 @@
+"""Tests for --database-url resolution precedence (issue #140).
+
+Precedence: --database-url flag > CONFITURE_DATABASE_URL > DATABASE_URL > None
+(None means: let MigratorSession/load_config resolve from --config).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from confiture.cli.helpers import resolve_database_url
+from confiture.exceptions import ConfigurationError
+
+
+def test_flag_wins_over_env_and_config(monkeypatch) -> None:
+    monkeypatch.setenv("CONFITURE_DATABASE_URL", "postgresql://env/db")
+    assert (
+        resolve_database_url("postgresql://flag/db", Path("env.yaml"))
+        == "postgresql://flag/db"
+    )
+
+
+def test_env_used_when_no_flag(monkeypatch) -> None:
+    monkeypatch.setenv("CONFITURE_DATABASE_URL", "postgresql://env/db")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    assert resolve_database_url(None, None) == "postgresql://env/db"
+
+
+def test_canonical_env_wins_over_bare(monkeypatch) -> None:
+    monkeypatch.setenv("CONFITURE_DATABASE_URL", "postgresql://canonical/db")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://bare/db")
+    assert resolve_database_url(None, None) == "postgresql://canonical/db"
+
+
+def test_bare_database_url_fallback(monkeypatch) -> None:
+    monkeypatch.delenv("CONFITURE_DATABASE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://bare/db")
+    assert resolve_database_url(None, None) == "postgresql://bare/db"
+
+
+def test_returns_none_when_only_config(monkeypatch) -> None:
+    monkeypatch.delenv("CONFITURE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    # No flag, no env → caller falls back to config_path.
+    assert resolve_database_url(None, Path("env.yaml")) is None
+
+
+def test_malformed_flag_dsn_raises_config_003(monkeypatch) -> None:
+    monkeypatch.delenv("CONFITURE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(ConfigurationError) as exc_info:
+        resolve_database_url("mysql://nope/db", None)
+    assert exc_info.value.error_code == "CONFIG_003"
+    assert exc_info.value.exit_code == 5  # #146: CONFIG family → config invalid

--- a/tests/unit/test_resolve_database_url.py
+++ b/tests/unit/test_resolve_database_url.py
@@ -16,10 +16,7 @@ from confiture.exceptions import ConfigurationError
 
 def test_flag_wins_over_env_and_config(monkeypatch) -> None:
     monkeypatch.setenv("CONFITURE_DATABASE_URL", "postgresql://env/db")
-    assert (
-        resolve_database_url("postgresql://flag/db", Path("env.yaml"))
-        == "postgresql://flag/db"
-    )
+    assert resolve_database_url("postgresql://flag/db", Path("env.yaml")) == "postgresql://flag/db"
 
 
 def test_env_used_when_no_flag(monkeypatch) -> None:

--- a/tests/unit/test_rollback_planner.py
+++ b/tests/unit/test_rollback_planner.py
@@ -1,0 +1,84 @@
+"""Unit tests for the pure rollback planner (issue #142, Phase 1).
+
+The planner computes the rollback set and validates reversibility up front,
+without touching the database. The four edge cases are typed outcomes.
+"""
+
+from __future__ import annotations
+
+from confiture.core._migrator.rollback_planner import RollbackPlan, plan_down_to
+
+APPLIED = ["20260101_a", "20260102_b", "20260103_c", "20260104_d"]  # ASC
+KNOWN = set(APPLIED)
+ALL_DOWN = set(APPLIED)
+
+
+def test_rolls_back_newer_than_target() -> None:
+    plan = plan_down_to(APPLIED, KNOWN, target="20260102_b", down_available=ALL_DOWN)
+    assert plan.valid
+    assert plan.to_rollback == ["20260104_d", "20260103_c"]  # newest → oldest
+    assert plan.target == "20260102_b"
+    assert not plan.noop
+
+
+def test_target_is_current_is_noop() -> None:
+    plan = plan_down_to(APPLIED, KNOWN, target="20260104_d", down_available=ALL_DOWN)
+    assert plan.valid
+    assert plan.to_rollback == []
+    assert plan.noop
+
+
+def test_target_newer_than_current_rejected() -> None:
+    # Known migration file that is not yet applied → forward move.
+    plan = plan_down_to(
+        APPLIED, KNOWN | {"20260105_e"}, target="20260105_e", down_available=ALL_DOWN
+    )
+    assert not plan.valid
+    assert plan.reason == "target_newer_than_current"
+
+
+def test_unknown_target_rejected() -> None:
+    plan = plan_down_to(APPLIED, KNOWN, target="nope", down_available=ALL_DOWN)
+    assert not plan.valid
+    assert plan.reason == "unknown_revision"
+
+
+def test_missing_down_aborts_whole_plan() -> None:
+    plan = plan_down_to(
+        APPLIED, KNOWN, target="20260101_a", down_available=ALL_DOWN - {"20260103_c"}
+    )
+    assert not plan.valid
+    assert plan.reason == "irreversible"
+    assert plan.missing_down == ["20260103_c"]
+    # to_rollback still computed (newest→oldest) so the error can name the set.
+    assert plan.to_rollback == ["20260104_d", "20260103_c", "20260102_b"]
+
+
+def test_rollback_to_oldest_keeps_first() -> None:
+    plan = plan_down_to(APPLIED, KNOWN, target="20260101_a", down_available=ALL_DOWN)
+    assert plan.valid
+    assert plan.to_rollback == ["20260104_d", "20260103_c", "20260102_b"]
+
+
+def test_empty_applied_unknown_target() -> None:
+    plan = plan_down_to([], set(), target="anything", down_available=set())
+    assert not plan.valid
+    assert plan.reason == "unknown_revision"
+
+
+def test_plan_is_a_dataclass_with_defaults() -> None:
+    plan = RollbackPlan(target="x", to_rollback=[], valid=True)
+    assert plan.noop is False
+    assert plan.reason is None
+    assert plan.missing_down == []
+
+
+def test_planner_imports_nothing_db_related() -> None:
+    """Purity guard: the planner module must not import psycopg / DB machinery."""
+    from pathlib import Path
+
+    import confiture.core._migrator.rollback_planner as mod
+
+    text = Path(mod.__file__).read_text()
+    assert "psycopg" not in text
+    assert "import" in text  # sanity: the file does have imports (dataclasses)


### PR DESCRIPTION
Implements the **#139–#148 batch** — stabilizing Confiture's machine-readable contracts (exit codes, structured error/issue JSON, new `migrate` subcommands, replica-safety lint) for the fraisier-core `ConfitureMigration` adapter. Ten issues, one clean commit each, full TDD per the phased plans. Target release: **0.19.0**.

| # | Title |
|---|-------|
| 146 | Stabilize + renumber the exit-code convention |
| 140 | `--database-url` flag on the migrate family |
| 145 | Structured error envelope in `--format json` |
| 141 | `migrate current` |
| 142 | `migrate down-to <revision>` (+ lock `down()`) |
| 147 | Lock-holder identity in lock-contention errors |
| 148 | Structured preflight report |
| 143 | `verify` → `verify-checksums` (deprecation alias) |
| 144 | offline `validate-config` |
| 139 | Replica-aware forward-compatibility lint |

---

## ⚠️ BREAKING — exit codes renumbered (#146)

The process exit codes for three error families changed so the structured exception registry now emits a wrapper-facing convention (no-table = 2, connection failed = 3, config invalid = 5). **Wrappers that branch on these exit codes must update.** Exit codes are now a documented stability contract — see `docs/reference/exit-codes.md`.

| Symbolic code | Meaning | Old exit (≤0.18.0) | New exit |
|---------------|---------|:------------------:|:--------:|
| `PRECON_1001` | Database not initialized (tracking table absent) | 5 | **2** |
| `CONFIG_001` | Missing required config field | 2 | **5** |
| `CONFIG_002` | Invalid YAML syntax | 2 | **5** |
| `CONFIG_003` | Invalid database URL format | 2 | **5** |
| `CONFIG_004` | Environment config not found | 2 | **5** |
| `CONFIG_005` | Invalid include/exclude pattern | 2 | **5** |
| `CONFIG_006` | Database connection failed | 2 | **3** |
| `CONFIG_010` | Database URL not set in environment | 2 | **5** |

Migration guidance for wrapper authors:
- If you branched on **exit 2 = config error**, it is now **5**.
- **Exit 2** now means **tracking table absent** (fresh DB, no current revision).
- **Exit 3** now distinguishes a **connection failure** from a config error.

Internally, `load_config()` / `create_connection()` now raise `ConfigurationError` (`CONFIG_002`/`CONFIG_004`/`CONFIG_006`) instead of `MigrationError`, so the correct exit code flows from the registry through `ConfiturError.exit_code`.

## ⚠️ BREAKING — `migrate preflight` JSON reshaped (#148)

`migrate preflight --format json` (no `--against`) now returns the structured report `{ok, summary, issues[]}` instead of the flat `PreflightResult` JSON. Each `issues[]` element is the unified issue object with a `PFLIGHT_*` code. Error-severity issues exit **7** (was 1); **non-transactional statements are now warnings** (exit 0 by default) unless `--strict`. The `--against` execution path is unchanged.

---

## Verification

- **7222 unit tests pass**; `ruff` + `ty` clean.
- **Zero new integration failures** introduced by this branch (verified via git-stash baseline diff). The repo carries 61 pre-existing integration failures from test-infrastructure issues unrelated to this work: leftover-table pollution that a fresh DB clears (migrator/schema-sync family), plus a `clean_test_db` abort-cascade (no `rollback()` between tests) that `view_manager`/`introspect` trigger. Neither touches code this PR changes.
- The exit-code renumbering is enforced by a parametric convention test asserting the live registry against a hand-authored `CANONICAL_EXIT_CODES` contract (never derived from the registry).

## Owner decisions confirmed during implementation

0.19.0 minor-flagged-breaking · fix `down()`'s lock within #142 · `migrate status` no-table keeps its informative payload · #139 replica-lint warns by default, errors when `infrastructure.replicas` is declared (bypass downgrades).

## Scope notes / follow-ups (filed separately)

1. General `--rule`/`--select` mechanism for `confiture lint` (when a second opt-in rule earns it; #139 ships the `--replica-safe` consumer + a `category` tag).
2. `--against` execution-replay structured envelope (`PFLIGHT_REPLAY_FAILED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
