### PR TITLE
feat(preflight): pin replica namespace + window_safe verdict (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,18 @@ code, existing field, or existing code value changed.
 ### Added
 
 - **`migrate preflight` now carries a typed blue-green window-safety verdict**
-  (issue #154). The structured report's `summary` gains a `window_safe` boolean —
-  `false` exactly when any `PFLIGHT_REPLICA_*` finding is present — so a consumer
-  (e.g. the fraisier blue-green window-safety gate) can read one typed field
-  instead of prefix-matching codes. Present in both the default and `--against`
-  payloads and pinned in the published JSON schemas. (`ok` still cannot certify
-  window safety: the replica lint is warn-by-default.)
+  (issue #154). The structured report gains a **top-level** `window_safe` boolean
+  so a consumer (e.g. the fraisier blue-green window-safety gate) reads one typed
+  field instead of prefix-matching codes. `window_safe == true` iff confiture
+  certifies every checked migration is forward-compatible for a two-version
+  shared-DB window **and** has a safe down path — it folds in any
+  `PFLIGHT_REPLICA_*` finding (a replica-unsafe op **or** an unreadable `.py`
+  migration), `PFLIGHT_MISSING_DOWN` (reversibility), and
+  `PFLIGHT_NON_TRANSACTIONAL` (transactionality). Present in both the default and
+  `--against` payloads and pinned in the published JSON schemas. (`ok` cannot
+  substitute: the replica/transactional cases are warn-by-default, so `ok` can be
+  true while `window_safe` is false. Note: `CREATE INDEX CONCURRENTLY` is
+  replica-safe but non-transactional, so it reads `window_safe == false`.)
 - **The `PFLIGHT_REPLICA_*` code namespace is now a pinned cross-repo contract**
   (issue #154). `replica_lint_codes()` is the single source for the set, and
   `tests/contract/test_fraisier_adapter_surface.py` pins it against a literal so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,14 @@ code, existing field, or existing code value changed.
   so a consumer (e.g. the fraisier blue-green window-safety gate) reads one typed
   field instead of prefix-matching codes. `window_safe == true` iff confiture
   certifies every checked migration is forward-compatible for a two-version
-  shared-DB window **and** has a safe down path — it folds in any
-  `PFLIGHT_REPLICA_*` finding (a replica-unsafe op **or** an unreadable `.py`
-  migration), `PFLIGHT_MISSING_DOWN` (reversibility), and
-  `PFLIGHT_NON_TRANSACTIONAL` (transactionality). Present in both the default and
-  `--against` payloads and pinned in the published JSON schemas. (`ok` cannot
-  substitute: the replica/transactional cases are warn-by-default, so `ok` can be
-  true while `window_safe` is false. Note: `CREATE INDEX CONCURRENTLY` is
-  replica-safe but non-transactional, so it reads `window_safe == false`.)
+  shared-DB window — it is `false` when any `PFLIGHT_REPLICA_*` finding is present
+  (a replica-unsafe op **or** an unreadable `.py` migration). Window-safety is
+  forward-compatibility only, **not** atomicity: reversibility
+  (`PFLIGHT_MISSING_DOWN`) and transactionality (`PFLIGHT_NON_TRANSACTIONAL`) are
+  reported but do not gate it, so a non-transactional `CREATE INDEX CONCURRENTLY`
+  is window-safe. Present in both the default and `--against` payloads and pinned
+  in the published JSON schemas. (`ok` cannot substitute: replica findings are
+  warn-by-default, so `ok` can be true while `window_safe` is false.)
 - **The `PFLIGHT_REPLICA_*` code namespace is now a pinned cross-repo contract**
   (issue #154). `replica_lint_codes()` is the single source for the set, and
   `tests/contract/test_fraisier_adapter_surface.py` pins it against a literal so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-06-06
+
+Hardens the confiture↔fraisier blue-green seam (issue #154): the
+`PFLIGHT_REPLICA_*` code namespace is now a pinned cross-repo contract, non-SQL
+migrations are no longer a blind spot in the replica preflight, and the
+window-safety decision is available as one typed `summary.window_safe` field. All
+changes are additive (new schema field, new warning, a new accessor); no exit
+code, existing field, or existing code value changed.
+
+### Added
+
+- **`migrate preflight` now carries a typed blue-green window-safety verdict**
+  (issue #154). The structured report's `summary` gains a `window_safe` boolean —
+  `false` exactly when any `PFLIGHT_REPLICA_*` finding is present — so a consumer
+  (e.g. the fraisier blue-green window-safety gate) can read one typed field
+  instead of prefix-matching codes. Present in both the default and `--against`
+  payloads and pinned in the published JSON schemas. (`ok` still cannot certify
+  window safety: the replica lint is warn-by-default.)
+- **The `PFLIGHT_REPLICA_*` code namespace is now a pinned cross-repo contract**
+  (issue #154). `replica_lint_codes()` is the single source for the set, and
+  `tests/contract/test_fraisier_adapter_surface.py` pins it against a literal so a
+  rename fails CI instead of silently disarming a downstream window-safety gate.
+  Documented as a stability commitment in the
+  [fraisier-adapter contract](docs/reference/fraisier-adapter-contract.md)
+  (renames breaking, additions allowed).
+
+### Changed
+
+- **Non-SQL (`.py`) migrations now surface in the replica preflight** (issue
+  #154). The SQL classifier cannot read `.py` migrations, so `migrate preflight`
+  emits a `PFLIGHT_REPLICA_UNCLASSIFIED` **warning** for each one — "no replica
+  issue" can no longer ambiguously mean "never inspected". Non-fatal (warning,
+  `ok` unchanged); adds one warning line per `.py` migration to preflight output.
+
 ## [0.22.0] - 2026-06-04
 
 A quality-remediation bundle: the error/exit-code contract is now universal and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.22.0
-**Last Updated**: 2026-06-04
+**Version**: 0.23.0
+**Last Updated**: 2026-06-06
 **Current Status**: Production-Ready
 
 > **Status**: Production-ready. Actively used in production since March 2026.
@@ -925,8 +925,8 @@ When stuck, ask:
 
 ---
 
-**Last Updated**: 2026-06-04
-**Version**: 0.22.0
+**Last Updated**: 2026-06-06
+**Version**: 0.23.0
 
 ---
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -177,10 +177,14 @@ default, error when replicas are declared, downgraded by
 | `PFLIGHT_REPLICA_CHANGE_TYPE` | `ALTER COLUMN ... TYPE` | add new column → backfill → swap readers → drop old |
 | `PFLIGHT_REPLICA_ADD_CONSTRAINT` | `ADD CONSTRAINT` (immediate) | `NOT VALID` → backfill → `VALIDATE` |
 | `PFLIGHT_REPLICA_CREATE_INDEX` | non-concurrent `CREATE INDEX` | `CREATE INDEX CONCURRENTLY` |
-| `PFLIGHT_REPLICA_UNCLASSIFIED` | dynamic / unparseable DDL | review manually (always a warning) |
+| `PFLIGHT_REPLICA_UNCLASSIFIED` | dynamic / unparseable DDL, or a non-SQL `.py` migration the classifier cannot read | review manually (always a warning) |
 
 See the [replica-safe migrations guide](replica-safe-migrations.md) for the full
-rationale.
+rationale. This `PFLIGHT_REPLICA_*` set is also a **cross-repo wire contract**:
+fraisier's blue-green window-safety gate blocks on the presence of any of these
+codes in `migrate preflight`'s `issues[]`, so the set is pinned by the
+[fraisier-adapter contract](fraisier-adapter-contract.md#replica-forward-compatibility-namespace-window-safety-seam)
+(renames are breaking, additions are allowed).
 
 ## Stability contract
 

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -57,7 +57,66 @@ The adapter-consumed fields per command:
 - **up** — `applied[].version` (the new head).
 - **down-to** — `from`, `to`, `rolled_back[]`.
 - **verify** — `failed_count` (ok ⇔ `0`) and each `results[].{version, name, status, error}`.
-- **preflight** — `ok`, `summary`, each `issues[].{severity, code, message, migration}`.
+- **preflight** — `ok`, `summary` (incl. `summary.window_safe`, the typed
+  blue-green window-safety verdict — see [below](#replica-forward-compatibility-namespace-window-safety-seam)),
+  each `issues[].{severity, code, message, migration}`.
+
+## Replica forward-compatibility namespace (window-safety seam)
+
+fraisier's **blue-green window-safety gate** consumes `migrate preflight` to
+decide whether a pending migration is forward-compatible for a two-version
+shared-DB cutover window (both N-1 and N served against one Postgres during the
+swap). It **blocks the deploy on the presence of any `PFLIGHT_REPLICA_*` issue**
+(warning *or* error) in `preflight`'s `issues[]`.
+
+`preflight`'s `ok` flag alone **cannot** certify window safety: the replica lint
+is warn-by-default unless `infrastructure.replicas` is declared, so an unsafe
+`DROP COLUMN` produces `ok == true` with a `warning`-severity
+`PFLIGHT_REPLICA_DROP_COLUMN`. The gate therefore keys on the **code prefix**,
+which makes the namespace below a wire contract.
+
+The complete namespace the lint can emit:
+
+| Code | Operation |
+|------|-----------|
+| `PFLIGHT_REPLICA_ADD_COLUMN` | `ADD COLUMN` NOT NULL / DEFAULT |
+| `PFLIGHT_REPLICA_DROP_COLUMN` | `DROP COLUMN` |
+| `PFLIGHT_REPLICA_RENAME_COLUMN` | `RENAME COLUMN` |
+| `PFLIGHT_REPLICA_CHANGE_TYPE` | `ALTER COLUMN ... TYPE` |
+| `PFLIGHT_REPLICA_ADD_CONSTRAINT` | immediate `ADD CONSTRAINT` |
+| `PFLIGHT_REPLICA_CREATE_INDEX` | non-concurrent `CREATE INDEX` |
+| `PFLIGHT_REPLICA_UNCLASSIFIED` | dynamic / unparseable DDL (always a warning) |
+
+This set is a **stability commitment**: existing codes are **never renamed or
+removed** (that is a breaking change requiring a major version bump and a
+CHANGELOG note); **new codes may be added**. The set is the single value returned
+by `confiture.core.linting.libraries.replica.replica_lint_codes()`, and
+[`test_fraisier_adapter_surface.py`](../../tests/contract/test_fraisier_adapter_surface.py)
+pins it (`test_replica_code_namespace_is_a_stability_commitment`) against a
+hardcoded literal — so a rename fails Confiture's CI instead of silently
+disarming fraisier's gate. See the per-code remediation table in
+[error-codes.md](error-codes.md#replica-safety-codes-pflight_replica_-lint-replica_001-139).
+
+### Non-SQL (`.py`) migrations are covered
+
+The replica classifier reads SQL (`*.up.sql`). A schema change inside a `.py`
+migration is **opaque** to it, so Confiture emits a `PFLIGHT_REPLICA_UNCLASSIFIED`
+warning for every `.py` migration — "no replica issue" therefore always means
+*inspected-and-safe*, never *never-inspected*. The presence rule covers `.py`
+migrations automatically; a downstream gate does not need a separate "refuse any
+`.py` in the set" rule.
+
+### Typed verdict: `summary.window_safe`
+
+Rather than prefix-match the codes, a consumer may read the single boolean
+`summary.window_safe` (#154). It is `false` exactly when any `PFLIGHT_REPLICA_*`
+finding is present (an unsafe operation **or** an unreadable `.py` migration), so
+it is the typed form of the presence rule above and is total: `false` means
+"blocked or uninspected", `true` means "inspected and forward-compatible for the
+shared-DB window". It is present in both the default and `--against` payloads and
+pinned in the published schemas; its presence is the capability signal (additive
+field, gated by the ≥ 0.20.0 minimum version). The `ok` flag still **cannot**
+substitute for it (warn-by-default keeps `ok == true` on an unsafe migration).
 
 ## Exit codes
 

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -116,27 +116,30 @@ which a consumer reads instead of prefix-matching codes:
 ```
 
 `window_safe == true` iff confiture certifies **every checked migration** is
-forward-compatible for a two-version shared-DB window **and** has a safe down
-path. It is the *whole* safety contract — it folds in:
+forward-compatible for a two-version shared-DB window. It is `false` when any
+`PFLIGHT_REPLICA_*` finding is present:
 
-- any `PFLIGHT_REPLICA_*` finding — a replica-unsafe op **or** a non-SQL `.py`
-  migration the classifier could not read;
-- reversibility (`PFLIGHT_MISSING_DOWN`) and transactionality
-  (`PFLIGHT_NON_TRANSACTIONAL`) — the down path.
+- a replica-unsafe op, **or**
+- a non-SQL `.py` migration the classifier could not read
+  (`PFLIGHT_REPLICA_UNCLASSIFIED`).
 
-So `true` means "inspected everything and it is all forward-compatible +
-reversible"; `false` means "unsafe or uninspectable". The fraisier gate consumes
-it as `PreflightReport.window_safe: Option<bool>`: `Some(true)` → allowed
+Window-safety is purely **forward-compatibility**, not atomicity. Reversibility
+(`PFLIGHT_MISSING_DOWN`) and transactionality (`PFLIGHT_NON_TRANSACTIONAL`) are
+reported as their own issues but do **not** gate this verdict — in a blue-green
+cutover, rollback is a traffic swap-back to the still-hot old version (no DB
+rollback), so a non-transactional `CREATE INDEX CONCURRENTLY` — the canonical
+online-migration op — is window-safe. Genuine apply failures are caught at the
+migrate step, before any traffic moves.
+
+So `true` means "every pending op is forward-compatible"; `false` means "unsafe
+or uninspectable". The fraisier gate consumes it as
+`PreflightReport.window_safe: Option<bool>`: `Some(true)` → allowed
 (authoritative), `Some(false)` → blocked, **absent → `None` → blocked**
 (fail-safe, so an older confiture that cannot certify is refused, not waved
 through). It is present at top level in both the default and `--against` payloads
 and pinned in the published schemas + the contract test. The `ok` flag **cannot**
-substitute for it: the replica and non-transactional cases are warn-by-default,
-so `ok == true` can coincide with `window_safe == false`.
-
-> **Note — `CREATE INDEX CONCURRENTLY`:** a concurrent index is replica-safe but
-> *non-transactional*, so it reads `window_safe == false` (the down path is not
-> transactionally reversible). This is intentional under the contract above.
+substitute for it: replica findings are warn-by-default, so `ok == true` can
+coincide with `window_safe == false`.
 
 ## Exit codes
 

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -57,9 +57,9 @@ The adapter-consumed fields per command:
 - **up** — `applied[].version` (the new head).
 - **down-to** — `from`, `to`, `rolled_back[]`.
 - **verify** — `failed_count` (ok ⇔ `0`) and each `results[].{version, name, status, error}`.
-- **preflight** — `ok`, `summary` (incl. `summary.window_safe`, the typed
-  blue-green window-safety verdict — see [below](#replica-forward-compatibility-namespace-window-safety-seam)),
-  each `issues[].{severity, code, message, migration}`.
+- **preflight** — `ok`, the top-level `window_safe` verdict (the typed blue-green
+  window-safety contract — see [below](#replica-forward-compatibility-namespace-window-safety-seam)),
+  `summary`, each `issues[].{severity, code, message, migration}`.
 
 ## Replica forward-compatibility namespace (window-safety seam)
 
@@ -106,17 +106,37 @@ warning for every `.py` migration — "no replica issue" therefore always means
 migrations automatically; a downstream gate does not need a separate "refuse any
 `.py` in the set" rule.
 
-### Typed verdict: `summary.window_safe`
+### Typed verdict: top-level `window_safe`
 
-Rather than prefix-match the codes, a consumer may read the single boolean
-`summary.window_safe` (#154). It is `false` exactly when any `PFLIGHT_REPLICA_*`
-finding is present (an unsafe operation **or** an unreadable `.py` migration), so
-it is the typed form of the presence rule above and is total: `false` means
-"blocked or uninspected", `true` means "inspected and forward-compatible for the
-shared-DB window". It is present in both the default and `--against` payloads and
-pinned in the published schemas; its presence is the capability signal (additive
-field, gated by the ≥ 0.20.0 minimum version). The `ok` flag still **cannot**
-substitute for it (warn-by-default keeps `ok == true` on an unsafe migration).
+The preferred surface is the single **top-level** boolean `window_safe` (#154),
+which a consumer reads instead of prefix-matching codes:
+
+```json
+{ "ok": true, "window_safe": true, "summary": { ... }, "issues": [ ... ] }
+```
+
+`window_safe == true` iff confiture certifies **every checked migration** is
+forward-compatible for a two-version shared-DB window **and** has a safe down
+path. It is the *whole* safety contract — it folds in:
+
+- any `PFLIGHT_REPLICA_*` finding — a replica-unsafe op **or** a non-SQL `.py`
+  migration the classifier could not read;
+- reversibility (`PFLIGHT_MISSING_DOWN`) and transactionality
+  (`PFLIGHT_NON_TRANSACTIONAL`) — the down path.
+
+So `true` means "inspected everything and it is all forward-compatible +
+reversible"; `false` means "unsafe or uninspectable". The fraisier gate consumes
+it as `PreflightReport.window_safe: Option<bool>`: `Some(true)` → allowed
+(authoritative), `Some(false)` → blocked, **absent → `None` → blocked**
+(fail-safe, so an older confiture that cannot certify is refused, not waved
+through). It is present at top level in both the default and `--against` payloads
+and pinned in the published schemas + the contract test. The `ok` flag **cannot**
+substitute for it: the replica and non-transactional cases are warn-by-default,
+so `ok == true` can coincide with `window_safe == false`.
+
+> **Note — `CREATE INDEX CONCURRENTLY`:** a concurrent index is replica-safe but
+> *non-transactional*, so it reads `window_safe == false` (the down path is not
+> transactionally reversible). This is intentional under the contract above.
 
 ## Exit codes
 

--- a/docs/reference/json-schemas/migrate-preflight-against.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight-against.schema.json
@@ -12,8 +12,8 @@
     },
     "window_safe": {
       "type": "boolean",
-      "description": "Top-level blue-green window-safety verdict (#154): true iff confiture certifies every checked migration is forward-compatible for a two-version shared-DB window AND has a safe down path. False when any PFLIGHT_REPLICA_* finding is present (a replica-unsafe op, OR a non-SQL .py migration the classifier cannot read), or any PFLIGHT_MISSING_DOWN (not reversible) / PFLIGHT_NON_TRANSACTIONAL (no transactional rollback). The whole safety contract: consume it directly instead of prefix-matching codes; its absence (older confiture) is fail-safe blocked. (Replay failures are reported as PFLIGHT_REPLAY_FAILED and independently set `ok` false.)",
-      "$comment": "STABILITY: this field and its semantics are a cross-repo contract (#154). It must remain present and a strict superset of the safety conditions above."
+      "description": "Top-level blue-green window-safety verdict (#154): true iff confiture certifies every checked migration is forward-compatible for a two-version shared-DB window. False when any PFLIGHT_REPLICA_* finding is present: a replica-unsafe op, OR a non-SQL .py migration the classifier cannot read. Forward-compatibility only — NOT atomicity: PFLIGHT_MISSING_DOWN (reversibility) and PFLIGHT_NON_TRANSACTIONAL are reported but do not gate this (a non-transactional CREATE INDEX CONCURRENTLY is window-safe). The whole window-safety contract: consume it directly instead of prefix-matching codes; its absence (older confiture) is fail-safe blocked. (Replay failures are reported as PFLIGHT_REPLAY_FAILED and independently set `ok` false.)",
+      "$comment": "STABILITY: this field and its semantics are a cross-repo contract (#154). It must remain present and false whenever any PFLIGHT_REPLICA_* finding (incl. PFLIGHT_REPLICA_UNCLASSIFIED for unreadable migrations) is present."
     },
     "summary": {
       "type": "object",

--- a/docs/reference/json-schemas/migrate-preflight-against.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight-against.schema.json
@@ -4,11 +4,16 @@
   "title": "confiture migrate preflight --against <url> --format json",
   "description": "Structured preflight report (issue #151): the SAME {ok, summary, issues[]} envelope as `migrate preflight` without --against. Static findings (reversibility, transactionality, duplicate versions, checksums) and replica-forward-compat lints are joined by per-migration execution-replay results: each migration that fails to replay against the --against database appears as a `PFLIGHT_REPLAY_FAILED` issue (the database error is in `details.error`). Run-level metadata that is not a finding — `db_consumed` — rides in `summary`. A preflight that *crashed* (config/DB/connection error, e.g. an unreachable --against URL → CONFIG_006/exit 3) emits the #145 error envelope instead — branch on `issues` vs `error`.\n\nNote: `summary.migrations_checked` is the number of migrations *replayed* (the pending set), which may be smaller than the directory-wide set the static findings are drawn from.",
   "type": "object",
-  "required": ["ok", "summary", "issues"],
+  "required": ["ok", "window_safe", "summary", "issues"],
   "properties": {
     "ok": {
       "type": "boolean",
       "description": "False if any error-severity issue (e.g. a failed replay), or — under --strict — any warning."
+    },
+    "window_safe": {
+      "type": "boolean",
+      "description": "Top-level blue-green window-safety verdict (#154): true iff confiture certifies every checked migration is forward-compatible for a two-version shared-DB window AND has a safe down path. False when any PFLIGHT_REPLICA_* finding is present (a replica-unsafe op, OR a non-SQL .py migration the classifier cannot read), or any PFLIGHT_MISSING_DOWN (not reversible) / PFLIGHT_NON_TRANSACTIONAL (no transactional rollback). The whole safety contract: consume it directly instead of prefix-matching codes; its absence (older confiture) is fail-safe blocked. (Replay failures are reported as PFLIGHT_REPLAY_FAILED and independently set `ok` false.)",
+      "$comment": "STABILITY: this field and its semantics are a cross-repo contract (#154). It must remain present and a strict superset of the safety conditions above."
     },
     "summary": {
       "type": "object",
@@ -17,8 +22,7 @@
         "warnings",
         "info",
         "migrations_checked",
-        "db_consumed",
-        "window_safe"
+        "db_consumed"
       ],
       "additionalProperties": false,
       "properties": {
@@ -33,10 +37,6 @@
         "db_consumed": {
           "type": "boolean",
           "description": "True when non-transactional migrations ran outside the SAVEPOINT (--allow-non-transactional). The preflight DB is no longer in its original state — reprovision before the next run."
-        },
-        "window_safe": {
-          "type": "boolean",
-          "description": "Blue-green window-safety verdict (#154): false when any PFLIGHT_REPLICA_* finding is present (an unsafe operation OR a .py migration the classifier cannot read). The typed form of fraisier's presence rule — consume this instead of prefix-matching codes."
         }
       }
     },

--- a/docs/reference/json-schemas/migrate-preflight-against.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight-against.schema.json
@@ -12,7 +12,14 @@
     },
     "summary": {
       "type": "object",
-      "required": ["errors", "warnings", "info", "migrations_checked", "db_consumed"],
+      "required": [
+        "errors",
+        "warnings",
+        "info",
+        "migrations_checked",
+        "db_consumed",
+        "window_safe"
+      ],
       "additionalProperties": false,
       "properties": {
         "errors": { "type": "integer", "minimum": 0 },
@@ -26,6 +33,10 @@
         "db_consumed": {
           "type": "boolean",
           "description": "True when non-transactional migrations ran outside the SAVEPOINT (--allow-non-transactional). The preflight DB is no longer in its original state — reprovision before the next run."
+        },
+        "window_safe": {
+          "type": "boolean",
+          "description": "Blue-green window-safety verdict (#154): false when any PFLIGHT_REPLICA_* finding is present (an unsafe operation OR a .py migration the classifier cannot read). The typed form of fraisier's presence rule — consume this instead of prefix-matching codes."
         }
       }
     },

--- a/docs/reference/json-schemas/migrate-preflight.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight.schema.json
@@ -12,13 +12,17 @@
     },
     "summary": {
       "type": "object",
-      "required": ["errors", "warnings", "info", "migrations_checked"],
+      "required": ["errors", "warnings", "info", "migrations_checked", "window_safe"],
       "additionalProperties": false,
       "properties": {
         "errors": { "type": "integer", "minimum": 0 },
         "warnings": { "type": "integer", "minimum": 0 },
         "info": { "type": "integer", "minimum": 0 },
-        "migrations_checked": { "type": "integer", "minimum": 0 }
+        "migrations_checked": { "type": "integer", "minimum": 0 },
+        "window_safe": {
+          "type": "boolean",
+          "description": "Blue-green window-safety verdict (#154): false when any PFLIGHT_REPLICA_* finding is present (an unsafe operation OR a .py migration the classifier cannot read). The typed form of fraisier's presence rule — consume this instead of prefix-matching codes."
+        }
       }
     },
     "issues": {

--- a/docs/reference/json-schemas/migrate-preflight.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight.schema.json
@@ -2,27 +2,28 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://confiture.fraiseql.dev/schemas/migrate-preflight.schema.json",
   "title": "confiture migrate preflight --format json (no --against)",
-  "description": "Structured preflight report (issue #148): {ok, summary, issues[]}. Reports per-migration reversibility (.down.sql present), transactionality, duplicate version prefixes, and checksum mismatches as a uniform issues[] of the shared issue object. No database connection required. A preflight that *crashed* (config/DB error) emits the #145 error envelope instead — branch on `issues` vs `error`.",
+  "description": "Structured preflight report (issue #148/#154): {ok, window_safe, summary, issues[]}. Reports per-migration reversibility (.down.sql present), transactionality, duplicate version prefixes, checksum mismatches, and replica forward-compatibility as a uniform issues[] of the shared issue object. No database connection required. A preflight that *crashed* (config/DB error) emits the #145 error envelope instead — branch on `issues` vs `error`.",
   "type": "object",
-  "required": ["ok", "summary", "issues"],
+  "required": ["ok", "window_safe", "summary", "issues"],
   "properties": {
     "ok": {
       "type": "boolean",
       "description": "False if any error-severity issue (or, under --strict, any warning)."
     },
+    "window_safe": {
+      "type": "boolean",
+      "description": "Top-level blue-green window-safety verdict (#154): true iff confiture certifies every checked migration is forward-compatible for a two-version shared-DB window AND has a safe down path. False when any PFLIGHT_REPLICA_* finding is present (a replica-unsafe op, OR a non-SQL .py migration the classifier cannot read), or any PFLIGHT_MISSING_DOWN (not reversible) / PFLIGHT_NON_TRANSACTIONAL (no transactional rollback). This is the whole safety contract: consume it directly instead of prefix-matching codes; a consumer treats its absence (older confiture) as fail-safe blocked. Note `ok` cannot substitute for it — the replica/transactional cases are warn-by-default, so `ok` can be true while `window_safe` is false.",
+      "$comment": "STABILITY: this field and its semantics are a cross-repo contract (#154). It must remain present and a strict superset of the safety conditions above."
+    },
     "summary": {
       "type": "object",
-      "required": ["errors", "warnings", "info", "migrations_checked", "window_safe"],
+      "required": ["errors", "warnings", "info", "migrations_checked"],
       "additionalProperties": false,
       "properties": {
         "errors": { "type": "integer", "minimum": 0 },
         "warnings": { "type": "integer", "minimum": 0 },
         "info": { "type": "integer", "minimum": 0 },
-        "migrations_checked": { "type": "integer", "minimum": 0 },
-        "window_safe": {
-          "type": "boolean",
-          "description": "Blue-green window-safety verdict (#154): false when any PFLIGHT_REPLICA_* finding is present (an unsafe operation OR a .py migration the classifier cannot read). The typed form of fraisier's presence rule — consume this instead of prefix-matching codes."
-        }
+        "migrations_checked": { "type": "integer", "minimum": 0 }
       }
     },
     "issues": {

--- a/docs/reference/json-schemas/migrate-preflight.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight.schema.json
@@ -12,8 +12,8 @@
     },
     "window_safe": {
       "type": "boolean",
-      "description": "Top-level blue-green window-safety verdict (#154): true iff confiture certifies every checked migration is forward-compatible for a two-version shared-DB window AND has a safe down path. False when any PFLIGHT_REPLICA_* finding is present (a replica-unsafe op, OR a non-SQL .py migration the classifier cannot read), or any PFLIGHT_MISSING_DOWN (not reversible) / PFLIGHT_NON_TRANSACTIONAL (no transactional rollback). This is the whole safety contract: consume it directly instead of prefix-matching codes; a consumer treats its absence (older confiture) as fail-safe blocked. Note `ok` cannot substitute for it — the replica/transactional cases are warn-by-default, so `ok` can be true while `window_safe` is false.",
-      "$comment": "STABILITY: this field and its semantics are a cross-repo contract (#154). It must remain present and a strict superset of the safety conditions above."
+      "description": "Top-level blue-green window-safety verdict (#154): true iff confiture certifies every checked migration is forward-compatible for a two-version shared-DB window (both N-1 and N served against one Postgres during the cutover). False when any PFLIGHT_REPLICA_* finding is present: a replica-unsafe op, OR a non-SQL .py migration the classifier cannot read. Forward-compatibility only — NOT atomicity: PFLIGHT_MISSING_DOWN (reversibility) and PFLIGHT_NON_TRANSACTIONAL are reported but do not gate this (a non-transactional CREATE INDEX CONCURRENTLY is window-safe). This is the whole window-safety contract: consume it directly instead of prefix-matching codes; a consumer treats its absence (older confiture) as fail-safe blocked. Note `ok` cannot substitute for it — replica findings are warn-by-default, so `ok` can be true while `window_safe` is false.",
+      "$comment": "STABILITY: this field and its semantics are a cross-repo contract (#154). It must remain present and false whenever any PFLIGHT_REPLICA_* finding (incl. PFLIGHT_REPLICA_UNCLASSIFIED for unreadable migrations) is present."
     },
     "summary": {
       "type": "object",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.22.0"
+version = "0.23.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -2107,7 +2107,10 @@ def migrate_preflight(
     """
     from rich.table import Table
 
-    from confiture.core.linting.libraries.replica import replica_preflight_issues
+    from confiture.core.linting.libraries.replica import (
+        is_window_safe,
+        replica_preflight_issues,
+    )
     from confiture.core.preflight import preflight_exit_code, run_preflight
 
     if check_dependents not in {"off", "fail", "warn"}:
@@ -2142,6 +2145,9 @@ def migrate_preflight(
             "warnings": sum(1 for i in all_issues if i.severity == "warning"),
             "info": sum(1 for i in all_issues if i.severity == "info"),
             "migrations_checked": len(result.migrations),
+            # #154: typed blue-green window-safety verdict (fraisier's presence
+            # rule, computed here) — False when any PFLIGHT_REPLICA_* finding fires.
+            "window_safe": is_window_safe(all_issues),
         }
         exit_code = preflight_exit_code(summary, strict=strict)
 
@@ -2315,6 +2321,8 @@ def migrate_preflight(
         "info": sum(1 for i in all_issues if i.severity == "info"),
         "migrations_checked": len(against_result.migrations),
         "db_consumed": against_result.db_consumed,
+        # #154: same typed window-safety verdict as the no-`--against` path.
+        "window_safe": is_window_safe(all_issues),
     }
     exit_code = preflight_exit_code(summary, strict=strict)
 

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -2107,11 +2107,12 @@ def migrate_preflight(
     """
     from rich.table import Table
 
-    from confiture.core.linting.libraries.replica import (
+    from confiture.core.linting.libraries.replica import replica_preflight_issues
+    from confiture.core.preflight import (
         is_window_safe,
-        replica_preflight_issues,
+        preflight_exit_code,
+        run_preflight,
     )
-    from confiture.core.preflight import preflight_exit_code, run_preflight
 
     if check_dependents not in {"off", "fail", "warn"}:
         error_console.print(
@@ -2145,15 +2146,16 @@ def migrate_preflight(
             "warnings": sum(1 for i in all_issues if i.severity == "warning"),
             "info": sum(1 for i in all_issues if i.severity == "info"),
             "migrations_checked": len(result.migrations),
-            # #154: typed blue-green window-safety verdict (fraisier's presence
-            # rule, computed here) — False when any PFLIGHT_REPLICA_* finding fires.
-            "window_safe": is_window_safe(all_issues),
         }
         exit_code = preflight_exit_code(summary, strict=strict)
 
         if format_type == "json":
             payload = {
                 "ok": exit_code == 0,
+                # #154: top-level typed blue-green window-safety verdict — the whole
+                # safety contract for the consumer (folds in replica-unsafe ops,
+                # unreadable .py migrations, and the down path).
+                "window_safe": is_window_safe(all_issues),
                 "summary": summary,
                 "issues": [i.to_dict() for i in all_issues],
             }
@@ -2321,14 +2323,14 @@ def migrate_preflight(
         "info": sum(1 for i in all_issues if i.severity == "info"),
         "migrations_checked": len(against_result.migrations),
         "db_consumed": against_result.db_consumed,
-        # #154: same typed window-safety verdict as the no-`--against` path.
-        "window_safe": is_window_safe(all_issues),
     }
     exit_code = preflight_exit_code(summary, strict=strict)
 
     if format_type == "json":
         payload: dict[str, Any] = {
             "ok": exit_code == 0,
+            # #154: same top-level typed window-safety verdict as the no-`--against` path.
+            "window_safe": is_window_safe(all_issues),
             "summary": summary,
             "issues": [i.to_dict() for i in all_issues],
         }

--- a/python/confiture/core/linting/libraries/replica.py
+++ b/python/confiture/core/linting/libraries/replica.py
@@ -12,7 +12,7 @@ One engine (`_iter_findings`) feeds two surfaces: the `confiture lint` rule
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -191,16 +191,3 @@ def replica_preflight_issues(
         for py in _unreadable_migrations(migrations_dir)
     )
     return issues
-
-
-def is_window_safe(issues: Iterable[PreflightIssue]) -> bool:
-    """Whether a preflight issue set certifies blue-green window safety (#154).
-
-    The typed form of fraisier's gate: ``True`` iff no replica forward-compat
-    finding is present. Reuses :func:`replica_lint_codes` so the verdict tracks the
-    pinned namespace exactly. With the ``*.py`` coverage above this is total — a
-    ``False`` means "blocked or uninspected", a ``True`` means "inspected and
-    forward-compatible for a two-version shared-DB window".
-    """
-    codes = replica_lint_codes()
-    return not any(issue.code in codes for issue in issues)

--- a/python/confiture/core/linting/libraries/replica.py
+++ b/python/confiture/core/linting/libraries/replica.py
@@ -12,7 +12,7 @@ One engine (`_iter_findings`) feeds two surfaces: the `confiture lint` rule
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -41,6 +41,21 @@ REPLICA_CODE_BY_OP = {
     "CreateIndex": "PFLIGHT_REPLICA_CREATE_INDEX",
     "Other": "PFLIGHT_REPLICA_UNCLASSIFIED",
 }
+
+
+def replica_lint_codes() -> frozenset[str]:
+    """The exact set of ``PFLIGHT_REPLICA_*`` codes the replica lint can emit.
+
+    fraisier's blue-green **window-safety gate** keys on the *presence* of any of
+    these in ``migrate preflight``'s ``issues[]`` to decide whether a migration is
+    forward-compatible for a two-version shared-DB cutover window. This set is a
+    **cross-repo stability commitment** (issue #154): renames/removals are
+    breaking and require a major version bump; additions are allowed. It is the
+    single source for that namespace — derived from :data:`REPLICA_CODE_BY_OP`, so
+    there is no second copy of the code strings to drift. The contract test in
+    ``tests/contract/test_fraisier_adapter_surface.py`` pins it.
+    """
+    return frozenset(REPLICA_CODE_BY_OP.values())
 
 
 @dataclass(frozen=True)
@@ -111,13 +126,39 @@ class Replica001ForwardCompat:
         ]
 
 
+def _unreadable_migrations(migrations_dir: Path) -> Iterator[Path]:
+    """Yield migration files the SQL replica classifier cannot read.
+
+    Mirrors ``run_preflight``'s Python-migration discovery filter (skip
+    ``__init__.py`` and ``_``-prefixed helpers). A ``.py`` migration is opaque to
+    the SQL classifier, so its forward-compatibility cannot be certified.
+    """
+    if not migrations_dir.exists():
+        return
+    yield from sorted(
+        (
+            f
+            for f in migrations_dir.glob("*.py")
+            if f.name != "__init__.py" and not f.name.startswith("_")
+        ),
+        key=lambda f: f.name,
+    )
+
+
 def replica_preflight_issues(
     migrations_dir: Path, *, has_replicas: bool, bypass: bool
 ) -> list[PreflightIssue]:
-    """Return the same findings as PreflightIssues (#148 shape) for preflight."""
+    """Return replica findings as PreflightIssues (#148 shape) for preflight.
+
+    Covers both the SQL operations the classifier reads (``*.up.sql``) and, per
+    issue #154, the migrations it *cannot* read (``*.py``) — the latter surface as
+    ``PFLIGHT_REPLICA_UNCLASSIFIED`` warnings so "no replica issue" can never
+    silently mean "never inspected". UNCLASSIFIED is always a warning (opacity
+    never hard-blocks).
+    """
     from confiture.models.results import PreflightIssue
 
-    return [
+    issues = [
         PreflightIssue(
             severity=f.severity,
             code=f.code,
@@ -129,3 +170,37 @@ def replica_preflight_issues(
         )
         for f in _iter_findings(migrations_dir, has_replicas=has_replicas, bypass=bypass)
     ]
+    issues.extend(
+        PreflightIssue(
+            severity="warning",
+            code="PFLIGHT_REPLICA_UNCLASSIFIED",
+            message=(
+                "non-SQL (.py) migration: the replica forward-compatibility "
+                "classifier cannot inspect it, so window-safety cannot be "
+                "certified automatically; review manually"
+            ),
+            migration=None,
+            file=py.name,
+            actionable=(
+                "review the migration's DDL by hand for replica "
+                "forward-compatibility, or express the schema change as a "
+                ".up.sql so it can be classified"
+            ),
+            details={"operation": "NonSqlMigration"},
+        )
+        for py in _unreadable_migrations(migrations_dir)
+    )
+    return issues
+
+
+def is_window_safe(issues: Iterable[PreflightIssue]) -> bool:
+    """Whether a preflight issue set certifies blue-green window safety (#154).
+
+    The typed form of fraisier's gate: ``True`` iff no replica forward-compat
+    finding is present. Reuses :func:`replica_lint_codes` so the verdict tracks the
+    pinned namespace exactly. With the ``*.py`` coverage above this is total — a
+    ``False`` means "blocked or uninspected", a ``True`` means "inspected and
+    forward-compatible for a two-version shared-DB window".
+    """
+    codes = replica_lint_codes()
+    return not any(issue.code in codes for issue in issues)

--- a/python/confiture/core/preflight.py
+++ b/python/confiture/core/preflight.py
@@ -21,32 +21,34 @@ from confiture.models.results import MigrationPreflightInfo, PreflightResult
 if TYPE_CHECKING:
     from confiture.models.results import PreflightIssue
 
-# Preflight issue codes that, beyond the replica namespace, make a migration set
-# unsafe for a two-version blue-green window (#154): an unsafe down path.
-_DOWN_PATH_BLOCKING_CODES = frozenset({"PFLIGHT_MISSING_DOWN", "PFLIGHT_NON_TRANSACTIONAL"})
-
 
 def is_window_safe(issues: Iterable[PreflightIssue]) -> bool:
     """Typed blue-green window-safety verdict over a preflight issue set (#154).
 
-    ``True`` iff confiture certifies every checked migration is forward-compatible
-    for a two-version shared-DB window *and* has a safe down path. It folds in,
-    per the fraisier window-safety contract:
+    ``True`` iff confiture certifies every checked migration is **forward-compatible
+    for a two-version shared-DB window** — both N-1 and N serving against one
+    Postgres during the cutover. It is ``False`` when any ``PFLIGHT_REPLICA_*``
+    finding is present: a replica-unsafe op, **or** a non-SQL ``.py`` migration the
+    classifier could not read (``PFLIGHT_REPLICA_UNCLASSIFIED``).
 
-    - any ``PFLIGHT_REPLICA_*`` finding — a replica-unsafe op, **or** a non-SQL
-      ``.py`` migration the classifier could not read (``PFLIGHT_REPLICA_UNCLASSIFIED``);
-    - reversibility (``PFLIGHT_MISSING_DOWN``) and transactionality
-      (``PFLIGHT_NON_TRANSACTIONAL``) — the down path.
+    Window-safety is purely about forward-compatibility, **not** atomicity:
+    reversibility (``PFLIGHT_MISSING_DOWN``) and transactionality
+    (``PFLIGHT_NON_TRANSACTIONAL``) are reported as their own issues but do **not**
+    gate this verdict. In a blue-green cutover, rollback is a traffic swap-back to
+    the still-hot old version (no DB rollback), so a non-transactional op such as
+    ``CREATE INDEX CONCURRENTLY`` — the canonical online-migration operation — is
+    window-safe. Genuine apply failures are caught at the migrate step, before any
+    traffic moves.
 
-    This is the *whole* safety contract for the consumer: ``True`` means "inspected
-    everything and it is all forward-compatible + reversible", ``False`` means
-    "unsafe or uninspectable". The field's absence is treated fail-safe (blocked)
-    by the consumer, so older confiture keeps working.
+    This is the *whole* window-safety contract for the consumer: ``True`` means
+    "every pending op is forward-compatible", ``False`` means "unsafe or
+    uninspectable". The field's absence is treated fail-safe (blocked) by the
+    consumer, so older confiture keeps working.
     """
     from confiture.core.linting.libraries.replica import replica_lint_codes
 
-    blocking = replica_lint_codes() | _DOWN_PATH_BLOCKING_CODES
-    return not any(issue.code in blocking for issue in issues)
+    replica_codes = replica_lint_codes()
+    return not any(issue.code in replica_codes for issue in issues)
 
 
 def preflight_exit_code(summary: dict[str, int], *, strict: bool) -> int:

--- a/python/confiture/core/preflight.py
+++ b/python/confiture/core/preflight.py
@@ -8,13 +8,45 @@ Filesystem-only checks that require no database connection:
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from confiture.core._migrator.discovery import (
     _version_from_migration_filename,
     find_duplicate_migration_versions,
 )
 from confiture.models.results import MigrationPreflightInfo, PreflightResult
+
+if TYPE_CHECKING:
+    from confiture.models.results import PreflightIssue
+
+# Preflight issue codes that, beyond the replica namespace, make a migration set
+# unsafe for a two-version blue-green window (#154): an unsafe down path.
+_DOWN_PATH_BLOCKING_CODES = frozenset({"PFLIGHT_MISSING_DOWN", "PFLIGHT_NON_TRANSACTIONAL"})
+
+
+def is_window_safe(issues: Iterable[PreflightIssue]) -> bool:
+    """Typed blue-green window-safety verdict over a preflight issue set (#154).
+
+    ``True`` iff confiture certifies every checked migration is forward-compatible
+    for a two-version shared-DB window *and* has a safe down path. It folds in,
+    per the fraisier window-safety contract:
+
+    - any ``PFLIGHT_REPLICA_*`` finding — a replica-unsafe op, **or** a non-SQL
+      ``.py`` migration the classifier could not read (``PFLIGHT_REPLICA_UNCLASSIFIED``);
+    - reversibility (``PFLIGHT_MISSING_DOWN``) and transactionality
+      (``PFLIGHT_NON_TRANSACTIONAL``) — the down path.
+
+    This is the *whole* safety contract for the consumer: ``True`` means "inspected
+    everything and it is all forward-compatible + reversible", ``False`` means
+    "unsafe or uninspectable". The field's absence is treated fail-safe (blocked)
+    by the consumer, so older confiture keeps working.
+    """
+    from confiture.core.linting.libraries.replica import replica_lint_codes
+
+    blocking = replica_lint_codes() | _DOWN_PATH_BLOCKING_CODES
+    return not any(issue.code in blocking for issue in issues)
 
 
 def preflight_exit_code(summary: dict[str, int], *, strict: bool) -> int:

--- a/tests/contract/test_fraisier_adapter_surface.py
+++ b/tests/contract/test_fraisier_adapter_surface.py
@@ -47,6 +47,23 @@ UNINITIALISED_ERROR_CODE = "PRECON_1001"  # current → "no current revision"
 NO_DSN_ERROR_CODE = "CONFIG_010"  # InvalidConfig
 LOCK_EXIT_CODE = 6  # LOCK_1300, retriable
 
+# The PFLIGHT_REPLICA_* namespace fraisier's blue-green window-safety gate keys on
+# (fraisier-core/src/window_safety.rs blocks the deploy on the presence of ANY of
+# these in preflight's issues[]). Pinned here as a cross-repo stability commitment:
+# renames/removals are breaking (major bump); additions are allowed by extending
+# this literal. See docs/reference/fraisier-adapter-contract.md.
+EXPECTED_REPLICA_CODES = frozenset(
+    {
+        "PFLIGHT_REPLICA_ADD_COLUMN",
+        "PFLIGHT_REPLICA_ADD_CONSTRAINT",
+        "PFLIGHT_REPLICA_CHANGE_TYPE",
+        "PFLIGHT_REPLICA_CREATE_INDEX",
+        "PFLIGHT_REPLICA_DROP_COLUMN",
+        "PFLIGHT_REPLICA_RENAME_COLUMN",
+        "PFLIGHT_REPLICA_UNCLASSIFIED",
+    }
+)
+
 _SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "docs" / "reference" / "json-schemas"
 
 # Two real migrations so `down-to` rolls something back.
@@ -110,6 +127,61 @@ def test_adapter_pinned_error_codes_keep_their_exit_numbers() -> None:
     assert CANONICAL_EXIT_CODES[UNINITIALISED_ERROR_CODE] == 2
     assert CANONICAL_EXIT_CODES[NO_DSN_ERROR_CODE] == 5
     assert CANONICAL_EXIT_CODES["LOCK_1300"] == LOCK_EXIT_CODE
+
+
+def test_replica_code_namespace_is_a_stability_commitment() -> None:
+    """The exact set fraisier's blue-green window-safety gate keys on (#154).
+
+    fraisier blocks a deploy on the *presence* of any ``PFLIGHT_REPLICA_*`` issue
+    in preflight's ``issues[]``. A rename of one of these codes would silently make
+    that gate match nothing — blue-green would proceed on an uncertified migration
+    with confiture CI still green. Pin the set so a rename fails here instead.
+    """
+    from confiture.core.linting.libraries.replica import replica_lint_codes
+
+    assert replica_lint_codes() == EXPECTED_REPLICA_CODES
+
+
+def test_replica_codes_keep_the_pflight_replica_prefix() -> None:
+    """Every emittable replica code carries the prefix fraisier string-matches on."""
+    from confiture.core.linting.libraries.replica import replica_lint_codes
+
+    assert replica_lint_codes(), "the replica lint must emit at least one code"
+    assert all(code.startswith("PFLIGHT_REPLICA_") for code in replica_lint_codes())
+
+
+def test_preflight_summary_carries_window_safe_verdict(tmp_path: Path) -> None:
+    """The default preflight summary exposes the typed `window_safe` verdict (#154).
+
+    The fraisier window-safety gate can read one typed boolean instead of
+    prefix-matching ``PFLIGHT_REPLICA_*`` codes. Filesystem-only — no DB needed —
+    and validated against the published schema so the field is a pinned contract.
+    """
+    md = tmp_path / "migrations"
+    md.mkdir()
+    (md / "20260101000001_a.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    (md / "20260101000001_a.down.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    report = tmp_path / "report.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "preflight",
+            "--no-config",
+            "--format",
+            "json",
+            "--output",
+            str(report),
+            "--migrations-dir",
+            str(md),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(report.read_text())
+    _schema("migrate-preflight.schema.json").validate(payload)
+    # DROP COLUMN is not forward-compatible for the shared-DB read window.
+    assert payload["summary"]["window_safe"] is False
 
 
 def test_version_output_shape_matches_adapter_parser() -> None:

--- a/tests/contract/test_fraisier_adapter_surface.py
+++ b/tests/contract/test_fraisier_adapter_surface.py
@@ -150,19 +150,14 @@ def test_replica_codes_keep_the_pflight_replica_prefix() -> None:
     assert all(code.startswith("PFLIGHT_REPLICA_") for code in replica_lint_codes())
 
 
-def test_preflight_summary_carries_window_safe_verdict(tmp_path: Path) -> None:
-    """The default preflight summary exposes the typed `window_safe` verdict (#154).
-
-    The fraisier window-safety gate can read one typed boolean instead of
-    prefix-matching ``PFLIGHT_REPLICA_*`` codes. Filesystem-only — no DB needed —
-    and validated against the published schema so the field is a pinned contract.
-    """
+def _preflight_payload(tmp_path: Path, up_sql: str, down_sql: str | None) -> dict:
+    """Run the default (no-DB) preflight the adapter consumes and return its JSON."""
     md = tmp_path / "migrations"
-    md.mkdir()
-    (md / "20260101000001_a.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
-    (md / "20260101000001_a.down.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    md.mkdir(parents=True)
+    (md / "20260101000001_a.up.sql").write_text(up_sql)
+    if down_sql is not None:
+        (md / "20260101000001_a.down.sql").write_text(down_sql)
     report = tmp_path / "report.json"
-
     result = runner.invoke(
         app,
         [
@@ -177,11 +172,35 @@ def test_preflight_summary_carries_window_safe_verdict(tmp_path: Path) -> None:
             str(md),
         ],
     )
-    assert result.exit_code == 0, result.output
+    assert result.exit_code in EXIT_CODE_MEANINGS, result.output
     payload = json.loads(report.read_text())
     _schema("migrate-preflight.schema.json").validate(payload)
-    # DROP COLUMN is not forward-compatible for the shared-DB read window.
-    assert payload["summary"]["window_safe"] is False
+    return payload
+
+
+def test_preflight_exposes_top_level_window_safe_verdict(tmp_path: Path) -> None:
+    """`window_safe` is a top-level typed boolean, pinned against the schema (#154).
+
+    fraisier's window-safety gate reads this single field instead of prefix-matching
+    ``PFLIGHT_REPLICA_*`` codes — and (since fraisier dropped its own safety nets)
+    it is the *whole* safety contract. Filesystem-only, no DB. This is the Phase-3
+    commitment.
+    """
+    # A forward-compatible, reversible, transactional migration → certified safe.
+    safe = _preflight_payload(
+        tmp_path / "safe",
+        "ALTER TABLE t ADD COLUMN c int;",
+        "ALTER TABLE t DROP COLUMN c;",
+    )
+    assert safe["window_safe"] is True
+
+    # A replica-unsafe op (DROP COLUMN) → not certifiable, even though reversible.
+    unsafe = _preflight_payload(
+        tmp_path / "unsafe",
+        "ALTER TABLE t DROP COLUMN c;",
+        "ALTER TABLE t ADD COLUMN c int;",
+    )
+    assert unsafe["window_safe"] is False
 
 
 def test_version_output_shape_matches_adapter_parser() -> None:
@@ -330,6 +349,8 @@ def test_adapter_full_flow_against_real_db(adapter_db, migrations_dir, tmp_path)
     preflight_payload = _read_report(result, report)
     _schema("migrate-preflight.schema.json").validate(preflight_payload)
     assert isinstance(preflight_payload["ok"], bool)
+    # #154: the typed window-safety verdict the adapter now consumes directly.
+    assert isinstance(preflight_payload["window_safe"], bool)
 
     # 6. down-to the first version → exit 0; rolled_back lists the newer migration.
     result = invoke("down-to", _VERSIONS[0][0])

--- a/tests/integration/test_replica_lint_surfaces.py
+++ b/tests/integration/test_replica_lint_surfaces.py
@@ -124,11 +124,12 @@ def test_preflight_py_migration_is_window_unsafe(tmp_path: Path) -> None:
     assert payload["window_safe"] is False
 
 
-def test_preflight_window_safe_false_when_not_reversible(tmp_path: Path) -> None:
-    """A missing .down.sql (unsafe down path) folds into the top-level verdict (#154)."""
+def test_preflight_window_safe_decoupled_from_reversibility(tmp_path: Path) -> None:
+    """Window-safety is forward-compatibility only: a missing .down.sql is reported
+    but does not flip the top-level verdict (#154)."""
     migs = tmp_path / "migrations"
     migs.mkdir()
-    # nullable ADD is forward-compatible, but there is no .down.sql sibling
+    # nullable ADD is forward-compatible; no .down.sql sibling → PFLIGHT_MISSING_DOWN
     (migs / "20260531_1200_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
 
     r = runner.invoke(
@@ -136,7 +137,7 @@ def test_preflight_window_safe_false_when_not_reversible(tmp_path: Path) -> None
     )
     payload = json.loads(r.stdout)
     assert "PFLIGHT_MISSING_DOWN" in {i["code"] for i in payload["issues"]}
-    assert payload["window_safe"] is False
+    assert payload["window_safe"] is True
 
 
 # ── lint surface ──────────────────────────────────────────────────────────────

--- a/tests/integration/test_replica_lint_surfaces.py
+++ b/tests/integration/test_replica_lint_surfaces.py
@@ -80,8 +80,8 @@ def test_preflight_replica_bypass_downgrades(tmp_path: Path) -> None:
     assert r.exit_code == 0, r.output  # bypass downgrades to warning
 
 
-def test_preflight_summary_window_safe_false_when_unsafe(tmp_path: Path) -> None:
-    """The typed `window_safe` verdict is False when a replica finding is present (#154)."""
+def test_preflight_window_safe_false_when_unsafe(tmp_path: Path) -> None:
+    """The top-level `window_safe` verdict is False when a replica finding is present (#154)."""
     migs = tmp_path / "migrations"
     migs.mkdir()
     (migs / "20260531_1200_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
@@ -91,11 +91,11 @@ def test_preflight_summary_window_safe_false_when_unsafe(tmp_path: Path) -> None
         app, ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json"]
     )
     assert r.exit_code == 0, r.output  # warn-by-default, but window-unsafe
-    assert json.loads(r.stdout)["summary"]["window_safe"] is False
+    assert json.loads(r.stdout)["window_safe"] is False
 
 
-def test_preflight_summary_window_safe_true_when_clean(tmp_path: Path) -> None:
-    """A nullable ADD COLUMN is forward-compatible → window_safe True (#154)."""
+def test_preflight_window_safe_true_when_fully_certified(tmp_path: Path) -> None:
+    """Forward-compatible + reversible + transactional → top-level window_safe True (#154)."""
     migs = tmp_path / "migrations"
     migs.mkdir()
     (migs / "20260531_1200_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
@@ -105,7 +105,7 @@ def test_preflight_summary_window_safe_true_when_clean(tmp_path: Path) -> None:
         app, ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json"]
     )
     assert r.exit_code == 0, r.output
-    assert json.loads(r.stdout)["summary"]["window_safe"] is True
+    assert json.loads(r.stdout)["window_safe"] is True
 
 
 def test_preflight_py_migration_is_window_unsafe(tmp_path: Path) -> None:
@@ -121,7 +121,22 @@ def test_preflight_py_migration_is_window_unsafe(tmp_path: Path) -> None:
     payload = json.loads(r.stdout)
     codes = {i["code"] for i in payload["issues"]}
     assert "PFLIGHT_REPLICA_UNCLASSIFIED" in codes
-    assert payload["summary"]["window_safe"] is False
+    assert payload["window_safe"] is False
+
+
+def test_preflight_window_safe_false_when_not_reversible(tmp_path: Path) -> None:
+    """A missing .down.sql (unsafe down path) folds into the top-level verdict (#154)."""
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    # nullable ADD is forward-compatible, but there is no .down.sql sibling
+    (migs / "20260531_1200_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json"]
+    )
+    payload = json.loads(r.stdout)
+    assert "PFLIGHT_MISSING_DOWN" in {i["code"] for i in payload["issues"]}
+    assert payload["window_safe"] is False
 
 
 # ── lint surface ──────────────────────────────────────────────────────────────

--- a/tests/integration/test_replica_lint_surfaces.py
+++ b/tests/integration/test_replica_lint_surfaces.py
@@ -80,6 +80,50 @@ def test_preflight_replica_bypass_downgrades(tmp_path: Path) -> None:
     assert r.exit_code == 0, r.output  # bypass downgrades to warning
 
 
+def test_preflight_summary_window_safe_false_when_unsafe(tmp_path: Path) -> None:
+    """The typed `window_safe` verdict is False when a replica finding is present (#154)."""
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260531_1200_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    (migs / "20260531_1200_drop.down.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json"]
+    )
+    assert r.exit_code == 0, r.output  # warn-by-default, but window-unsafe
+    assert json.loads(r.stdout)["summary"]["window_safe"] is False
+
+
+def test_preflight_summary_window_safe_true_when_clean(tmp_path: Path) -> None:
+    """A nullable ADD COLUMN is forward-compatible → window_safe True (#154)."""
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260531_1200_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    (migs / "20260531_1200_add.down.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json"]
+    )
+    assert r.exit_code == 0, r.output
+    assert json.loads(r.stdout)["summary"]["window_safe"] is True
+
+
+def test_preflight_py_migration_is_window_unsafe(tmp_path: Path) -> None:
+    """A `.py` migration the classifier can't read makes the window not certifiable (#154)."""
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260531_1200_data.py").write_text("def up(cur):\n    pass\n")
+
+    r = runner.invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json"]
+    )
+    assert r.exit_code == 0, r.output
+    payload = json.loads(r.stdout)
+    codes = {i["code"] for i in payload["issues"]}
+    assert "PFLIGHT_REPLICA_UNCLASSIFIED" in codes
+    assert payload["summary"]["window_safe"] is False
+
+
 # ── lint surface ──────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_replica_preflight.py
+++ b/tests/unit/test_replica_preflight.py
@@ -70,24 +70,26 @@ def test_is_window_safe_false_on_unreadable_py(tmp_path: Path) -> None:
     assert is_window_safe(_all_issues(tmp_path)) is False
 
 
-def test_is_window_safe_false_when_not_reversible(tmp_path: Path) -> None:
-    """A migration with no .down.sql folds into the verdict — unsafe down path (#154)."""
+def test_is_window_safe_true_despite_missing_down(tmp_path: Path) -> None:
+    """Reversibility is NOT a window-safety property — a forward-compatible op with
+    no .down.sql is still window-safe (#154)."""
     (tmp_path / "20260606120000_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
-    # no .down.sql sibling → PFLIGHT_MISSING_DOWN
-    assert is_window_safe(_all_issues(tmp_path)) is False
+    # no .down.sql sibling → PFLIGHT_MISSING_DOWN, but window-safety ignores it
+    assert is_window_safe(_all_issues(tmp_path)) is True
 
 
-def test_is_window_safe_false_when_non_transactional(tmp_path: Path) -> None:
-    """A non-transactional statement folds into the verdict — unsafe down path (#154)."""
+def test_is_window_safe_true_for_concurrent_index(tmp_path: Path) -> None:
+    """CREATE INDEX CONCURRENTLY is the canonical online op — window-safe despite
+    being non-transactional (#154)."""
     (tmp_path / "20260606120000_idx.up.sql").write_text(
         "CREATE INDEX CONCURRENTLY idx_t_c ON t (c);"
     )
     (tmp_path / "20260606120000_idx.down.sql").write_text("DROP INDEX idx_t_c;")
-    assert is_window_safe(_all_issues(tmp_path)) is False
+    assert is_window_safe(_all_issues(tmp_path)) is True
 
 
-def test_is_window_safe_true_when_fully_certified(tmp_path: Path) -> None:
-    """Forward-compatible + reversible + transactional → window safe (#154)."""
+def test_is_window_safe_true_when_forward_compatible(tmp_path: Path) -> None:
+    """A nullable ADD COLUMN is forward-compatible → window safe (#154)."""
     (tmp_path / "20260606120000_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
     (tmp_path / "20260606120000_add.down.sql").write_text("ALTER TABLE t DROP COLUMN c;")
     assert is_window_safe(_all_issues(tmp_path)) is True

--- a/tests/unit/test_replica_preflight.py
+++ b/tests/unit/test_replica_preflight.py
@@ -1,0 +1,65 @@
+"""Unit tests for the preflight replica surface (#154).
+
+Covers the ".py can't-see" blind spot (Phase 2): the replica classifier reads
+``*.up.sql`` only, so a ``DROP COLUMN`` inside a Python migration used to produce
+no finding at all — making "no replica issue" ambiguous between *inspected-and-safe*
+and *never-inspected*. The surface now emits ``PFLIGHT_REPLICA_UNCLASSIFIED`` for
+migrations it cannot read, so the presence rule covers them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from confiture.core.linting.libraries.replica import (
+    is_window_safe,
+    replica_preflight_issues,
+)
+
+
+def test_py_migration_emits_unclassified(tmp_path: Path) -> None:
+    """A `.py` migration the classifier can't read surfaces as UNCLASSIFIED."""
+    (tmp_path / "20260606120000_data.py").write_text(
+        "def up(cur):\n    cur.execute('ALTER TABLE t DROP COLUMN c')\n"
+    )
+    issues = replica_preflight_issues(tmp_path, has_replicas=False, bypass=False)
+    unclassified = [i for i in issues if i.code == "PFLIGHT_REPLICA_UNCLASSIFIED"]
+    assert len(unclassified) == 1
+    assert unclassified[0].severity == "warning"
+    assert unclassified[0].file == "20260606120000_data.py"
+
+
+def test_py_unclassified_is_warning_even_with_replicas(tmp_path: Path) -> None:
+    """Opacity never hard-blocks: UNCLASSIFIED stays a warning even with replicas."""
+    (tmp_path / "20260606120000_data.py").write_text("def up(cur):\n    pass\n")
+    issues = replica_preflight_issues(tmp_path, has_replicas=True, bypass=False)
+    unclassified = [i for i in issues if i.code == "PFLIGHT_REPLICA_UNCLASSIFIED"]
+    assert unclassified and all(i.severity == "warning" for i in unclassified)
+
+
+def test_dunder_and_underscore_py_not_flagged(tmp_path: Path) -> None:
+    """`__init__.py` and `_`-prefixed helpers are not migrations (discovery filter)."""
+    (tmp_path / "__init__.py").write_text("")
+    (tmp_path / "_helpers.py").write_text("X = 1\n")
+    issues = replica_preflight_issues(tmp_path, has_replicas=False, bypass=False)
+    assert issues == []
+
+
+def test_sql_only_dir_has_no_unclassified(tmp_path: Path) -> None:
+    """A readable SQL migration is classified, not marked unclassified."""
+    (tmp_path / "20260606120000_safe.up.sql").write_text("CREATE TABLE t (id int);")
+    issues = replica_preflight_issues(tmp_path, has_replicas=False, bypass=False)
+    assert all(i.code != "PFLIGHT_REPLICA_UNCLASSIFIED" for i in issues)
+
+
+def test_is_window_safe_reflects_replica_findings(tmp_path: Path) -> None:
+    """is_window_safe() is the typed form of fraisier's presence rule (#154)."""
+    (tmp_path / "20260606120000_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    unsafe = replica_preflight_issues(tmp_path, has_replicas=False, bypass=False)
+    assert is_window_safe(unsafe) is False
+
+    safe_dir = tmp_path / "safe"
+    safe_dir.mkdir()
+    (safe_dir / "20260606120000_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    safe = replica_preflight_issues(safe_dir, has_replicas=False, bypass=False)
+    assert is_window_safe(safe) is True

--- a/tests/unit/test_replica_preflight.py
+++ b/tests/unit/test_replica_preflight.py
@@ -11,10 +11,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from confiture.core.linting.libraries.replica import (
-    is_window_safe,
-    replica_preflight_issues,
-)
+from confiture.core.linting.libraries.replica import replica_preflight_issues
+from confiture.core.preflight import is_window_safe, run_preflight
 
 
 def test_py_migration_emits_unclassified(tmp_path: Path) -> None:
@@ -52,14 +50,44 @@ def test_sql_only_dir_has_no_unclassified(tmp_path: Path) -> None:
     assert all(i.code != "PFLIGHT_REPLICA_UNCLASSIFIED" for i in issues)
 
 
-def test_is_window_safe_reflects_replica_findings(tmp_path: Path) -> None:
-    """is_window_safe() is the typed form of fraisier's presence rule (#154)."""
-    (tmp_path / "20260606120000_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
-    unsafe = replica_preflight_issues(tmp_path, has_replicas=False, bypass=False)
-    assert is_window_safe(unsafe) is False
+def _all_issues(migrations_dir: Path):
+    """The full preflight issue set the CLI builds: static + replica findings."""
+    static = run_preflight(migrations_dir).issues
+    replica = replica_preflight_issues(migrations_dir, has_replicas=False, bypass=False)
+    return static + replica
 
-    safe_dir = tmp_path / "safe"
-    safe_dir.mkdir()
-    (safe_dir / "20260606120000_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
-    safe = replica_preflight_issues(safe_dir, has_replicas=False, bypass=False)
-    assert is_window_safe(safe) is True
+
+def test_is_window_safe_false_on_replica_unsafe_op(tmp_path: Path) -> None:
+    """A replica-unsafe op (DROP COLUMN) makes the window unsafe (#154)."""
+    (tmp_path / "20260606120000_drop.up.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    (tmp_path / "20260606120000_drop.down.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    assert is_window_safe(_all_issues(tmp_path)) is False
+
+
+def test_is_window_safe_false_on_unreadable_py(tmp_path: Path) -> None:
+    """A `.py` migration the classifier can't read makes the window unsafe (#154)."""
+    (tmp_path / "20260606120000_data.py").write_text("def up(cur):\n    pass\n")
+    assert is_window_safe(_all_issues(tmp_path)) is False
+
+
+def test_is_window_safe_false_when_not_reversible(tmp_path: Path) -> None:
+    """A migration with no .down.sql folds into the verdict — unsafe down path (#154)."""
+    (tmp_path / "20260606120000_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    # no .down.sql sibling → PFLIGHT_MISSING_DOWN
+    assert is_window_safe(_all_issues(tmp_path)) is False
+
+
+def test_is_window_safe_false_when_non_transactional(tmp_path: Path) -> None:
+    """A non-transactional statement folds into the verdict — unsafe down path (#154)."""
+    (tmp_path / "20260606120000_idx.up.sql").write_text(
+        "CREATE INDEX CONCURRENTLY idx_t_c ON t (c);"
+    )
+    (tmp_path / "20260606120000_idx.down.sql").write_text("DROP INDEX idx_t_c;")
+    assert is_window_safe(_all_issues(tmp_path)) is False
+
+
+def test_is_window_safe_true_when_fully_certified(tmp_path: Path) -> None:
+    """Forward-compatible + reversible + transactional → window safe (#154)."""
+    (tmp_path / "20260606120000_add.up.sql").write_text("ALTER TABLE t ADD COLUMN c int;")
+    (tmp_path / "20260606120000_add.down.sql").write_text("ALTER TABLE t DROP COLUMN c;")
+    assert is_window_safe(_all_issues(tmp_path)) is True


### PR DESCRIPTION
## Description

Closes #154. Hardens the confiture↔fraisier blue-green **window-safety seam**.

fraisier's blue-green gate consumes `migrate preflight` to decide whether a
pending migration is forward-compatible for a two-version shared-DB cutover
window. This PR makes that decision a **pinned, typed, total contract** — and
matches the fraisier side the owner has already merged (per the #154 comments).

Released as **0.23.0**. Additive on the wire: a new top-level field + a new
warning + a new accessor; no exit code, existing field, or existing code value
changed.

## Type of Change
- [x] New feature
- [x] Documentation
- [ ] Bug fix
- [ ] Breaking change

## What landed

**1 — Pin the `PFLIGHT_REPLICA_*` namespace.** `replica_lint_codes()` is the
single source for the emittable set; `tests/contract/test_fraisier_adapter_surface.py`
pins it against a hardcoded literal, so a rename fails confiture CI instead of
silently disarming the gate. Documented as a stability commitment.

**2 — Close the `.py` "can't-see" blind spot.** `migrate preflight` emits a
`PFLIGHT_REPLICA_UNCLASSIFIED` **warning** for every non-SQL `.py` migration the
SQL classifier cannot read.

**3 — Top-level, total `window_safe` verdict.** The structured report gains a
**top-level** boolean `window_safe`:

```json
{ "ok": true, "window_safe": true, "summary": { ... }, "issues": [ ... ] }
```

`window_safe == true` iff confiture certifies **every** checked migration is
forward-compatible for a two-version window. It is `false` when any
`PFLIGHT_REPLICA_*` finding is present (a replica-unsafe op **or** an unreadable
`.py` migration). Because fraisier dropped its own prefix-matching and
`.py`-refusal nets, this is the **whole** window-safety contract.

Window-safety is **forward-compatibility only, not atomicity**: reversibility
(`PFLIGHT_MISSING_DOWN`) and transactionality (`PFLIGHT_NON_TRANSACTIONAL`) are
still reported as issues but do **not** gate the verdict — in a blue-green
cutover, rollback is a traffic swap-back to the still-hot old version (no DB
rollback). So a non-transactional `CREATE INDEX CONCURRENTLY`, the canonical
online-migration op, reads `window_safe == true`.

fraisier consumes it as `Option<bool>`: `Some(true)` → allow, `Some(false)` →
block, **absent → block (fail-safe)**. Pinned in both JSON schemas and the
contract test. (`ok` cannot substitute — replica findings are warn-by-default, so
`ok == true` can coincide with `window_safe == false`.)

## Checklist
- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff format`)
- [x] Lint + type checking pass (`uv run ruff check` / `uv run ty check`)
- [x] Documentation updated (adapter contract, error-codes, JSON schemas)
- [x] CHANGELOG updated (0.23.0)

## Verification
- **7649 passed / 75 skipped** — unit + integration + contract + e2e
- ruff + ruff-format + ty clean

## Related Issues
Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
