### PR TITLE
feat(#156): parallel-test-friendly schema provisioning (0.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-06-08
+
+Turns three pieces of hand-rolled, every-confiture-project-reinvents-it plumbing
+into reusable, Dagger-cacheable confiture capabilities for parallel-test CI
+(issue #156). **Purely additive** — every change is a new flag, command, fixture,
+or config field; no exit code, existing field, or existing behaviour changed.
+
+This is a **CI-path** capability (developer/CI tooling), not the deploy ops-path:
+the fraisier adapter contract is unaffected.
+
+### Added
+
+- **`confiture build --dump <path> [--dump-format custom|directory]`** emits a
+  content-addressed `pg_dump -Fc`/`-Fd` artifact restorable by the existing
+  three-phase `confiture restore`. The schema (+ seeds) is built into an
+  **ephemeral throwaway database** and dumped from there, so the artifact content
+  always matches the `db/` hash that names it — never a drifted live database.
+  The filename embeds env + seed-profile + schema hash, so an unchanged `db/` is
+  a cache hit (skipped no-op) and slim/full dumps never collide. `BuildResult`
+  gains `artifact_path` / `artifact_hash`. This lets CI cache schema provisioning
+  by `db/` hash instead of treating schema-apply as an uncacheable live-DB side
+  effect.
+- **`confiture test-db`** group — a CI-callable provisioning primitive:
+  `provision-template` (build/apply or `--from-artifact` restore + stamp the
+  `db/` hash), `clone` (lock-free `CREATE DATABASE … WITH TEMPLATE`), `drop`,
+  `status` (exit 0 current / 1 stale-or-absent), `list`, and `prune` (reap clones
+  leaked by crashed workers). Template staleness is recorded as a
+  `COMMENT ON DATABASE` and read connection-free from the maintenance DB, so a
+  status check never connects to the template and never races a concurrent clone;
+  the comment also marks confiture-managed databases so `drop` refuses to
+  fat-finger an unrelated database. Concurrent clones retry on "source database
+  is being accessed". DB identifiers are always quoted via `psycopg.sql.Identifier`.
+- **Per-worker pytest-xdist fixtures** in `confiture.testing.pytest_plugin`
+  (`confiture_template_db`, `confiture_worker_db`, plus override-able config
+  fixtures): each xdist worker gets its own database cloned from a shared template
+  built once per session (single-flight via a PostgreSQL advisory lock). The
+  **primary** integration surface is the import-time helper
+  `confiture.testing.worker_db.resolve_worker_db_url`, callable from a consumer's
+  `conftest.py` **before** the app freezes its settings/pool singleton (a fixture
+  runs too late for that); the fixture is convenience for apps that read their URL
+  lazily. `pytest-xdist` added to the `[testing]` extra.
+- **Declarative slim seed profiles** — `seed.profiles.<name>` (include/exclude
+  filename globs) in env config, surfaced on `seed apply --profile`,
+  `build --sequential --seed-profile`, and `test-db provision-template
+  --seed-profile`. Lets CI apply a lean test seed (e.g. excluding large
+  ETL-statistics partitions) for faster, higher-parallel test databases. Absent
+  profile ⇒ apply-all behaviour unchanged; an unknown name exits 5 listing the
+  defined profiles.
+
+### Security
+
+- `test-db clone --format json` redacts any DSN password (`***`) in the emitted
+  `target_url`, so connection credentials never leak to stdout / CI logs.
+
 ## [0.23.0] - 2026-06-06
 
 Hardens the confiture↔fraisier blue-green seam (issue #154): the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.23.0
-**Last Updated**: 2026-06-06
+**Version**: 0.24.0
+**Last Updated**: 2026-06-08
 **Current Status**: Production-Ready
 
 > **Status**: Production-ready. Actively used in production since March 2026.
@@ -925,8 +925,8 @@ When stuck, ask:
 
 ---
 
-**Last Updated**: 2026-06-06
-**Version**: 0.23.0
+**Last Updated**: 2026-06-08
+**Version**: 0.24.0
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ with Migrator.from_config("db/environments/prod.yaml") as m:
 **Guides**
 - [Build from DDL](docs/guides/01-build-from-ddl.md)
 - [Incremental Migrations](docs/guides/02-incremental-migrations.md) — `up`, `down`, rollback.
+- [Parallel, cacheable CI provisioning](docs/guides/parallel-ci-provisioning.md) — `build --dump` artifacts, `test-db` template/clone, per-worker xdist fixtures, slim seed profiles.
 - [Production Data Sync](docs/guides/03-production-sync.md)
 - [Zero-Downtime Migrations](docs/guides/04-schema-to-schema.md)
 - [Dry-Run + Preflight](docs/guides/dry-run.md)

--- a/docs/guides/parallel-ci-provisioning.md
+++ b/docs/guides/parallel-ci-provisioning.md
@@ -1,0 +1,203 @@
+# Parallel, cacheable CI provisioning
+
+Three confiture capabilities turn the slow, serial "apply the schema on every CI
+run" step into a cached, parallel one. They compose, but each is useful alone:
+
+| Capability | What it gives you | Command / API |
+|---|---|---|
+| **Cacheable artifact** | A content-addressed `pg_dump -Fc` of a fully-built DB, cached by `db/` hash | `confiture build --dump` + `confiture restore` |
+| **Template / clone primitive** | Build a template once, hand out lock-free per-worker clones | `confiture test-db …` |
+| **Per-worker fixtures** | Each pytest-xdist worker gets its own isolated database | `confiture.testing` fixtures |
+| **Slim seed profile** | Apply a lean subset of seeds for fast, RAM-cheap clones | `seed.profiles.<name>` |
+
+> This is a **CI-path** capability — developer/CI tooling. It is independent of
+> the confiture-at-deploy-time path (the fraisier adapter contract is unaffected).
+
+---
+
+## 1. Cacheable build artifacts
+
+`confiture build --dump` builds your schema (and seeds) into an **ephemeral
+throwaway database**, then `pg_dump -Fc`s it to a content-addressed file:
+
+```bash
+confiture build --env test --database-url "$PG_SERVER_URL" \
+  --dump db/generated/            # a directory → auto-named by hash
+# → db/generated/schema_test.full.ab12cd34ef56.pgdump
+```
+
+Because the dump comes from a freshly-built ephemeral DB (not a live database
+that may have drifted), the artifact's content always matches the `db/` hash in
+its name. An unchanged `db/` resolves to the same filename — so the dump is a
+**no-op cache hit**, and Dagger/BuildKit caches the whole step by `db/` hash
+instead of treating schema-apply as an uncacheable live-DB side effect.
+
+Restore it — in parallel — with the three-phase restorer:
+
+```bash
+createdb app_ci   # pg_restore needs the target to exist
+confiture restore db/generated/schema_test.full.ab12cd34ef56.pgdump \
+  --database app_ci --jobs 8 --no-owner --no-acl
+```
+
+Use `--dump-format directory` for `-Fd` (parallel *dump* as well as restore).
+
+> **Version skew:** a `-Fc`/`-Fd` archive produced by a newer `pg_dump` will not
+> restore under an older `pg_restore`. Build and restore the artifact with
+> **matching** PostgreSQL client major versions (pin the same client image in CI).
+
+---
+
+## 2. The `test-db` primitive
+
+Build a template once, then clone it per worker:
+
+```bash
+# Build (or refresh) the template from db/schema (+ seeds), stamping the db/ hash.
+confiture test-db provision-template --env test --template app_tmpl
+#   …or restore a P1 artifact instead of applying DDL:
+confiture test-db provision-template --template app_tmpl \
+  --from-artifact db/generated/schema_test.full.ab12cd34ef56.pgdump
+
+# Is the template still current? exit 0 = current, 1 = stale/absent.
+confiture test-db status --env test --template app_tmpl || \
+  confiture test-db provision-template --env test --template app_tmpl
+
+confiture test-db clone --template app_tmpl --target app_gw0   # ~1s
+confiture test-db drop  --target app_gw0
+confiture test-db prune --template app_tmpl    # reap clones leaked by crashed workers
+confiture test-db list                         # all confiture-managed DBs
+```
+
+Staleness is stored as a `COMMENT ON DATABASE` on the template and read
+connection-free from the maintenance database, so `status` never connects to the
+template and never races a concurrent clone. The same comment marks
+confiture-managed databases, so `drop` refuses to remove a database it did not
+create (pass `--force` to override).
+
+---
+
+## 3. Per-worker pytest-xdist fixtures
+
+> ⚠️ **The import-order seam — read this first.** An xdist worker resolves its
+> database name from `PYTEST_XDIST_WORKER`, but a *fixture* runs at test time —
+> **too late** for an application that freezes a `Settings()` / connection-pool
+> singleton at *module import*. If your app does that, the supported integration
+> is the **import-time helper**, called from `conftest.py` before the app is
+> imported:
+
+```python
+# conftest.py — runs before your app package is imported
+import os
+from confiture.testing.worker_db import resolve_worker_db_url
+
+os.environ["DATABASE_URL"] = resolve_worker_db_url(os.environ["DATABASE_URL"])
+# only now import anything that reads DATABASE_URL into a frozen singleton
+```
+
+For apps that read their URL lazily, the fixtures are convenience. Point them at
+your project and override the defaults as needed:
+
+```python
+# conftest.py
+import pytest
+from pathlib import Path
+
+@pytest.fixture(scope="session")
+def confiture_project_dir():
+    return Path(__file__).parent
+
+@pytest.fixture(scope="session")
+def confiture_template_name():
+    return "app_tmpl"
+
+def test_widgets(confiture_worker_db):          # yields this worker's DB URL
+    import psycopg
+    with psycopg.connect(confiture_worker_db) as conn:
+        ...
+```
+
+`confiture_template_db` builds the shared template exactly once even under
+`-n N` (single-flight via a PostgreSQL advisory lock); `confiture_worker_db`
+clones `{template}_db_gwN` for the running worker and drops it on teardown.
+
+Run it: `pytest -n auto` (requires the `[testing]` extra, which pulls in
+`pytest-xdist`).
+
+---
+
+## 4. Slim seed profiles
+
+A 1 GB ETL-statistics seed inflates apply time, clone time, and per-worker RAM
+(`6 × 1.3 GB ≈ 8 GB` caps your `-n`). Declare a lean subset in env config:
+
+```yaml
+# db/environments/test.yaml
+seed:
+  execution_mode: sequential
+  profiles:
+    slim:
+      exclude:
+        - "stats_*.sql"      # skip the heavy ETL-statistics partitions
+    core:
+      include:
+        - "core_*.sql"       # only the reference data
+```
+
+```bash
+confiture seed apply --sequential --env test --profile slim
+confiture build --sequential --env test --seed-profile slim --dump db/generated/
+confiture test-db provision-template --env test --template app_tmpl --seed-profile slim
+```
+
+Profile globs match seed **filenames** (discovery is top-level, non-recursive).
+An absent profile keeps today's apply-all behaviour; an unknown name exits 5
+listing the defined profiles. The artifact filename carries the profile segment
+(`schema_test.slim.<hash>.pgdump`) so slim and full dumps never collide.
+
+> Tip: run a **slim** seed for the fast parallel unit/integration lanes and the
+> **full** seed for the stat/dashboard suites — a seed-by-tier split.
+
+---
+
+## Putting it together (Dagger / GitHub Actions)
+
+```python
+# A two-lane CI: build the artifact once (cached by db/ hash), restore per lane.
+SERVER = "postgresql://postgres@db:5432/postgres"
+
+# 1) Build the cached artifact — a no-op when db/ is unchanged.
+build = base.with_exec([
+    "confiture", "build", "--env", "test", "--database-url", SERVER,
+    "--seed-profile", "slim", "--dump", "db/generated/",
+])
+
+# 2) Parallel lane: provision a template from the artifact, then `pytest -n auto`
+#    (the fixtures clone one DB per worker).
+parallel = build.with_exec([
+    "confiture", "test-db", "provision-template", "--env", "test",
+    "--template", "app_tmpl", "--from-artifact", ARTIFACT,
+]).with_exec(["pytest", "-n", "auto"])
+```
+
+### Server tuning (your responsibility, not confiture's)
+
+For the *ephemeral CI* PostgreSQL only, these unsafe-but-fast settings make
+template builds and clones cheaper. confiture **documents** them; it never sets
+them — they are PostgreSQL server configuration:
+
+```
+fsync = off
+synchronous_commit = off
+full_page_writes = off
+```
+
+Never use these on a database whose data you care about.
+
+---
+
+## See also
+
+- [`confiture restore`](../reference/cli.md) — the three-phase parallel restorer
+- [Build from DDL](./01-build-from-ddl.md) — Medium 1
+- [Prep-seed validation](./prep-seed-validation.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -283,6 +283,42 @@ confiture build --env legacy --no-validate-comments --no-fail-on-unclosed --no-f
 
 ---
 
+## `confiture build --dump` (cacheable artifact)
+
+`confiture build` also emits a content-addressed `pg_dump` artifact for fast,
+cached CI provisioning:
+
+| Option | Description |
+|---|---|
+| `--dump <path>` | Also write a `pg_dump` artifact. A directory auto-names `schema_{env}.{profile}.{hash}.pgdump` inside it (cache by `db/` hash); a file path is used verbatim. Requires a server URL (`--database-url` or env). |
+| `--dump-format custom\|directory` | `custom` = `-Fc` (default), `directory` = `-Fd` (parallel dump). |
+| `--seed-profile <name>` | Apply only the named seed profile (see `seed.profiles`) during `--sequential` seed application and `--dump`. |
+
+The artifact is restorable by [`confiture restore`](#confiture-restore). See the
+[Parallel CI provisioning guide](../guides/parallel-ci-provisioning.md).
+
+---
+
+## `confiture test-db`
+
+CI-path primitive for parallel-test database provisioning: build a template once,
+hand out lock-free per-worker clones. See the
+[Parallel CI provisioning guide](../guides/parallel-ci-provisioning.md).
+
+| Subcommand | Description | Exit codes |
+|---|---|---|
+| `provision-template --template <name> [--env] [--from-artifact <path>] [--seed-profile <name>] [--force]` | Build/apply (or restore an artifact) into a template DB and stamp its `db/` hash. | 0 ok; 5 bad input/refused clobber; 4 build/restore failed |
+| `clone --template <src> --target <dst>` | Clone via `CREATE DATABASE … WITH TEMPLATE` (retries while the source is in use). `--format json` redacts DSN passwords in `target_url`. | 0 ok; 4 clone failed |
+| `drop --target <name> [--force]` | Drop a confiture-managed clone/template (refuses unmanaged DBs without `--force`). | 0 ok; 5 refused |
+| `status --template <name> [--env]` | Report staleness vs the current `db/` hash. | **0 current; 1 stale/absent** |
+| `list` | List confiture-managed templates and clones. | 0 |
+| `prune --template <name>` | Drop every clone of a template (reap leaked clones). | 0 |
+
+All accept `--database-url` (else the env config supplies the server URL),
+`--env`, `--project-dir`, and `--format text\|json`.
+
+---
+
 ## `confiture sync`
 
 Copy data from a production database to a local/staging target (Medium 3), with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ testing = [
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
     "pytest-json-report>=1.5.0",
+    "pytest-xdist>=3.0.0",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.23.0"
+version = "0.24.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/schema.py
+++ b/python/confiture/cli/commands/schema.py
@@ -19,6 +19,7 @@ from confiture.core.error_handler import handle_cli_error, print_error_to_consol
 from confiture.core.introspector import SchemaIntrospector
 from confiture.core.linting import SchemaLinter
 from confiture.core.linting.schema_linter import LintConfig as LinterConfig
+from confiture.core.schema_artifact import build_schema_artifact, default_artifact_path
 from confiture.core.seed_applier import SeedApplier
 from confiture.exceptions import ConfigurationError, SchemaError, SeedError
 
@@ -272,6 +273,21 @@ def build(
             "Save structured build report (JSON/CSV) to file (default: stdout). "
             "Distinct from --output/-o, which is the generated *schema* file."
         ),
+    ),
+    dump: Path = typer.Option(
+        None,
+        "--dump",
+        help=(
+            "Also emit a content-addressed pg_dump -Fc artifact restorable by "
+            "'confiture restore'. Pass a file path, or an existing directory to "
+            "auto-name 'schema_{env}.{profile}.{hash}.pgdump' inside it (cache by db/ hash)."
+        ),
+    ),
+    dump_format: str = typer.Option(
+        "custom",
+        "--dump-format",
+        help="Artifact format for --dump: custom (-Fc) or directory (-Fd, parallel). "
+        "Default: custom.",
     ),
 ) -> None:
     """Build complete schema from DDL files in one fast operation.
@@ -537,6 +553,72 @@ def build(
                 output_file=report_output,
             )
 
+        # Emit a cacheable pg_dump artifact when --dump is given. The schema is
+        # built into an ephemeral throwaway database and dumped from there, so
+        # the artifact content always matches the db/ hash that names it.
+        artifact_path_str: str | None = None
+        artifact_hash_str: str | None = None
+        if dump is not None:
+            if dump_format not in ("custom", "directory"):
+                fail(
+                    ConfigurationError(
+                        f"Invalid dump format: {dump_format}. Use custom or directory.",
+                        resolution_hint="Pass --dump-format custom or directory.",
+                    ),
+                    json_mode=is_json(format_type),
+                    output_file=report_output,
+                )
+
+            server_url = database_url or builder.env_config.database_url
+            if not server_url:
+                fail(
+                    ConfigurationError(
+                        "--dump requires a database server URL to build the ephemeral "
+                        "dump database.",
+                        error_code="CONFIG_010",
+                        resolution_hint="Provide --database-url or set it in the environment "
+                        "config.",
+                    ),
+                    json_mode=is_json(format_type),
+                    output_file=report_output,
+                )
+
+            if schema_hash is None:
+                schema_hash = builder.compute_hash()
+
+            if dump.is_dir() or str(dump).endswith("/"):
+                artifact_out = default_artifact_path(
+                    dump, env, schema_hash, dump_format=dump_format
+                )
+            else:
+                artifact_out = dump
+
+            # Schema-only DDL plus seed files, applied into the ephemeral DB.
+            artifact_schema_sql = builder.build(schema_only=True)
+            if schema_only:
+                artifact_seed_files: list[Path] | None = None
+            else:
+                _schema_files, seed_paths = builder.categorize_sql_files()
+                artifact_seed_files = seed_paths or None
+
+            artifact_result = build_schema_artifact(
+                server_url=server_url,
+                schema_sql=artifact_schema_sql,
+                output_path=artifact_out,
+                schema_hash=schema_hash,
+                seed_files=artifact_seed_files,
+                dump_format=dump_format,
+            )
+            artifact_path_str = str(artifact_result.artifact_path)
+            artifact_hash_str = artifact_result.artifact_hash
+            if format_type == "text":
+                if artifact_result.skipped:
+                    console.print(
+                        f"[cyan]📦 Artifact up-to-date (cache hit): {artifact_path_str}[/cyan]"
+                    )
+                else:
+                    console.print(f"[green]📦 Artifact written: {artifact_path_str}[/green]")
+
         # Create and format build result
         from confiture.cli.formatters.build_formatter import format_build_result
         from confiture.models.results import BuildResult
@@ -549,6 +631,8 @@ def build(
             hash=schema_hash,
             execution_time_ms=0,  # Could track this if needed
             seed_files_applied=seed_files_applied,
+            artifact_path=artifact_path_str,
+            artifact_hash=artifact_hash_str,
         )
 
         # Format and output result

--- a/python/confiture/cli/commands/schema.py
+++ b/python/confiture/cli/commands/schema.py
@@ -289,6 +289,12 @@ def build(
         help="Artifact format for --dump: custom (-Fc) or directory (-Fd, parallel). "
         "Default: custom.",
     ),
+    seed_profile: str | None = typer.Option(
+        None,
+        "--seed-profile",
+        help="Apply only the named seed profile (seed.profiles.<name>) during "
+        "--sequential seed application and --dump. Unknown name → exit 5.",
+    ),
 ) -> None:
     """Build complete schema from DDL files in one fast operation.
 
@@ -425,6 +431,14 @@ def build(
             output_dir.mkdir(parents=True, exist_ok=True)
             output = output_dir / f"schema_{env}.sql"
 
+        # Resolve a named seed profile from env config (unknown → exit 5).
+        seed_profile_obj = None
+        if seed_profile is not None:
+            try:
+                seed_profile_obj = builder.env_config.seed.get_profile(seed_profile)
+            except Exception as e:
+                fail(e, json_mode=is_json(format_type), output_file=report_output)
+
         # Determine if we should apply seeds sequentially
         apply_sequential = sequential or (
             builder.env_config.seed and builder.env_config.seed.execution_mode == "sequential"
@@ -504,7 +518,9 @@ def build(
                         connection=connection,
                         console=console,
                     )
-                    result = applier.apply_sequential(continue_on_error=continue_on_error)
+                    result = applier.apply_sequential(
+                        continue_on_error=continue_on_error, profile=seed_profile_obj
+                    )
 
                     seed_files_applied = result.succeeded
                     console.print(f"[green]✅ Applied {result.succeeded} seed files[/green]")
@@ -588,7 +604,7 @@ def build(
 
             if dump.is_dir() or str(dump).endswith("/"):
                 artifact_out = default_artifact_path(
-                    dump, env, schema_hash, dump_format=dump_format
+                    dump, env, schema_hash, profile=seed_profile, dump_format=dump_format
                 )
             else:
                 artifact_out = dump
@@ -599,6 +615,10 @@ def build(
                 artifact_seed_files: list[Path] | None = None
             else:
                 _schema_files, seed_paths = builder.categorize_sql_files()
+                if seed_profile_obj is not None:
+                    from confiture.core.seed_applier import _apply_profile_filter
+
+                    seed_paths = _apply_profile_filter(seed_paths, seed_profile_obj)
                 artifact_seed_files = seed_paths or None
 
             artifact_result = build_schema_artifact(
@@ -633,6 +653,7 @@ def build(
             seed_files_applied=seed_files_applied,
             artifact_path=artifact_path_str,
             artifact_hash=artifact_hash_str,
+            seed_profile=seed_profile,
         )
 
         # Format and output result

--- a/python/confiture/cli/formatters/build_formatter.py
+++ b/python/confiture/cli/formatters/build_formatter.py
@@ -40,6 +40,8 @@ def format_build_result(
                 ["hash", result.hash or ""],
                 ["execution_time_ms", str(result.execution_time_ms)],
                 ["seed_files_applied", str(result.seed_files_applied)],
+                ["artifact_path", result.artifact_path or ""],
+                ["artifact_hash", result.artifact_hash or ""],
             ],
         )
         handle_output(format_type, result.to_dict(), csv_data, output_path, console)
@@ -61,6 +63,8 @@ def format_text(result: BuildResult, console: Console) -> None:
             console.print(f"🔐 Hash: {result.hash}")
         if result.seed_files_applied > 0:
             console.print(f"🌱 Seeds: {result.seed_files_applied} files applied")
+        if result.artifact_path:
+            console.print(f"📦 Artifact: {result.artifact_path}")
         if result.execution_time_ms > 0:
             console.print(f"⏱️ Time: {result.execution_time_ms}ms")
         if result.warnings:

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -464,6 +464,31 @@ def _output_json(data: dict[str, Any], output_file: Path | None, console: Consol
         print(json_str)
 
 
+def redact_url(url: str) -> str:
+    """Return *url* with any password replaced by ``***`` (username preserved).
+
+    Use before emitting a connection URL into JSON output or logs so DSN
+    credentials never leak to stdout / CI artifacts.
+
+    Args:
+        url: A connection URL that may embed a password.
+
+    Returns:
+        The URL with its password redacted (unchanged if there is none).
+    """
+    from urllib.parse import urlparse, urlunparse
+
+    parsed = urlparse(url)
+    if not parsed.password:
+        return url
+    host_part = parsed.hostname or ""
+    if parsed.port:
+        host_part = f"{host_part}:{parsed.port}"
+    if parsed.username:
+        host_part = f"{parsed.username}:***@{host_part}"
+    return urlunparse(parsed._replace(netloc=host_part))
+
+
 def _find_orphaned_sql_files(migrations_dir: Path) -> list[Path]:
     """Find .sql files that don't match the expected naming pattern.
 

--- a/python/confiture/cli/main.py
+++ b/python/confiture/cli/main.py
@@ -52,6 +52,7 @@ from confiture.cli.helpers import console
 from confiture.cli.schema_to_schema import schema_to_schema_app
 from confiture.cli.seed import seed_app
 from confiture.cli.sync import sync
+from confiture.cli.test_db import test_db_app
 
 # Valid output formats for linting
 LINT_FORMATS = ("table", "json", "csv")
@@ -109,6 +110,9 @@ app.add_typer(coordinate_app, name="coordinate")
 
 # Add seed subcommand group (seed validation)
 app.add_typer(seed_app, name="seed")
+
+# Add test-db subcommand group (CI template/clone provisioning)
+app.add_typer(test_db_app, name="test-db")
 
 # Add mcp subcommand group (MCP server)
 app.add_typer(mcp_app, name="mcp")

--- a/python/confiture/cli/seed.py
+++ b/python/confiture/cli/seed.py
@@ -460,6 +460,11 @@ def apply(
             "back-compat alias for --output/-o (DOCS-M2)."
         ),
     ),
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        help="Apply only the named seed profile (seed.profiles.<name> in env config).",
+    ),
 ) -> None:
     """Load seed data into the database.
 
@@ -525,6 +530,16 @@ def apply(
                 output_file=report_output,
             )
 
+        # Resolve a named seed profile (before connecting): unknown → exit 5.
+        seed_profile = None
+        if profile is not None:
+            from confiture.config.environment import Environment
+
+            try:
+                seed_profile = Environment.load(env).seed.get_profile(profile)
+            except Exception as e:
+                fail(e, json_mode=is_json(format_type), output_file=report_output)
+
         # Get database connection
         if database_url:
             # Use provided URL directly
@@ -577,7 +592,9 @@ def apply(
                 result = applier.apply_sequential(
                     continue_on_error=continue_on_error,
                     progress=progress,
+                    profile=seed_profile,
                 )
+            result.seed_profile = profile
 
             # Format output
             from confiture.cli.formatters.seed_formatter import format_apply_result

--- a/python/confiture/cli/test_db.py
+++ b/python/confiture/cli/test_db.py
@@ -1,0 +1,207 @@
+"""``confiture test-db``: provision isolated template/clone test databases.
+
+A CI-path primitive (not the deploy ops-path). Composable subcommands a Dagger /
+GitHub Actions / local script calls directly to build a template once and hand
+out lock-free per-worker clones.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from confiture.cli.error_json import fail
+from confiture.cli.helpers import _output_json, console, is_json
+from confiture.config.environment import Environment
+from confiture.core.builder import SchemaBuilder
+from confiture.core.test_db import TemplateState, TestDbProvisioner
+
+test_db_app = typer.Typer(
+    help="Provision isolated template/clone test databases for parallel CI."
+)
+
+
+def _resolve_server_url(database_url: str | None, env: str, project_dir: Path) -> str:
+    """Resolve the PG server URL from --database-url or the environment config."""
+    if database_url:
+        return database_url
+    return Environment.load(env, project_dir).database_url
+
+
+@test_db_app.command("provision-template")
+def provision_template(
+    template: str = typer.Option(..., "--template", help="Template database name."),
+    env: str = typer.Option("local", "--env", "-e", help="Environment to build."),
+    project_dir: Path = typer.Option(Path("."), "--project-dir", help="Project directory."),
+    from_artifact: Path = typer.Option(
+        None,
+        "--from-artifact",
+        help="Restore a pg_dump -Fc/-Fd artifact (from 'build --dump') instead of "
+        "applying DDL.",
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Replace a same-named database even if not confiture-managed."
+    ),
+    database_url: str = typer.Option(
+        None, "--database-url", help="PG server URL (default: from env config)."
+    ),
+    format_type: str = typer.Option("text", "--format", "-f", help="text or json."),
+) -> None:
+    """Build (or restore) a template database and stamp its db/ content hash."""
+    try:
+        builder = SchemaBuilder(env=env, project_dir=project_dir)
+        schema_hash = builder.compute_hash()
+        server_url = database_url or builder.env_config.database_url
+        provisioner = TestDbProvisioner(server_url)
+
+        if from_artifact is not None:
+            status = provisioner.provision_template(
+                template, schema_hash=schema_hash, from_artifact=from_artifact, force=force
+            )
+        else:
+            schema_sql = builder.build(schema_only=True)
+            _schema_files, seed_files = builder.categorize_sql_files()
+            status = provisioner.provision_template(
+                template,
+                schema_hash=schema_hash,
+                schema_sql=schema_sql,
+                seed_files=seed_files or None,
+                force=force,
+            )
+
+        if is_json(format_type):
+            _output_json(status.to_dict(), None, console)
+        else:
+            console.print(
+                f"[green]✅ Template '{template}' provisioned ({status.state.value})[/green]"
+            )
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001 - routed through the fail() envelope boundary
+        fail(e, json_mode=is_json(format_type))
+
+
+@test_db_app.command("clone")
+def clone(
+    template: str = typer.Option(..., "--template", help="Source template database."),
+    target: str = typer.Option(..., "--target", help="Clone database name to create."),
+    env: str = typer.Option("local", "--env", "-e", help="Environment (for server URL)."),
+    project_dir: Path = typer.Option(Path("."), "--project-dir", help="Project directory."),
+    database_url: str = typer.Option(None, "--database-url", help="PG server URL."),
+    format_type: str = typer.Option("text", "--format", "-f", help="text or json."),
+) -> None:
+    """Clone a template into a fresh database via CREATE DATABASE … WITH TEMPLATE."""
+    try:
+        provisioner = TestDbProvisioner(_resolve_server_url(database_url, env, project_dir))
+        result = provisioner.clone(template, target)
+        if is_json(format_type):
+            _output_json(result.to_dict(), None, console)
+        else:
+            console.print(f"[green]✅ Cloned '{template}' → '{target}'[/green]")
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001 - fail() envelope boundary
+        fail(e, json_mode=is_json(format_type))
+
+
+@test_db_app.command("drop")
+def drop(
+    target: str = typer.Option(..., "--target", help="Database to drop."),
+    force: bool = typer.Option(
+        False, "--force", help="Drop even if not confiture-managed (use with care)."
+    ),
+    env: str = typer.Option("local", "--env", "-e", help="Environment (for server URL)."),
+    project_dir: Path = typer.Option(Path("."), "--project-dir", help="Project directory."),
+    database_url: str = typer.Option(None, "--database-url", help="PG server URL."),
+    format_type: str = typer.Option("text", "--format", "-f", help="text or json."),
+) -> None:
+    """Drop a confiture-managed clone or template (terminating its backends)."""
+    try:
+        provisioner = TestDbProvisioner(_resolve_server_url(database_url, env, project_dir))
+        dropped = provisioner.drop(target, force=force)
+        if is_json(format_type):
+            _output_json({"target": target, "dropped": dropped}, None, console)
+        elif dropped:
+            console.print(f"[green]✅ Dropped '{target}'[/green]")
+        else:
+            console.print(f"[yellow]ℹ '{target}' did not exist[/yellow]")
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001 - fail() envelope boundary
+        fail(e, json_mode=is_json(format_type))
+
+
+@test_db_app.command("status")
+def status(
+    template: str = typer.Option(..., "--template", help="Template database name."),
+    env: str = typer.Option("local", "--env", "-e", help="Environment to hash."),
+    project_dir: Path = typer.Option(Path("."), "--project-dir", help="Project directory."),
+    database_url: str = typer.Option(None, "--database-url", help="PG server URL."),
+    format_type: str = typer.Option("text", "--format", "-f", help="text or json."),
+) -> None:
+    """Report template staleness vs the current db/ hash (exit 0 current, 1 stale/absent)."""
+    try:
+        builder = SchemaBuilder(env=env, project_dir=project_dir)
+        current_hash = builder.compute_hash()
+        server_url = database_url or builder.env_config.database_url
+        provisioner = TestDbProvisioner(server_url)
+        result = provisioner.template_status(template, current_hash)
+
+        if is_json(format_type):
+            _output_json(result.to_dict(), None, console)
+        else:
+            console.print(f"Template '{template}': [bold]{result.state.value}[/bold]")
+
+        if result.state is not TemplateState.CURRENT:
+            raise typer.Exit(1)
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001 - fail() envelope boundary
+        fail(e, json_mode=is_json(format_type))
+
+
+@test_db_app.command("list")
+def list_databases(
+    env: str = typer.Option("local", "--env", "-e", help="Environment (for server URL)."),
+    project_dir: Path = typer.Option(Path("."), "--project-dir", help="Project directory."),
+    database_url: str = typer.Option(None, "--database-url", help="PG server URL."),
+    format_type: str = typer.Option("text", "--format", "-f", help="text or json."),
+) -> None:
+    """List confiture-managed templates and clones on the server."""
+    try:
+        provisioner = TestDbProvisioner(_resolve_server_url(database_url, env, project_dir))
+        databases = provisioner.list_databases()
+        if is_json(format_type):
+            _output_json({"databases": [d.to_dict() for d in databases]}, None, console)
+        elif databases:
+            for db in databases:
+                console.print(f"  {db.kind:9} {db.name}  ({db.detail})")
+        else:
+            console.print("[yellow]ℹ No confiture-managed databases found[/yellow]")
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001 - fail() envelope boundary
+        fail(e, json_mode=is_json(format_type))
+
+
+@test_db_app.command("prune")
+def prune(
+    template: str = typer.Option(..., "--template", help="Template whose clones to drop."),
+    env: str = typer.Option("local", "--env", "-e", help="Environment (for server URL)."),
+    project_dir: Path = typer.Option(Path("."), "--project-dir", help="Project directory."),
+    database_url: str = typer.Option(None, "--database-url", help="PG server URL."),
+    format_type: str = typer.Option("text", "--format", "-f", help="text or json."),
+) -> None:
+    """Drop every clone of a template (reaps clones leaked by crashed workers)."""
+    try:
+        provisioner = TestDbProvisioner(_resolve_server_url(database_url, env, project_dir))
+        dropped = provisioner.prune(template)
+        if is_json(format_type):
+            _output_json({"template": template, "dropped": dropped}, None, console)
+        else:
+            console.print(f"[green]✅ Pruned {len(dropped)} clone(s) of '{template}'[/green]")
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001 - fail() envelope boundary
+        fail(e, json_mode=is_json(format_type))

--- a/python/confiture/cli/test_db.py
+++ b/python/confiture/cli/test_db.py
@@ -40,6 +40,11 @@ def provision_template(
         help="Restore a pg_dump -Fc/-Fd artifact (from 'build --dump') instead of "
         "applying DDL.",
     ),
+    seed_profile: str = typer.Option(
+        None,
+        "--seed-profile",
+        help="Apply only the named seed profile (seed.profiles.<name>) on the DDL path.",
+    ),
     force: bool = typer.Option(
         False, "--force", help="Replace a same-named database even if not confiture-managed."
     ),
@@ -62,6 +67,11 @@ def provision_template(
         else:
             schema_sql = builder.build(schema_only=True)
             _schema_files, seed_files = builder.categorize_sql_files()
+            if seed_profile is not None:
+                from confiture.core.seed_applier import _apply_profile_filter
+
+                profile_obj = builder.env_config.seed.get_profile(seed_profile)
+                seed_files = _apply_profile_filter(seed_files, profile_obj)
             status = provisioner.provision_template(
                 template,
                 schema_hash=schema_hash,

--- a/python/confiture/cli/test_db.py
+++ b/python/confiture/cli/test_db.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import typer
 
 from confiture.cli.error_json import fail
-from confiture.cli.helpers import _output_json, console, is_json
+from confiture.cli.helpers import _output_json, console, is_json, redact_url
 from confiture.config.environment import Environment
 from confiture.core.builder import SchemaBuilder
 from confiture.core.test_db import TemplateState, TestDbProvisioner
@@ -106,7 +106,9 @@ def clone(
         provisioner = TestDbProvisioner(_resolve_server_url(database_url, env, project_dir))
         result = provisioner.clone(template, target)
         if is_json(format_type):
-            _output_json(result.to_dict(), None, console)
+            payload = result.to_dict()
+            payload["target_url"] = redact_url(payload["target_url"])  # no DSN creds in logs
+            _output_json(payload, None, console)
         else:
             console.print(f"[green]✅ Cloned '{template}' → '{target}'[/green]")
     except typer.Exit:

--- a/python/confiture/cli/test_db.py
+++ b/python/confiture/cli/test_db.py
@@ -17,9 +17,7 @@ from confiture.config.environment import Environment
 from confiture.core.builder import SchemaBuilder
 from confiture.core.test_db import TemplateState, TestDbProvisioner
 
-test_db_app = typer.Typer(
-    help="Provision isolated template/clone test databases for parallel CI."
-)
+test_db_app = typer.Typer(help="Provision isolated template/clone test databases for parallel CI.")
 
 
 def _resolve_server_url(database_url: str | None, env: str, project_dir: Path) -> str:
@@ -37,8 +35,7 @@ def provision_template(
     from_artifact: Path = typer.Option(
         None,
         "--from-artifact",
-        help="Restore a pg_dump -Fc/-Fd artifact (from 'build --dump') instead of "
-        "applying DDL.",
+        help="Restore a pg_dump -Fc/-Fd artifact (from 'build --dump') instead of applying DDL.",
     ),
     seed_profile: str = typer.Option(
         None,

--- a/python/confiture/config/environment.py
+++ b/python/confiture/config/environment.py
@@ -147,6 +147,24 @@ class BuildConfig(BaseModel):
     lint: BuildLintConfig = Field(default_factory=BuildLintConfig)
 
 
+class SeedProfile(BaseModel):
+    """A named subset of seed files, selected by glob patterns.
+
+    Patterns match seed *filenames* (seed discovery is top-level, non-recursive).
+    Selection is include-then-exclude: an empty ``include`` starts from all
+    files; ``exclude`` then removes matches. Lets CI apply a lean test seed
+    (e.g. excluding large ETL-statistics partitions) for faster, higher-parallel
+    test databases.
+
+    Attributes:
+        include: Globs a file must match to be included (empty = all files).
+        exclude: Globs that remove an otherwise-included file.
+    """
+
+    include: list[str] = Field(default_factory=list)
+    exclude: list[str] = Field(default_factory=list)
+
+
 class SeedConfig(BaseModel):
     """Seed data application configuration.
 
@@ -158,11 +176,37 @@ class SeedConfig(BaseModel):
         execution_mode: Execution strategy ("concatenate" | "sequential")
         continue_on_error: Continue applying files if one fails (default: False)
         transaction_mode: Transaction isolation ("savepoint" | "transaction")
+        profiles: Named seed subsets (see :class:`SeedProfile`). Absent ⇒ today's
+            apply-all behaviour is unchanged.
     """
 
     execution_mode: str = "concatenate"  # "concatenate" | "sequential"
     continue_on_error: bool = False
     transaction_mode: str = "savepoint"  # "savepoint" | "transaction"
+    profiles: dict[str, SeedProfile] = Field(default_factory=dict)
+
+    def get_profile(self, name: str) -> SeedProfile:
+        """Return the named seed profile, or raise a clear configuration error.
+
+        Args:
+            name: Profile name to resolve.
+
+        Returns:
+            The matching :class:`SeedProfile`.
+
+        Raises:
+            ConfigurationError: If no profile by that name is defined.
+        """
+        try:
+            return self.profiles[name]
+        except KeyError:
+            defined = ", ".join(sorted(self.profiles)) or "(none defined)"
+            raise ConfigurationError(
+                f"Unknown seed profile: {name!r}. Defined profiles: {defined}.",
+                error_code="CONFIG_010",
+                resolution_hint="Define it under seed.profiles.<name> in the environment "
+                "config, or omit --profile/--seed-profile.",
+            ) from None
 
 
 class LockingConfig(BaseModel):

--- a/python/confiture/core/schema_artifact.py
+++ b/python/confiture/core/schema_artifact.py
@@ -1,0 +1,231 @@
+"""Cacheable schema-artifact dumper (Medium 1, CI provisioning).
+
+Produces a content-addressed ``pg_dump -Fc`` (custom) or ``-Fd`` (directory)
+archive of a fully-built schema so that CI can cache schema provisioning by the
+``db/`` content hash instead of treating schema-apply as an uncacheable live-DB
+side effect, and restore it in parallel via the three-phase
+:class:`confiture.core.restorer.DatabaseRestorer`.
+
+The archive is produced by building the freshly-generated schema (plus optional
+seed files) into an **ephemeral throwaway database** and dumping *that*, so the
+artifact's content always matches the ``db/`` source whose hash names it — never
+a drifted live database.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg
+
+from confiture.core.seed_executor import SeedExecutor
+from confiture.core.temp_database import TempDatabase
+from confiture.exceptions import SchemaError
+
+# Supported pg_dump archive formats → the format flag and on-disk extension.
+_DUMP_FORMAT_FLAG = {"custom": "-Fc", "directory": "-Fd"}
+_DUMP_FORMAT_EXT = {"custom": "pgdump", "directory": "pgdir"}
+
+
+@dataclass
+class ArtifactResult:
+    """Outcome of an artifact build.
+
+    Attributes:
+        artifact_path: Path to the produced (or reused) archive.
+        artifact_hash: The ``db/`` content hash the artifact corresponds to.
+        dump_format: ``"custom"`` or ``"directory"``.
+        skipped: True if an up-to-date artifact already existed and the dump was
+            a no-op.
+        seed_files_applied: Number of seed files loaded into the ephemeral DB
+            before dumping.
+    """
+
+    artifact_path: Path
+    artifact_hash: str
+    dump_format: str
+    skipped: bool = False
+    seed_files_applied: int = 0
+
+
+def default_artifact_path(
+    output_dir: Path,
+    env: str,
+    schema_hash: str,
+    *,
+    profile: str | None = None,
+    dump_format: str = "custom",
+) -> Path:
+    """Build the content-addressed default artifact path.
+
+    The filename embeds the environment, the seed-profile name, and the first 12
+    characters of the schema content hash, so that an unchanged ``db/`` resolves
+    to the same path (cache hit) while a different schema *or* seed profile
+    resolves to a distinct one (no slim/full collision).
+
+    Args:
+        output_dir: Directory to place the artifact in.
+        env: Environment name.
+        schema_hash: Full schema content hash (``builder.compute_hash()``).
+        profile: Seed-profile name, or None for the full seed set.
+        dump_format: ``"custom"`` or ``"directory"``.
+
+    Returns:
+        The resolved artifact path.
+    """
+    profile_seg = profile or "full"
+    ext = _DUMP_FORMAT_EXT.get(dump_format, _DUMP_FORMAT_EXT["custom"])
+    return Path(output_dir) / f"schema_{env}.{profile_seg}.{schema_hash[:12]}.{ext}"
+
+
+class SchemaArtifactDumper:
+    """Thin wrapper around ``pg_dump`` for custom/directory-format archives.
+
+    Args:
+        jobs: Parallel workers for directory-format dumps (ignored for custom
+            format, which pg_dump cannot parallelise).
+    """
+
+    def __init__(self, *, jobs: int = 4) -> None:
+        self.jobs = jobs
+
+    def build_argv(
+        self, source_url: str, output_path: Path, dump_format: str = "custom"
+    ) -> list[str]:
+        """Construct the ``pg_dump`` argument list.
+
+        Args:
+            source_url: Connection URL of the database to dump.
+            output_path: Destination archive path.
+            dump_format: ``"custom"`` (-Fc) or ``"directory"`` (-Fd).
+
+        Returns:
+            Full argv list.
+
+        Raises:
+            SchemaError: If ``dump_format`` is not supported.
+        """
+        try:
+            fmt_flag = _DUMP_FORMAT_FLAG[dump_format]
+        except KeyError as e:
+            raise SchemaError(
+                f"Unsupported dump format: {dump_format!r}.",
+                resolution_hint="Use --dump-format custom or directory.",
+            ) from e
+
+        argv = ["pg_dump", fmt_flag]
+        if dump_format == "directory" and self.jobs > 1:
+            argv += ["-j", str(self.jobs)]
+        argv += ["-d", str(source_url), "-f", str(output_path)]
+        return argv
+
+    def dump(
+        self, source_url: str, output_path: Path, dump_format: str = "custom"
+    ) -> None:
+        """Run ``pg_dump`` to produce the archive.
+
+        Args:
+            source_url: Connection URL of the database to dump.
+            output_path: Destination archive path.
+            dump_format: ``"custom"`` or ``"directory"``.
+
+        Raises:
+            SchemaError: If ``pg_dump`` is missing or exits non-zero.
+        """
+        argv = self.build_argv(source_url, output_path, dump_format)
+        try:
+            result = subprocess.run(argv, capture_output=True, text=True, check=False)
+        except FileNotFoundError as e:
+            raise SchemaError(
+                "pg_dump not found on PATH. Install postgresql-client.",
+                resolution_hint="Ensure PostgreSQL client tools are installed and on PATH.",
+            ) from e
+
+        if result.returncode != 0:
+            stderr_tail = "\n".join((result.stderr or "").strip().splitlines()[-5:])
+            raise SchemaError(
+                f"pg_dump failed: {stderr_tail}",
+                resolution_hint="Check the connection URL and that the schema applied cleanly.",
+            )
+
+
+def _apply_seed_files(temp_url: str, seed_files: list[Path]) -> int:
+    """Apply seed files into the ephemeral database, each in its own savepoint.
+
+    Args:
+        temp_url: Connection URL of the ephemeral database.
+        seed_files: Ordered seed files to apply.
+
+    Returns:
+        The number of seed files applied.
+    """
+    with psycopg.connect(temp_url, autocommit=False) as conn:
+        executor = SeedExecutor(connection=conn)
+        for i, seed_file in enumerate(seed_files, 1):
+            executor.execute_file(seed_file, savepoint_name=f"sp_artifact_seed_{i:03d}")
+        conn.commit()
+    return len(seed_files)
+
+
+def build_schema_artifact(
+    *,
+    server_url: str,
+    schema_sql: str,
+    output_path: Path,
+    schema_hash: str,
+    seed_files: list[Path] | None = None,
+    dump_format: str = "custom",
+    dumper: SchemaArtifactDumper | None = None,
+) -> ArtifactResult:
+    """Build a content-addressed schema artifact via an ephemeral database.
+
+    If ``output_path`` already exists it is treated as an up-to-date cache hit
+    (the path is content-addressed by ``schema_hash``) and the dump is skipped.
+    Otherwise the schema (and any seed files) are applied into a throwaway
+    :class:`TempDatabase`, dumped, and the throwaway database is dropped.
+
+    Args:
+        server_url: PostgreSQL server URL; only its server component is used (the
+            database is ignored — an ephemeral DB is created on that server).
+        schema_sql: Fully-built schema DDL to apply.
+        output_path: Destination artifact path (content-addressed by the caller).
+        schema_hash: The ``db/`` content hash this artifact corresponds to.
+        seed_files: Optional ordered seed files to load before dumping.
+        dump_format: ``"custom"`` or ``"directory"``.
+        dumper: Injectable dumper (for testing); a default is created otherwise.
+
+    Returns:
+        :class:`ArtifactResult` describing the produced or reused artifact.
+
+    Raises:
+        SchemaError: If schema/seed application or the dump fails.
+    """
+    output_path = Path(output_path)
+    if output_path.exists():
+        return ArtifactResult(
+            artifact_path=output_path,
+            artifact_hash=schema_hash,
+            dump_format=dump_format,
+            skipped=True,
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    dumper = dumper or SchemaArtifactDumper()
+    seeds_applied = 0
+
+    temp_db = TempDatabase(server_url)
+    with temp_db as temp_url:
+        temp_db.apply_schema(temp_url, schema_sql)
+        if seed_files:
+            seeds_applied = _apply_seed_files(temp_url, seed_files)
+        dumper.dump(temp_url, output_path, dump_format)
+
+    return ArtifactResult(
+        artifact_path=output_path,
+        artifact_hash=schema_hash,
+        dump_format=dump_format,
+        skipped=False,
+        seed_files_applied=seeds_applied,
+    )

--- a/python/confiture/core/schema_artifact.py
+++ b/python/confiture/core/schema_artifact.py
@@ -18,9 +18,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-import psycopg
-
-from confiture.core.seed_executor import SeedExecutor
+from confiture.core.seed_applier import apply_seed_files
 from confiture.core.temp_database import TempDatabase
 from confiture.exceptions import SchemaError
 
@@ -151,24 +149,6 @@ class SchemaArtifactDumper:
             )
 
 
-def _apply_seed_files(temp_url: str, seed_files: list[Path]) -> int:
-    """Apply seed files into the ephemeral database, each in its own savepoint.
-
-    Args:
-        temp_url: Connection URL of the ephemeral database.
-        seed_files: Ordered seed files to apply.
-
-    Returns:
-        The number of seed files applied.
-    """
-    with psycopg.connect(temp_url, autocommit=False) as conn:
-        executor = SeedExecutor(connection=conn)
-        for i, seed_file in enumerate(seed_files, 1):
-            executor.execute_file(seed_file, savepoint_name=f"sp_artifact_seed_{i:03d}")
-        conn.commit()
-    return len(seed_files)
-
-
 def build_schema_artifact(
     *,
     server_url: str,
@@ -219,7 +199,7 @@ def build_schema_artifact(
     with temp_db as temp_url:
         temp_db.apply_schema(temp_url, schema_sql)
         if seed_files:
-            seeds_applied = _apply_seed_files(temp_url, seed_files)
+            seeds_applied = apply_seed_files(temp_url, seed_files)
         dumper.dump(temp_url, output_path, dump_format)
 
     return ArtifactResult(

--- a/python/confiture/core/schema_artifact.py
+++ b/python/confiture/core/schema_artifact.py
@@ -119,9 +119,7 @@ class SchemaArtifactDumper:
         argv += ["-d", str(source_url), "-f", str(output_path)]
         return argv
 
-    def dump(
-        self, source_url: str, output_path: Path, dump_format: str = "custom"
-    ) -> None:
+    def dump(self, source_url: str, output_path: Path, dump_format: str = "custom") -> None:
         """Run ``pg_dump`` to produce the archive.
 
         Args:

--- a/python/confiture/core/seed_applier.py
+++ b/python/confiture/core/seed_applier.py
@@ -6,14 +6,39 @@ sequentially (each in own savepoint) or concatenated (default behavior).
 
 from __future__ import annotations
 
+import fnmatch
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import psycopg
 from rich.console import Console
 
 from confiture.core.progress import ProgressManager
 from confiture.core.seed_executor import SeedExecutor
+
+if TYPE_CHECKING:
+    from confiture.config.environment import SeedProfile
+
+
+def _apply_profile_filter(files: list[Path], profile: SeedProfile) -> list[Path]:
+    """Filter *files* by a profile's include-then-exclude filename globs.
+
+    Order is preserved. Empty ``include`` means "start from all files".
+    """
+
+    def _matches_any(name: str, patterns: list[str]) -> bool:
+        return any(fnmatch.fnmatch(name, pat) for pat in patterns)
+
+    result: list[Path] = []
+    for path in files:
+        name = path.name
+        if profile.include and not _matches_any(name, profile.include):
+            continue
+        if profile.exclude and _matches_any(name, profile.exclude):
+            continue
+        result.append(path)
+    return result
 
 
 def apply_seed_files(connection_url: str, seed_files: list[Path]) -> int:
@@ -49,6 +74,7 @@ class ApplyResult:
     succeeded: int = 0
     failed: int = 0
     failed_files: list[str] = field(default_factory=list)
+    seed_profile: str | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization.
@@ -62,6 +88,7 @@ class ApplyResult:
             "failed": self.failed,
             "failed_files": self.failed_files,
             "success": self.failed == 0,
+            "seed_profile": self.seed_profile,
         }
 
 
@@ -95,24 +122,34 @@ class SeedApplier:
         self.connection = connection
         self.console = console or Console()
 
-    def find_seed_files(self) -> list[Path]:
-        """Discover and return sorted seed files.
+    def find_seed_files(self, profile: SeedProfile | None = None) -> list[Path]:
+        """Discover and return sorted seed files, optionally filtered by *profile*.
 
-        Returns SQL files in sorted order from seeds directory.
-        Non-SQL files are ignored.
+        Returns SQL files in sorted order from the (top-level, non-recursive)
+        seeds directory. Non-SQL files are ignored. When *profile* is None the
+        result is byte-identical to the historical apply-all behaviour.
+
+        Args:
+            profile: Optional seed profile selecting an include/exclude subset by
+                filename glob.
 
         Returns:
-            List of Path objects for SQL files in sorted order
+            List of Path objects for SQL files in sorted order.
         """
         if not self.seeds_dir.exists():
             return []
 
-        # Find all .sql files
+        # Find all .sql files (top-level only — globs match filenames)
         sql_files = sorted(self.seeds_dir.glob("*.sql"))
-        return sql_files
+        if profile is None:
+            return sql_files
+        return _apply_profile_filter(sql_files, profile)
 
     def apply_sequential(
-        self, continue_on_error: bool = False, progress: ProgressManager | None = None
+        self,
+        continue_on_error: bool = False,
+        progress: ProgressManager | None = None,
+        profile: SeedProfile | None = None,
     ) -> ApplyResult:
         """Apply seed files sequentially with savepoints.
 
@@ -122,6 +159,7 @@ class SeedApplier:
         Args:
             continue_on_error: Continue applying files if one fails
             progress: Optional ProgressManager for displaying progress
+            profile: Optional seed profile selecting a subset of files
 
         Returns:
             ApplyResult with tracking info
@@ -137,7 +175,7 @@ class SeedApplier:
             discover_task = progress.add_task("Discovering seed files...", total=None)
 
         # Discover seed files
-        files = self.find_seed_files()
+        files = self.find_seed_files(profile=profile)
         result = ApplyResult(total=len(files))
 
         if progress and discover_task is not None:

--- a/python/confiture/core/seed_applier.py
+++ b/python/confiture/core/seed_applier.py
@@ -9,10 +9,33 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import psycopg
 from rich.console import Console
 
 from confiture.core.progress import ProgressManager
 from confiture.core.seed_executor import SeedExecutor
+
+
+def apply_seed_files(connection_url: str, seed_files: list[Path]) -> int:
+    """Apply ordered seed files into the database at *connection_url*.
+
+    Each file runs inside its own savepoint for failure isolation. Used to load
+    seeds into ephemeral / template databases (artifact builds, test-db
+    provisioning) where no long-lived :class:`SeedApplier` is in play.
+
+    Args:
+        connection_url: Connection URL of the target database.
+        seed_files: Ordered seed files to apply.
+
+    Returns:
+        The number of seed files applied.
+    """
+    with psycopg.connect(connection_url, autocommit=False) as conn:
+        executor = SeedExecutor(connection=conn)
+        for i, seed_file in enumerate(seed_files, 1):
+            executor.execute_file(seed_file, savepoint_name=f"sp_seed_{i:03d}")
+        conn.commit()
+    return len(seed_files)
 
 
 @dataclass

--- a/python/confiture/core/temp_database.py
+++ b/python/confiture/core/temp_database.py
@@ -33,6 +33,44 @@ def _replace_dbname(server_url: str, dbname: str) -> str:
     return urlunparse(parsed._replace(path=f"/{dbname}"))
 
 
+def terminate_backends(conn: psycopg.Connection, db_name: str) -> None:
+    """Terminate all other sessions connected to *db_name*.
+
+    Needed before ``CREATE DATABASE … WITH TEMPLATE`` (PostgreSQL forbids cloning
+    a database that has other active sessions) and before dropping on PG < 13.
+
+    Args:
+        conn: An autocommit maintenance connection.
+        db_name: Database whose backends should be terminated.
+    """
+    conn.execute(
+        "SELECT pg_terminate_backend(pid) "
+        "FROM pg_stat_activity "
+        "WHERE datname = %s AND pid <> pg_backend_pid()",
+        (db_name,),
+    )
+
+
+def force_drop_database(conn: psycopg.Connection, db_name: str) -> None:
+    """Drop *db_name* if it exists, terminating any remaining backends first.
+
+    Uses ``DROP DATABASE … WITH (FORCE)`` on PostgreSQL >= 13, falling back to an
+    explicit :func:`terminate_backends` + plain ``DROP DATABASE`` on older
+    versions. The database name is quoted via :class:`psycopg.sql.Identifier`
+    (never string-interpolated).
+
+    Args:
+        conn: An autocommit maintenance connection.
+        db_name: Database to drop.
+    """
+    db_id = psycopg.sql.Identifier(db_name)
+    if conn.info.server_version >= 130000:
+        conn.execute(psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(db_id))
+    else:
+        terminate_backends(conn, db_name)
+        conn.execute(psycopg.sql.SQL("DROP DATABASE IF EXISTS {}").format(db_id))
+
+
 class TempDatabase:
     """Context manager that creates a throwaway PostgreSQL database.
 

--- a/python/confiture/core/test_db.py
+++ b/python/confiture/core/test_db.py
@@ -156,7 +156,9 @@ def _managed_kind(comment: str | None) -> str | None:
     return None
 
 
-def _classify_template(comment: str | None, current_hash: str | None, exists: bool) -> TemplateStatus:
+def _classify_template(
+    comment: str | None, current_hash: str | None, exists: bool
+) -> TemplateStatus:
     """Classify a template's staleness from its stored comment.
 
     Args:
@@ -340,9 +342,7 @@ class TestDbProvisioner:
             finally:
                 conn.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
 
-    def _restore_into(
-        self, target: str, artifact: Path, restorer: DatabaseRestorer | None
-    ) -> None:
+    def _restore_into(self, target: str, artifact: Path, restorer: DatabaseRestorer | None) -> None:
         restorer = restorer or DatabaseRestorer()
         result = restorer.restore(
             RestoreOptions(
@@ -416,8 +416,7 @@ class TestDbProvisioner:
                 ) from e
 
         raise SchemaError(
-            f"Could not clone {template!r} into {target!r} after {retries} attempts: "
-            f"{last_err}",
+            f"Could not clone {template!r} into {target!r} after {retries} attempts: {last_err}",
             error_code="SCHEMA_001",
             resolution_hint="The template was continuously in use; reduce clone concurrency.",
         )

--- a/python/confiture/core/test_db.py
+++ b/python/confiture/core/test_db.py
@@ -1,0 +1,430 @@
+"""Test-database provisioning primitive (CI-path).
+
+Provisions a template database, hands out lock-free per-worker clones via
+``CREATE DATABASE … WITH TEMPLATE``, tears them down, and reports template
+staleness by ``db/`` content hash. The CI-callable core that the pytest-xdist
+fixtures sit on.
+
+Built on :mod:`confiture.core.temp_database`'s injection-safe CREATE/DROP
+helpers. Staleness is recorded as a ``COMMENT ON DATABASE`` on the template (not
+an in-template table): comments are read connection-free from the maintenance DB
+via ``shobj_description`` — so a status check never connects to the template and
+never races a concurrent clone — and are not copied into clones.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from urllib.parse import urlparse
+
+import psycopg
+import psycopg.errors
+import psycopg.sql
+from psycopg.sql import SQL, Identifier, Literal
+
+from confiture.core.restorer import DatabaseRestorer, RestoreOptions
+from confiture.core.seed_applier import apply_seed_files
+from confiture.core.temp_database import (
+    _maintenance_url,
+    _replace_dbname,
+    force_drop_database,
+    terminate_backends,
+)
+from confiture.exceptions import ConfigurationError, SchemaError
+
+# Marker comments stamped on confiture-managed databases (see module docstring).
+_TEMPLATE_PREFIX = "confiture:template:"
+_CLONE_PREFIX = "confiture:clone:"
+_MANAGED_PREFIX = "confiture:"
+
+# PostgreSQL identifier: leading letter/underscore, then letters/digits/underscore,
+# 1–63 ASCII chars. Quoting still happens via Identifier; this is defence in depth.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+
+
+class TemplateState(str, Enum):
+    """Whether a template matches the current ``db/`` hash."""
+
+    CURRENT = "current"
+    STALE = "stale"
+    ABSENT = "absent"
+
+
+@dataclass
+class TemplateStatus:
+    """Result of a template staleness check."""
+
+    name: str
+    state: TemplateState
+    stored_hash: str | None
+    current_hash: str | None
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "state": self.state.value,
+            "stored_hash": self.stored_hash,
+            "current_hash": self.current_hash,
+        }
+
+
+@dataclass
+class CloneResult:
+    """Result of a template clone."""
+
+    template: str
+    target: str
+    target_url: str
+
+    def to_dict(self) -> dict:
+        return {"template": self.template, "target": self.target, "target_url": self.target_url}
+
+
+@dataclass
+class ManagedDatabase:
+    """A confiture-managed database discovered by :meth:`list_databases`."""
+
+    name: str
+    kind: str  # "template" | "clone"
+    detail: str  # the hash (template) or source template name (clone)
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "kind": self.kind, "detail": self.detail}
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-testable without a database)
+# ---------------------------------------------------------------------------
+
+
+def _validate_identifier(name: str) -> None:
+    """Raise :class:`ConfigurationError` unless *name* is a safe SQL identifier.
+
+    Args:
+        name: Proposed database name.
+
+    Raises:
+        ConfigurationError: If the name is not a valid 1–63 char identifier.
+    """
+    if not _IDENTIFIER_RE.match(name or ""):
+        raise ConfigurationError(
+            f"Invalid database identifier: {name!r}.",
+            error_code="CONFIG_010",
+            resolution_hint="Use 1–63 chars: a letter or underscore followed by "
+            "letters, digits, or underscores.",
+        )
+
+
+def _clone_sql(target: str, template: str) -> psycopg.sql.Composed:
+    return SQL("CREATE DATABASE {} WITH TEMPLATE {}").format(
+        Identifier(target), Identifier(template)
+    )
+
+
+def _create_db_sql(name: str) -> psycopg.sql.Composed:
+    return SQL("CREATE DATABASE {}").format(Identifier(name))
+
+
+def _comment_sql(name: str, value: str) -> psycopg.sql.Composed:
+    return SQL("COMMENT ON DATABASE {} IS {}").format(Identifier(name), Literal(value))
+
+
+def _managed_kind(comment: str | None) -> str | None:
+    """Return ``"template"``/``"clone"`` for a managed comment, else ``None``."""
+    if not comment:
+        return None
+    if comment.startswith(_TEMPLATE_PREFIX):
+        return "template"
+    if comment.startswith(_CLONE_PREFIX):
+        return "clone"
+    return None
+
+
+def _classify_template(comment: str | None, current_hash: str | None, exists: bool) -> TemplateStatus:
+    """Classify a template's staleness from its stored comment.
+
+    Args:
+        comment: The template database comment, or None.
+        current_hash: The freshly computed ``db/`` hash to compare against.
+        exists: Whether the database exists at all.
+
+    Returns:
+        A :class:`TemplateStatus`. A database that does not exist — or exists but
+        carries no confiture template marker — is reported ABSENT (it is not a
+        usable template).
+    """
+    name = ""  # filled in by caller
+    if not exists or not comment or not comment.startswith(_TEMPLATE_PREFIX):
+        return TemplateStatus(name, TemplateState.ABSENT, None, current_hash)
+    stored = comment[len(_TEMPLATE_PREFIX) :]
+    state = TemplateState.CURRENT if stored == current_hash else TemplateState.STALE
+    return TemplateStatus(name, state, stored, current_hash)
+
+
+# ---------------------------------------------------------------------------
+# Provisioner
+# ---------------------------------------------------------------------------
+
+
+class TestDbProvisioner:
+    """Provisions template databases and per-worker clones on one PG server.
+
+    Args:
+        server_url: Any connection URL on the target server. The database
+            component is ignored for administrative work (the maintenance
+            ``postgres`` database is used for CREATE/DROP); it is the base for
+            deriving per-database URLs.
+    """
+
+    __test__ = False  # not a pytest test class despite the "Test" prefix
+
+    def __init__(self, server_url: str) -> None:
+        self.server_url = server_url
+        self.maintenance_url = _maintenance_url(server_url)
+        parsed = urlparse(server_url)
+        self._host = parsed.hostname or "/var/run/postgresql"
+        self._port = parsed.port or 5432
+        self._user = parsed.username
+
+    # -- connection helpers ------------------------------------------------
+
+    def _maintenance_conn(self) -> psycopg.Connection:
+        return psycopg.connect(self.maintenance_url, autocommit=True)
+
+    def _read_comment(self, conn: psycopg.Connection, db_name: str) -> tuple[bool, str | None]:
+        """Return ``(exists, comment)`` for *db_name*, read from the maintenance DB."""
+        row = conn.execute(
+            "SELECT shobj_description(d.oid, 'pg_database') "
+            "FROM pg_database d WHERE d.datname = %s",
+            (db_name,),
+        ).fetchone()
+        if row is None:
+            return False, None
+        return True, row[0]
+
+    def _set_comment(self, conn: psycopg.Connection, db_name: str, value: str) -> None:
+        conn.execute(_comment_sql(db_name, value))
+
+    # -- staleness ---------------------------------------------------------
+
+    def template_status(self, template: str, current_hash: str | None) -> TemplateStatus:
+        """Report whether *template* matches *current_hash* (connection-free read)."""
+        _validate_identifier(template)
+        with self._maintenance_conn() as conn:
+            exists, comment = self._read_comment(conn, template)
+        status = _classify_template(comment, current_hash, exists)
+        status.name = template
+        return status
+
+    # -- provisioning ------------------------------------------------------
+
+    def provision_template(
+        self,
+        template: str,
+        *,
+        schema_hash: str,
+        schema_sql: str | None = None,
+        seed_files: list[Path] | None = None,
+        from_artifact: Path | None = None,
+        restorer: DatabaseRestorer | None = None,
+        force: bool = False,
+    ) -> TemplateStatus:
+        """(Re)build *template* from DDL or a P1 artifact and stamp its hash.
+
+        Args:
+            template: Template database name.
+            schema_hash: ``db/`` content hash to record on the template.
+            schema_sql: Schema DDL to apply (DDL path).
+            seed_files: Optional seed files to apply after the schema (DDL path).
+            from_artifact: Path to a P1 ``-Fc``/``-Fd`` dump to restore instead
+                of applying DDL.
+            restorer: Injectable restorer (testing).
+            force: Permit clobbering a same-named database that is not
+                confiture-managed.
+
+        Returns:
+            A :class:`TemplateStatus` with ``state == CURRENT``.
+
+        Raises:
+            ConfigurationError: On invalid input or a refused clobber.
+            SchemaError / RestoreError: On a failed build or restore.
+        """
+        _validate_identifier(template)
+        if (schema_sql is None) == (from_artifact is None):
+            raise ConfigurationError(
+                "provision_template requires exactly one of schema_sql or from_artifact.",
+                error_code="CONFIG_010",
+            )
+
+        with self._maintenance_conn() as conn:
+            exists, comment = self._read_comment(conn, template)
+            if exists and not force and _managed_kind(comment) is None:
+                raise ConfigurationError(
+                    f"Refusing to replace database {template!r}: it exists and is not "
+                    "confiture-managed.",
+                    error_code="CONFIG_010",
+                    resolution_hint="Choose a different --template name, or pass --force.",
+                )
+            force_drop_database(conn, template)
+            conn.execute(_create_db_sql(template))
+
+        template_url = _replace_dbname(self.server_url, template)
+
+        if from_artifact is not None:
+            self._restore_into(template, from_artifact, restorer)
+        else:
+            with psycopg.connect(template_url, autocommit=True) as c:
+                c.execute(schema_sql, prepare=False)  # type: ignore[arg-type]
+            if seed_files:
+                apply_seed_files(template_url, seed_files)
+
+        with self._maintenance_conn() as conn:
+            self._set_comment(conn, template, _TEMPLATE_PREFIX + schema_hash)
+
+        return TemplateStatus(template, TemplateState.CURRENT, schema_hash, schema_hash)
+
+    def _restore_into(
+        self, target: str, artifact: Path, restorer: DatabaseRestorer | None
+    ) -> None:
+        restorer = restorer or DatabaseRestorer()
+        result = restorer.restore(
+            RestoreOptions(
+                backup_path=Path(artifact),
+                target_db=target,
+                host=self._host,
+                port=self._port,
+                username=self._user,
+                jobs=4,
+                parallel_restore=True,
+                no_owner=True,
+                no_acl=True,
+            )
+        )
+        if not result.success:
+            raise SchemaError(
+                f"Restoring artifact into template {target!r} failed: "
+                + "; ".join(result.errors[:3]),
+                error_code="SCHEMA_001",
+                resolution_hint="Check that the artifact is a valid -Fc/-Fd dump.",
+            )
+
+    # -- cloning -----------------------------------------------------------
+
+    def clone(
+        self, template: str, target: str, *, retries: int = 5, backoff: float = 0.25
+    ) -> CloneResult:
+        """Clone *template* into *target* via ``CREATE DATABASE … WITH TEMPLATE``.
+
+        Stray sessions on the template are terminated first; if a concurrent
+        clone is mid-copy (``source database … is being accessed``) the call
+        retries with a short backoff.
+
+        Args:
+            template: Source template database.
+            target: Clone database name to create.
+            retries: Bounded retries on "source is being accessed".
+            backoff: Seconds to wait between retries (grows linearly).
+
+        Returns:
+            A :class:`CloneResult` with the clone's connection URL.
+
+        Raises:
+            ConfigurationError: On invalid identifiers.
+            SchemaError: If cloning fails after all retries.
+        """
+        _validate_identifier(template)
+        _validate_identifier(target)
+
+        last_err: Exception | None = None
+        for attempt in range(1, retries + 1):
+            try:
+                with self._maintenance_conn() as conn:
+                    terminate_backends(conn, template)
+                    conn.execute(_clone_sql(target, template))
+                    self._set_comment(conn, target, _CLONE_PREFIX + template)
+                return CloneResult(
+                    template=template,
+                    target=target,
+                    target_url=_replace_dbname(self.server_url, target),
+                )
+            except psycopg.errors.ObjectInUse as e:
+                last_err = e
+                if attempt < retries:
+                    time.sleep(backoff * attempt)
+            except psycopg.errors.DuplicateDatabase as e:
+                raise SchemaError(
+                    f"Clone target {target!r} already exists.",
+                    error_code="SCHEMA_001",
+                    resolution_hint="Drop it first or choose a different target name.",
+                ) from e
+
+        raise SchemaError(
+            f"Could not clone {template!r} into {target!r} after {retries} attempts: "
+            f"{last_err}",
+            error_code="SCHEMA_001",
+            resolution_hint="The template was continuously in use; reduce clone concurrency.",
+        )
+
+    # -- teardown ----------------------------------------------------------
+
+    def drop(self, target: str, *, force: bool = False) -> bool:
+        """Drop a confiture-managed clone or template.
+
+        Args:
+            target: Database to drop.
+            force: Drop even if *target* carries no confiture marker.
+
+        Returns:
+            True if a database was dropped, False if it did not exist.
+
+        Raises:
+            ConfigurationError: If *target* is not confiture-managed and not
+                ``force`` (guards against fat-fingering a real database).
+        """
+        _validate_identifier(target)
+        with self._maintenance_conn() as conn:
+            exists, comment = self._read_comment(conn, target)
+            if not exists:
+                return False
+            if not force and _managed_kind(comment) is None:
+                raise ConfigurationError(
+                    f"Refusing to drop {target!r}: not a confiture-managed template/clone.",
+                    error_code="CONFIG_010",
+                    resolution_hint="Pass --force to override (use with care).",
+                )
+            force_drop_database(conn, target)
+        return True
+
+    # -- discovery / cleanup ----------------------------------------------
+
+    def list_databases(self) -> list[ManagedDatabase]:
+        """Enumerate all confiture-managed databases on the server."""
+        out: list[ManagedDatabase] = []
+        with self._maintenance_conn() as conn:
+            rows = conn.execute(
+                "SELECT d.datname, shobj_description(d.oid, 'pg_database') "
+                "FROM pg_database d WHERE NOT d.datistemplate"
+            ).fetchall()
+        for name, comment in rows:
+            kind = _managed_kind(comment)
+            if kind is None:
+                continue
+            prefix = _TEMPLATE_PREFIX if kind == "template" else _CLONE_PREFIX
+            out.append(ManagedDatabase(name=name, kind=kind, detail=comment[len(prefix) :]))
+        return out
+
+    def prune(self, template: str) -> list[str]:
+        """Drop every clone of *template*. Returns the dropped names.
+
+        Use to reap clones leaked by crashed workers.
+        """
+        _validate_identifier(template)
+        dropped: list[str] = []
+        for db in self.list_databases():
+            if db.kind == "clone" and db.detail == template and self.drop(db.name):
+                dropped.append(db.name)
+        return dropped

--- a/python/confiture/core/test_db.py
+++ b/python/confiture/core/test_db.py
@@ -14,6 +14,7 @@ never races a concurrent clone — and are not copied into clones.
 
 from __future__ import annotations
 
+import hashlib
 import re
 import time
 from dataclasses import dataclass
@@ -131,6 +132,17 @@ def _create_db_sql(name: str) -> psycopg.sql.Composed:
 
 def _comment_sql(name: str, value: str) -> psycopg.sql.Composed:
     return SQL("COMMENT ON DATABASE {} IS {}").format(Identifier(name), Literal(value))
+
+
+def _advisory_key(name: str) -> int:
+    """Derive a process-stable signed 64-bit advisory-lock key from *name*.
+
+    Used to single-flight template provisioning across xdist workers. Python's
+    builtin ``hash`` is not stable across processes (PYTHONHASHSEED), so a
+    SHA-256 prefix is used instead.
+    """
+    digest = hashlib.sha256(name.encode("utf-8")).digest()[:8]
+    return int.from_bytes(digest, "big", signed=True)
 
 
 def _managed_kind(comment: str | None) -> str | None:
@@ -286,6 +298,47 @@ class TestDbProvisioner:
             self._set_comment(conn, template, _TEMPLATE_PREFIX + schema_hash)
 
         return TemplateStatus(template, TemplateState.CURRENT, schema_hash, schema_hash)
+
+    def ensure_template(
+        self,
+        template: str,
+        *,
+        schema_hash: str,
+        schema_sql: str | None = None,
+        seed_files: list[Path] | None = None,
+        from_artifact: Path | None = None,
+        restorer: DatabaseRestorer | None = None,
+    ) -> TemplateStatus:
+        """Provision *template* only if stale, single-flight across processes.
+
+        A session-level PostgreSQL advisory lock keyed on the template name
+        serialises concurrent callers (e.g. xdist workers all entering the
+        session template fixture): the first to acquire the lock builds, and the
+        rest observe ``CURRENT`` and return without rebuilding.
+
+        Args mirror :meth:`provision_template`.
+
+        Returns:
+            The resulting :class:`TemplateStatus` (always ``CURRENT`` on success).
+        """
+        _validate_identifier(template)
+        lock_key = _advisory_key(template)
+        with self._maintenance_conn() as conn:
+            conn.execute("SELECT pg_advisory_lock(%s)", (lock_key,))
+            try:
+                status = self.template_status(template, schema_hash)
+                if status.state is TemplateState.CURRENT:
+                    return status
+                return self.provision_template(
+                    template,
+                    schema_hash=schema_hash,
+                    schema_sql=schema_sql,
+                    seed_files=seed_files,
+                    from_artifact=from_artifact,
+                    restorer=restorer,
+                )
+            finally:
+                conn.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
 
     def _restore_into(
         self, target: str, artifact: Path, restorer: DatabaseRestorer | None

--- a/python/confiture/models/results.py
+++ b/python/confiture/models/results.py
@@ -145,6 +145,7 @@ class BuildResult:
     seed_files_applied: int = 0
     artifact_path: str | None = None
     artifact_hash: str | None = None
+    seed_profile: str | None = None
     warnings: list[str] = field(default_factory=list)
     error: str | None = None
 
@@ -164,6 +165,7 @@ class BuildResult:
             "seed_files_applied": self.seed_files_applied,
             "artifact_path": self.artifact_path,
             "artifact_hash": self.artifact_hash,
+            "seed_profile": self.seed_profile,
             "warnings": self.warnings,
             "error": self.error,
         }

--- a/python/confiture/models/results.py
+++ b/python/confiture/models/results.py
@@ -143,6 +143,8 @@ class BuildResult:
     hash: str | None = None
     execution_time_ms: int = 0
     seed_files_applied: int = 0
+    artifact_path: str | None = None
+    artifact_hash: str | None = None
     warnings: list[str] = field(default_factory=list)
     error: str | None = None
 
@@ -160,6 +162,8 @@ class BuildResult:
             "hash": self.hash,
             "execution_time_ms": self.execution_time_ms,
             "seed_files_applied": self.seed_files_applied,
+            "artifact_path": self.artifact_path,
+            "artifact_hash": self.artifact_hash,
             "warnings": self.warnings,
             "error": self.error,
         }

--- a/python/confiture/testing/pytest/__init__.py
+++ b/python/confiture/testing/pytest/__init__.py
@@ -19,18 +19,42 @@ Usage:
 # Re-export from the plugin module
 from confiture.testing.pytest_plugin import (
     confiture_db_url,
+    confiture_env,
+    confiture_project_dir,
     confiture_sandbox,
     confiture_snapshotter,
+    confiture_template_db,
+    confiture_template_name,
+    confiture_test_server_url,
     confiture_validator,
+    confiture_worker_db,
+    confiture_worker_id,
     migration_test,
+)
+from confiture.testing.worker_db import (
+    current_worker_id,
+    resolve_worker_db_name,
+    resolve_worker_db_url,
 )
 
 __all__ = [
     # Decorator
     "migration_test",
-    # Fixtures (for documentation, actual fixtures registered via plugin)
+    # Migration-sandbox fixtures (for documentation; registered via plugin)
     "confiture_db_url",
     "confiture_sandbox",
     "confiture_validator",
     "confiture_snapshotter",
+    # Per-worker test-database fixtures (pytest-xdist)
+    "confiture_test_server_url",
+    "confiture_template_name",
+    "confiture_env",
+    "confiture_project_dir",
+    "confiture_worker_id",
+    "confiture_template_db",
+    "confiture_worker_db",
+    # Import-time helpers (primary integration surface)
+    "resolve_worker_db_name",
+    "resolve_worker_db_url",
+    "current_worker_id",
 ]

--- a/python/confiture/testing/pytest_plugin.py
+++ b/python/confiture/testing/pytest_plugin.py
@@ -256,9 +256,7 @@ def confiture_worker_db(
     from confiture.testing.worker_db import resolve_worker_db_name
 
     provisioner = TestDbProvisioner(confiture_test_server_url)
-    target = resolve_worker_db_name(
-        f"{confiture_template_db}_db", worker_id=confiture_worker_id
-    )
+    target = resolve_worker_db_name(f"{confiture_template_db}_db", worker_id=confiture_worker_id)
 
     try:
         provisioner.drop(target)  # reap a leftover clone from a crashed run

--- a/python/confiture/testing/pytest_plugin.py
+++ b/python/confiture/testing/pytest_plugin.py
@@ -25,6 +25,7 @@ Example test file:
 
 from __future__ import annotations
 
+import contextlib
 import os
 from collections.abc import Generator
 from pathlib import Path
@@ -146,6 +147,130 @@ def confiture_snapshotter(confiture_sandbox: MigrationSandbox) -> SchemaSnapshot
         SchemaSnapshotter instance
     """
     return confiture_sandbox.snapshotter
+
+
+# ---------------------------------------------------------------------------
+# Per-worker test-database fixtures (pytest-xdist)
+#
+# These are OPT-IN: they only run when a test requests them, so existing plugin
+# users are unaffected. The primary integration surface for apps that freeze a
+# settings/pool singleton at import time is the import-time helper
+# ``confiture.testing.worker_db.resolve_worker_db_url`` (call it from conftest.py
+# BEFORE importing the app) — these fixtures are convenience for apps that read
+# their database URL lazily and cannot retro-fix an already-frozen singleton.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def confiture_test_server_url() -> str:
+    """PG server URL for test-db provisioning (override to customise).
+
+    ``CONFITURE_TEST_DB_URL`` takes precedence.
+    """
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+@pytest.fixture(scope="session")
+def confiture_template_name() -> str:
+    """Template database name (override to customise)."""
+    return "confiture_template"
+
+
+@pytest.fixture(scope="session")
+def confiture_env() -> str:
+    """Environment whose schema builds the template (override to customise)."""
+    return "local"
+
+
+@pytest.fixture(scope="session")
+def confiture_project_dir() -> Path:
+    """Project directory the template schema is built from (override to customise)."""
+    return Path(".")
+
+
+@pytest.fixture(scope="session")
+def confiture_worker_id() -> str | None:
+    """The active pytest-xdist worker id (``"gw0"``…), or None for single-process."""
+    from confiture.testing.worker_db import current_worker_id
+
+    return current_worker_id()
+
+
+@pytest.fixture(scope="session")
+def confiture_template_db(
+    confiture_test_server_url: str,
+    confiture_template_name: str,
+    confiture_env: str,
+    confiture_project_dir: Path,
+) -> str:
+    """Ensure the shared template database exists and matches the current db/ hash.
+
+    Built exactly once even under ``-n N`` (single-flight via a PostgreSQL
+    advisory lock in :meth:`TestDbProvisioner.ensure_template`). Skips cleanly
+    when no database is reachable.
+
+    Returns:
+        The template database name.
+    """
+    import psycopg
+
+    from confiture.core.builder import SchemaBuilder
+    from confiture.core.test_db import TestDbProvisioner
+
+    try:
+        builder = SchemaBuilder(env=confiture_env, project_dir=confiture_project_dir)
+        schema_hash = builder.compute_hash()
+        schema_sql = builder.build(schema_only=True)
+        _schema_files, seed_files = builder.categorize_sql_files()
+        provisioner = TestDbProvisioner(confiture_test_server_url)
+        provisioner.ensure_template(
+            confiture_template_name,
+            schema_hash=schema_hash,
+            schema_sql=schema_sql,
+            seed_files=seed_files or None,
+        )
+    except psycopg.OperationalError as e:
+        pytest.skip(f"confiture test database unavailable: {e}")
+    return confiture_template_name
+
+
+@pytest.fixture(scope="session")
+def confiture_worker_db(
+    confiture_template_db: str,
+    confiture_test_server_url: str,
+    confiture_worker_id: str | None,
+) -> Generator[str, None, None]:
+    """Yield a per-worker database cloned from the shared template.
+
+    One clone per xdist worker (session scope is per worker process), dropped on
+    teardown. The yielded value is the clone's connection URL.
+
+    Note:
+        Apps that freeze their settings/pool at import time must instead call
+        ``confiture.testing.worker_db.resolve_worker_db_url`` from conftest.py at
+        import time — this fixture runs too late to fix a frozen singleton.
+    """
+    import psycopg
+
+    from confiture.core.test_db import TestDbProvisioner
+    from confiture.testing.worker_db import resolve_worker_db_name
+
+    provisioner = TestDbProvisioner(confiture_test_server_url)
+    target = resolve_worker_db_name(
+        f"{confiture_template_db}_db", worker_id=confiture_worker_id
+    )
+
+    try:
+        provisioner.drop(target)  # reap a leftover clone from a crashed run
+        clone = provisioner.clone(confiture_template_db, target)
+    except psycopg.OperationalError as e:
+        pytest.skip(f"confiture test database unavailable: {e}")
+
+    try:
+        yield clone.target_url
+    finally:
+        with contextlib.suppress(psycopg.OperationalError):
+            provisioner.drop(target)  # best-effort teardown
 
 
 def migration_test(migration_name: str):

--- a/python/confiture/testing/worker_db.py
+++ b/python/confiture/testing/worker_db.py
@@ -1,0 +1,87 @@
+"""Per-worker test-database name/URL resolution for pytest-xdist.
+
+**This module's pure functions are the primary integration surface, not the
+fixtures.** An xdist worker resolves its database name from
+``PYTEST_XDIST_WORKER`` — but a fixture runs at *test* time, which is too late
+for an application that freezes a ``Settings()`` / connection-pool singleton at
+*module import*. The supported integration for such apps is to call
+:func:`resolve_worker_db_url` from the consumer's ``conftest.py`` **at import
+time**, before the app's settings are imported::
+
+    # conftest.py — runs before the app package is imported
+    import os
+    from confiture.testing.worker_db import resolve_worker_db_url
+
+    os.environ["DATABASE_URL"] = resolve_worker_db_url(os.environ["DATABASE_URL"])
+    # only now import anything that reads DATABASE_URL into a frozen singleton
+
+The :func:`confiture_worker_db` fixture (in ``pytest_plugin``) is convenience for
+apps that read the URL lazily; it cannot retro-fix an already-frozen singleton.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import urlparse
+
+from confiture.core.temp_database import _replace_dbname
+
+# A worker suffix this module appends, e.g. "_gw0". Stripped before re-appending
+# so resolution is idempotent (never "_gw0_gw1").
+_WORKER_SUFFIX_RE = re.compile(r"_gw\d+$")
+_WORKER_ID_RE = re.compile(r"^gw\d+$")
+
+
+def current_worker_id() -> str | None:
+    """Return the active pytest-xdist worker id (``"gw0"``…), or None.
+
+    Returns None for non-distributed runs and for the xdist controller
+    (``"master"``), both of which map to the single base database.
+    """
+    worker = os.getenv("PYTEST_XDIST_WORKER")
+    if not worker or worker == "master":
+        return None
+    return worker
+
+
+def resolve_worker_db_name(base: str, *, worker_id: str | None = None) -> str:
+    """Resolve the per-worker database name for *base*.
+
+    ``gw0`` → ``{base}_gw0``; no/unknown worker (single-process or ``master``)
+    → ``base``. Idempotent: an already-suffixed base is re-resolved cleanly
+    rather than double-suffixed.
+
+    Args:
+        base: The base database name.
+        worker_id: Explicit worker id; defaults to the live
+            ``PYTEST_XDIST_WORKER``.
+
+    Returns:
+        The resolved database name.
+    """
+    wid = worker_id if worker_id is not None else current_worker_id()
+    stripped = _WORKER_SUFFIX_RE.sub("", base)
+    if not wid or not _WORKER_ID_RE.match(wid):
+        return stripped
+    return f"{stripped}_{wid}"
+
+
+def resolve_worker_db_url(base_url: str, *, worker_id: str | None = None) -> str:
+    """Resolve the per-worker connection URL for *base_url*.
+
+    Replaces the database component of *base_url* with the worker-resolved name
+    (see :func:`resolve_worker_db_name`). This is the import-time entry point
+    consumers should call from ``conftest.py`` (see the module docstring).
+
+    Args:
+        base_url: The base connection URL.
+        worker_id: Explicit worker id; defaults to the live
+            ``PYTEST_XDIST_WORKER``.
+
+    Returns:
+        The URL with its database name resolved for this worker.
+    """
+    base_name = urlparse(base_url).path.lstrip("/")
+    worker_name = resolve_worker_db_name(base_name, worker_id=worker_id)
+    return _replace_dbname(base_url, worker_name)

--- a/tests/integration/test_build_artifact_roundtrip.py
+++ b/tests/integration/test_build_artifact_roundtrip.py
@@ -60,9 +60,7 @@ def fresh_target(server_url: str) -> Iterator[str]:
     maint = _maintenance_url(server_url)
     target_id = psycopg.sql.Identifier(target)
     with psycopg.connect(maint, autocommit=True) as conn:
-        conn.execute(
-            psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(target_id)
-        )
+        conn.execute(psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(target_id))
         conn.execute(psycopg.sql.SQL("CREATE DATABASE {}").format(target_id))
     try:
         yield target
@@ -118,9 +116,7 @@ def test_artifact_round_trips_through_restore(
     assert _restored_tables(server_url, fresh_target) == {"parent", "child"}
 
 
-def test_skip_when_artifact_exists_is_a_noop(
-    server_url: str, tmp_path: Path
-) -> None:
+def test_skip_when_artifact_exists_is_a_noop(server_url: str, tmp_path: Path) -> None:
     artifact = tmp_path / "schema_test.full.deadbeefcafe.pgdump"
     artifact.write_bytes(b"PGDMP-stub")  # pretend a cached artifact is present
 

--- a/tests/integration/test_build_artifact_roundtrip.py
+++ b/tests/integration/test_build_artifact_roundtrip.py
@@ -1,0 +1,135 @@
+"""Integration: a build artifact round-trips through `confiture restore` (P1).
+
+Builds a small schema into a pg_dump -Fc / -Fd artifact via an ephemeral
+database, restores it into a fresh database with the three-phase restorer, and
+asserts the restored object set matches what the schema declares.
+
+Requires a reachable local PostgreSQL (CONFITURE_TEST_DB_URL or localhost).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import psycopg.sql
+import pytest
+
+from confiture.core.restorer import DatabaseRestorer, RestoreOptions
+from confiture.core.schema_artifact import SchemaArtifactDumper, build_schema_artifact
+
+pytestmark = pytest.mark.integration
+
+_SCHEMA_SQL = """
+CREATE TABLE parent (id int PRIMARY KEY);
+CREATE TABLE child (
+    id int PRIMARY KEY,
+    parent_id int REFERENCES parent (id)
+);
+CREATE INDEX idx_child_parent ON child (parent_id);
+"""
+
+
+def _server_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+def _maintenance_url(server_url: str) -> str:
+    from confiture.core.temp_database import _maintenance_url
+
+    return _maintenance_url(server_url)
+
+
+@pytest.fixture
+def server_url() -> str:
+    url = _server_url()
+    try:
+        with psycopg.connect(_maintenance_url(url), autocommit=True):
+            pass
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+    return url
+
+
+@pytest.fixture
+def fresh_target(server_url: str) -> Iterator[str]:
+    """Create an empty target database; drop it afterwards."""
+    target = "confiture_artifact_roundtrip"
+    maint = _maintenance_url(server_url)
+    target_id = psycopg.sql.Identifier(target)
+    with psycopg.connect(maint, autocommit=True) as conn:
+        conn.execute(
+            psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(target_id)
+        )
+        conn.execute(psycopg.sql.SQL("CREATE DATABASE {}").format(target_id))
+    try:
+        yield target
+    finally:
+        with psycopg.connect(maint, autocommit=True) as conn:
+            conn.execute(
+                psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(target_id)
+            )
+
+
+def _restored_tables(server_url: str, target_db: str) -> set[str]:
+    target_url = server_url.rsplit("/", 1)[0] + f"/{target_db}"
+    with psycopg.connect(target_url, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+@pytest.mark.parametrize("dump_format", ["custom", "directory"])
+def test_artifact_round_trips_through_restore(
+    server_url: str, fresh_target: str, tmp_path: Path, dump_format: str
+) -> None:
+    ext = "pgdump" if dump_format == "custom" else "pgdir"
+    artifact = tmp_path / f"schema_test.full.deadbeefcafe.{ext}"
+
+    result = build_schema_artifact(
+        server_url=server_url,
+        schema_sql=_SCHEMA_SQL,
+        output_path=artifact,
+        schema_hash="deadbeefcafe0000",
+        dump_format=dump_format,
+        dumper=SchemaArtifactDumper(jobs=2),
+    )
+    assert result.skipped is False
+    assert artifact.exists()
+
+    host = "localhost"
+    restore = DatabaseRestorer().restore(
+        RestoreOptions(
+            backup_path=artifact,
+            target_db=fresh_target,
+            host=host,
+            port=5432,
+            jobs=2,
+            parallel_restore=True,
+            no_owner=True,
+            no_acl=True,
+        )
+    )
+    assert restore.success, restore.errors
+
+    assert _restored_tables(server_url, fresh_target) == {"parent", "child"}
+
+
+def test_skip_when_artifact_exists_is_a_noop(
+    server_url: str, tmp_path: Path
+) -> None:
+    artifact = tmp_path / "schema_test.full.deadbeefcafe.pgdump"
+    artifact.write_bytes(b"PGDMP-stub")  # pretend a cached artifact is present
+
+    result = build_schema_artifact(
+        server_url=server_url,
+        schema_sql=_SCHEMA_SQL,
+        output_path=artifact,
+        schema_hash="deadbeefcafe0000",
+    )
+
+    assert result.skipped is True
+    assert artifact.read_bytes() == b"PGDMP-stub"  # untouched

--- a/tests/integration/test_pytest_worker_db.py
+++ b/tests/integration/test_pytest_worker_db.py
@@ -61,9 +61,7 @@ def clean_server() -> Iterator[None]:
 
 
 class TestEnsureTemplateSingleFlight:
-    def test_concurrent_ensure_builds_once_and_is_consistent(
-        self, clean_server: None
-    ) -> None:
+    def test_concurrent_ensure_builds_once_and_is_consistent(self, clean_server: None) -> None:
         provisioner = TestDbProvisioner(_server_url())
         errors: list[Exception] = []
 
@@ -82,9 +80,7 @@ class TestEnsureTemplateSingleFlight:
         assert not errors, errors
         status = provisioner.template_status(_TEMPLATE, "h1")
         assert status.state is TemplateState.CURRENT
-        with psycopg.connect(
-            _replace_dbname(_server_url(), _TEMPLATE), autocommit=True
-        ) as conn:
+        with psycopg.connect(_replace_dbname(_server_url(), _TEMPLATE), autocommit=True) as conn:
             tables = {
                 r[0]
                 for r in conn.execute(
@@ -142,9 +138,7 @@ def _write_inner_project(root: Path, server_url: str) -> None:
     )
 
 
-def test_real_xdist_n2_gives_each_worker_its_own_db(
-    clean_server: None, tmp_path: Path
-) -> None:
+def test_real_xdist_n2_gives_each_worker_its_own_db(clean_server: None, tmp_path: Path) -> None:
     """A genuine `pytest -n2` run yields two distinct, isolated worker databases."""
     pytest.importorskip("xdist")
 

--- a/tests/integration/test_pytest_worker_db.py
+++ b/tests/integration/test_pytest_worker_db.py
@@ -1,0 +1,175 @@
+"""Integration tests for per-worker xdist provisioning (P3).
+
+Covers single-flight template build (`ensure_template`) and a REAL `pytest -n2`
+subprocess run exercising the `confiture_worker_db` fixture under genuine
+parallelism (not just a hand-set PYTEST_XDIST_WORKER).
+
+Requires a reachable local PostgreSQL.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from confiture.core.temp_database import _maintenance_url, _replace_dbname
+from confiture.core.test_db import TemplateState, TestDbProvisioner
+
+pytestmark = pytest.mark.integration
+
+_SCHEMA = "CREATE TABLE widget (id int PRIMARY KEY);"
+_TEMPLATE = "confiture_p3_template"
+
+
+def _server_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+def _drop_like(prefix: str) -> None:
+    with psycopg.connect(_maintenance_url(_server_url()), autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT datname FROM pg_database WHERE datname LIKE %s", (prefix + "%",)
+        ).fetchall()
+        for (name,) in rows:
+            conn.execute(
+                psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    psycopg.sql.Identifier(name)
+                )
+            )
+
+
+@pytest.fixture
+def clean_server() -> Iterator[None]:
+    url = _server_url()
+    try:
+        with psycopg.connect(_maintenance_url(url), autocommit=True):
+            pass
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+    _drop_like(_TEMPLATE)
+    try:
+        yield
+    finally:
+        _drop_like(_TEMPLATE)
+
+
+class TestEnsureTemplateSingleFlight:
+    def test_concurrent_ensure_builds_once_and_is_consistent(
+        self, clean_server: None
+    ) -> None:
+        provisioner = TestDbProvisioner(_server_url())
+        errors: list[Exception] = []
+
+        def _ensure() -> None:
+            try:
+                provisioner.ensure_template(_TEMPLATE, schema_hash="h1", schema_sql=_SCHEMA)
+            except Exception as e:  # noqa: BLE001 - recorded for assertion
+                errors.append(e)
+
+        threads = [threading.Thread(target=_ensure) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, errors
+        status = provisioner.template_status(_TEMPLATE, "h1")
+        assert status.state is TemplateState.CURRENT
+        with psycopg.connect(
+            _replace_dbname(_server_url(), _TEMPLATE), autocommit=True
+        ) as conn:
+            tables = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+                ).fetchall()
+            }
+        assert tables == {"widget"}
+
+    def test_ensure_is_noop_when_current(self, clean_server: None) -> None:
+        provisioner = TestDbProvisioner(_server_url())
+        provisioner.ensure_template(_TEMPLATE, schema_hash="h1", schema_sql=_SCHEMA)
+        # Second call with the same hash must observe CURRENT and not rebuild.
+        status = provisioner.ensure_template(_TEMPLATE, schema_hash="h1", schema_sql=_SCHEMA)
+        assert status.state is TemplateState.CURRENT
+
+
+def _write_inner_project(root: Path, server_url: str) -> None:
+    (root / "db" / "schema").mkdir(parents=True)
+    (root / "db" / "schema" / "01.sql").write_text(_SCHEMA)
+    (root / "db" / "environments").mkdir(parents=True)
+    (root / "db" / "environments" / "local.yaml").write_text(
+        f'name: local\ndatabase_url: "{server_url}"\ninclude_dirs:\n  - db/schema\n'
+    )
+    # No `pytest_plugins = [...]`: the confiture plugin is already auto-loaded
+    # via its pytest11 entry point, so re-declaring it raises a double-register
+    # error. This mirrors how a real consumer (confiture installed) sees it.
+    (root / "conftest.py").write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "import pytest\n"
+        "@pytest.fixture(scope='session')\n"
+        "def confiture_project_dir():\n"
+        "    return Path(__file__).parent\n"
+        "@pytest.fixture(scope='session')\n"
+        "def confiture_template_name():\n"
+        f"    return {_TEMPLATE!r}\n"
+        "@pytest.fixture(scope='session')\n"
+        "def confiture_test_server_url():\n"
+        "    return os.environ['CONFITURE_TEST_DB_URL']\n"
+    )
+    (root / "test_inner.py").write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "import psycopg\n"
+        "import pytest\n"
+        "@pytest.mark.parametrize('i', range(8))\n"
+        "def test_worker_db_is_isolated_clone(confiture_worker_db, i):\n"
+        "    with psycopg.connect(confiture_worker_db, autocommit=True) as conn:\n"
+        "        dbname = conn.execute('select current_database()').fetchone()[0]\n"
+        "        tables = {r[0] for r in conn.execute(\n"
+        "            \"select tablename from pg_tables where schemaname='public'\"\n"
+        "        ).fetchall()}\n"
+        "    assert 'widget' in tables\n"
+        "    Path(os.environ['P3_RECORD_DIR'], dbname).write_text('ok')\n"
+    )
+
+
+def test_real_xdist_n2_gives_each_worker_its_own_db(
+    clean_server: None, tmp_path: Path
+) -> None:
+    """A genuine `pytest -n2` run yields two distinct, isolated worker databases."""
+    pytest.importorskip("xdist")
+
+    inner = tmp_path / "proj"
+    inner.mkdir()
+    _write_inner_project(inner, _server_url())
+    record_dir = tmp_path / "records"
+    record_dir.mkdir()
+
+    env = {
+        **os.environ,
+        "CONFITURE_TEST_DB_URL": _server_url(),
+        "P3_RECORD_DIR": str(record_dir),
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(inner), "-n2", "-p", "no:cacheprovider", "-q"],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(inner),
+    )
+
+    assert result.returncode == 0, f"inner pytest failed:\n{result.stdout}\n{result.stderr}"
+
+    seen = {p.name for p in record_dir.iterdir()}
+    # Two workers → two distinct, suffixed worker databases.
+    assert len(seen) >= 2, f"expected >=2 worker DBs, saw {seen}"
+    assert all(name.startswith(f"{_TEMPLATE}_db_gw") for name in seen), seen

--- a/tests/integration/test_seed_profile_apply.py
+++ b/tests/integration/test_seed_profile_apply.py
@@ -1,0 +1,70 @@
+"""Integration: a slim seed profile applies only its subset (P4, Cycle 4).
+
+Requires a reachable local PostgreSQL.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from confiture.config.environment import SeedProfile
+from confiture.core.seed_applier import SeedApplier
+from confiture.core.temp_database import TempDatabase, _maintenance_url
+
+pytestmark = pytest.mark.integration
+
+
+def _server_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+@pytest.fixture
+def temp_db_url() -> Iterator[str]:
+    url = _server_url()
+    try:
+        with psycopg.connect(_maintenance_url(url), autocommit=True):
+            pass
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+    with TempDatabase(url) as temp_url:
+        with psycopg.connect(temp_url, autocommit=True) as conn:
+            conn.execute("CREATE TABLE loaded (name text)")
+        yield temp_url
+
+
+def _seeds(tmp_path: Path) -> Path:
+    d = tmp_path / "seeds"
+    d.mkdir()
+    (d / "core_1.sql").write_text("INSERT INTO loaded (name) VALUES ('core');")
+    (d / "stats_1.sql").write_text("INSERT INTO loaded (name) VALUES ('stats');")
+    return d
+
+
+def test_slim_profile_loads_only_subset(temp_db_url: str, tmp_path: Path) -> None:
+    seeds_dir = _seeds(tmp_path)
+    with psycopg.connect(temp_db_url, autocommit=False) as conn:
+        applier = SeedApplier(seeds_dir=seeds_dir, connection=conn)
+        result = applier.apply_sequential(profile=SeedProfile(exclude=["stats_*.sql"]))
+        conn.commit()
+
+    assert result.succeeded == 1
+    with psycopg.connect(temp_db_url, autocommit=True) as conn:
+        rows = {r[0] for r in conn.execute("SELECT name FROM loaded").fetchall()}
+    assert rows == {"core"}
+
+
+def test_no_profile_loads_all(temp_db_url: str, tmp_path: Path) -> None:
+    seeds_dir = _seeds(tmp_path)
+    with psycopg.connect(temp_db_url, autocommit=False) as conn:
+        applier = SeedApplier(seeds_dir=seeds_dir, connection=conn)
+        applier.apply_sequential()
+        conn.commit()
+
+    with psycopg.connect(temp_db_url, autocommit=True) as conn:
+        rows = {r[0] for r in conn.execute("SELECT name FROM loaded").fetchall()}
+    assert rows == {"core", "stats"}

--- a/tests/integration/test_test_db_provision.py
+++ b/tests/integration/test_test_db_provision.py
@@ -83,9 +83,7 @@ class TestProvisionAndClone:
         assert result.target == _CLONE
         assert _tables(provisioner, _CLONE) == {"widget"}
 
-    def test_provision_from_artifact(
-        self, provisioner: TestDbProvisioner, tmp_path: Path
-    ) -> None:
+    def test_provision_from_artifact(self, provisioner: TestDbProvisioner, tmp_path: Path) -> None:
         artifact = tmp_path / "p2.full.hash.pgdump"
         build_schema_artifact(
             server_url=provisioner.server_url,
@@ -107,9 +105,7 @@ class TestStaleness:
         assert provisioner.template_status(_TEMPLATE, "hash-v2").state is TemplateState.STALE
 
     def test_status_absent_when_missing(self, provisioner: TestDbProvisioner) -> None:
-        assert (
-            provisioner.template_status(_TEMPLATE, "hash-v1").state is TemplateState.ABSENT
-        )
+        assert provisioner.template_status(_TEMPLATE, "hash-v1").state is TemplateState.ABSENT
 
 
 class TestDropSafety:
@@ -149,9 +145,7 @@ class TestConcurrencyAndPrune:
         for i in range(6):
             assert _tables(provisioner, f"{_CLONE}_{i}") == {"widget"}
 
-    def test_prune_drops_all_clones_of_template(
-        self, provisioner: TestDbProvisioner
-    ) -> None:
+    def test_prune_drops_all_clones_of_template(self, provisioner: TestDbProvisioner) -> None:
         provisioner.provision_template(_TEMPLATE, schema_hash="h", schema_sql=_SCHEMA)
         provisioner.clone(_TEMPLATE, f"{_CLONE}_0")
         provisioner.clone(_TEMPLATE, f"{_CLONE}_1")

--- a/tests/integration/test_test_db_provision.py
+++ b/tests/integration/test_test_db_provision.py
@@ -1,0 +1,163 @@
+"""Integration tests for TestDbProvisioner (P2).
+
+Requires a reachable local PostgreSQL (CONFITURE_TEST_DB_URL or localhost).
+All databases created here use the ``confiture_p2_`` prefix and are dropped in
+fixture teardown.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from confiture.core.schema_artifact import build_schema_artifact
+from confiture.core.temp_database import _maintenance_url
+from confiture.core.test_db import TemplateState, TestDbProvisioner
+from confiture.exceptions import ConfigurationError
+
+pytestmark = pytest.mark.integration
+
+_SCHEMA = "CREATE TABLE widget (id int PRIMARY KEY, name text);"
+
+_TEMPLATE = "confiture_p2_template"
+_CLONE = "confiture_p2_clone"
+
+
+def _server_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+def _drop_all(names: list[str]) -> None:
+    with psycopg.connect(_maintenance_url(_server_url()), autocommit=True) as conn:
+        for name in names:
+            conn.execute(
+                psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    psycopg.sql.Identifier(name)
+                )
+            )
+
+
+@pytest.fixture
+def provisioner() -> Iterator[TestDbProvisioner]:
+    url = _server_url()
+    try:
+        with psycopg.connect(_maintenance_url(url), autocommit=True):
+            pass
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+
+    managed = [_TEMPLATE, _CLONE] + [f"{_CLONE}_{i}" for i in range(6)]
+    _drop_all(managed)
+    try:
+        yield TestDbProvisioner(url)
+    finally:
+        _drop_all(managed)
+
+
+def _tables(provisioner: TestDbProvisioner, db: str) -> set[str]:
+    from confiture.core.temp_database import _replace_dbname
+
+    with psycopg.connect(_replace_dbname(provisioner.server_url, db), autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+class TestProvisionAndClone:
+    def test_provision_template_ddl_path(self, provisioner: TestDbProvisioner) -> None:
+        status = provisioner.provision_template(
+            _TEMPLATE, schema_hash="hash-v1", schema_sql=_SCHEMA
+        )
+        assert status.state is TemplateState.CURRENT
+        assert _tables(provisioner, _TEMPLATE) == {"widget"}
+
+    def test_clone_has_template_tables(self, provisioner: TestDbProvisioner) -> None:
+        provisioner.provision_template(_TEMPLATE, schema_hash="hash-v1", schema_sql=_SCHEMA)
+        result = provisioner.clone(_TEMPLATE, _CLONE)
+        assert result.target == _CLONE
+        assert _tables(provisioner, _CLONE) == {"widget"}
+
+    def test_provision_from_artifact(
+        self, provisioner: TestDbProvisioner, tmp_path: Path
+    ) -> None:
+        artifact = tmp_path / "p2.full.hash.pgdump"
+        build_schema_artifact(
+            server_url=provisioner.server_url,
+            schema_sql=_SCHEMA,
+            output_path=artifact,
+            schema_hash="hash-v1",
+        )
+        status = provisioner.provision_template(
+            _TEMPLATE, schema_hash="hash-v1", from_artifact=artifact
+        )
+        assert status.state is TemplateState.CURRENT
+        assert _tables(provisioner, _TEMPLATE) == {"widget"}
+
+
+class TestStaleness:
+    def test_status_current_then_stale(self, provisioner: TestDbProvisioner) -> None:
+        provisioner.provision_template(_TEMPLATE, schema_hash="hash-v1", schema_sql=_SCHEMA)
+        assert provisioner.template_status(_TEMPLATE, "hash-v1").state is TemplateState.CURRENT
+        assert provisioner.template_status(_TEMPLATE, "hash-v2").state is TemplateState.STALE
+
+    def test_status_absent_when_missing(self, provisioner: TestDbProvisioner) -> None:
+        assert (
+            provisioner.template_status(_TEMPLATE, "hash-v1").state is TemplateState.ABSENT
+        )
+
+
+class TestDropSafety:
+    def test_drop_clone(self, provisioner: TestDbProvisioner) -> None:
+        provisioner.provision_template(_TEMPLATE, schema_hash="h", schema_sql=_SCHEMA)
+        provisioner.clone(_TEMPLATE, _CLONE)
+        assert provisioner.drop(_CLONE) is True
+        assert provisioner.template_status(_CLONE, "h").state is TemplateState.ABSENT
+
+    def test_drop_missing_returns_false(self, provisioner: TestDbProvisioner) -> None:
+        assert provisioner.drop(_CLONE) is False
+
+    def test_drop_refuses_unmanaged_database(self, provisioner: TestDbProvisioner) -> None:
+        # 'postgres' exists but is not confiture-managed → must refuse.
+        with pytest.raises(ConfigurationError, match="not a confiture-managed"):
+            provisioner.drop("postgres")
+
+
+class TestConcurrencyAndPrune:
+    def test_concurrent_clones_no_deadlock(self, provisioner: TestDbProvisioner) -> None:
+        provisioner.provision_template(_TEMPLATE, schema_hash="h", schema_sql=_SCHEMA)
+        errors: list[Exception] = []
+
+        def _clone(i: int) -> None:
+            try:
+                provisioner.clone(_TEMPLATE, f"{_CLONE}_{i}")
+            except Exception as e:  # noqa: BLE001 - recorded for assertion
+                errors.append(e)
+
+        threads = [threading.Thread(target=_clone, args=(i,)) for i in range(6)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, errors
+        for i in range(6):
+            assert _tables(provisioner, f"{_CLONE}_{i}") == {"widget"}
+
+    def test_prune_drops_all_clones_of_template(
+        self, provisioner: TestDbProvisioner
+    ) -> None:
+        provisioner.provision_template(_TEMPLATE, schema_hash="h", schema_sql=_SCHEMA)
+        provisioner.clone(_TEMPLATE, f"{_CLONE}_0")
+        provisioner.clone(_TEMPLATE, f"{_CLONE}_1")
+
+        dropped = provisioner.prune(_TEMPLATE)
+
+        assert set(dropped) == {f"{_CLONE}_0", f"{_CLONE}_1"}
+        # Template itself survives prune.
+        assert provisioner.template_status(_TEMPLATE, "h").state is TemplateState.CURRENT

--- a/tests/unit/test_cli_build_dump.py
+++ b/tests/unit/test_cli_build_dump.py
@@ -1,0 +1,123 @@
+"""Unit tests for `confiture build --dump` CLI wiring (P1, Cycle 3).
+
+The artifact orchestrator is mocked, so no real database or pg_dump is needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.schema_artifact import ArtifactResult
+
+runner = CliRunner()
+
+
+def _project(tmp_path: Path) -> Path:
+    schema_dir = tmp_path / "db" / "schema"
+    schema_dir.mkdir(parents=True)
+    (schema_dir / "01_test.sql").write_text("CREATE TABLE t (id int);")
+    env_dir = tmp_path / "db" / "environments"
+    env_dir.mkdir(parents=True)
+    (env_dir / "local.yaml").write_text(
+        f"""
+name: local
+database_url: "postgresql://localhost/confiture_test"
+include_dirs:
+  - {schema_dir}
+"""
+    )
+    return tmp_path
+
+
+class TestBuildDump:
+    @patch("confiture.cli.commands.schema.build_schema_artifact")
+    def test_dump_invokes_orchestrator_and_reports_artifact(self, mock_build, tmp_path):
+        _project(tmp_path)
+        out = tmp_path / "art" / "test.pgdump"
+        mock_build.return_value = ArtifactResult(
+            artifact_path=out,
+            artifact_hash="abcdef0123456789",
+            dump_format="custom",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "build",
+                "--env",
+                "local",
+                "--project-dir",
+                str(tmp_path),
+                "--dump",
+                str(out),
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_build.assert_called_once()
+        # The artifact fields surface in the JSON envelope.
+        assert "abcdef0123456789" in result.stdout
+        assert "test.pgdump" in result.stdout
+
+    @patch("confiture.cli.commands.schema.build_schema_artifact")
+    def test_dump_format_directory_passed_through(self, mock_build, tmp_path):
+        _project(tmp_path)
+        out = tmp_path / "art" / "test.pgdir"
+        mock_build.return_value = ArtifactResult(
+            artifact_path=out, artifact_hash="h" * 16, dump_format="directory"
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "build",
+                "--env",
+                "local",
+                "--project-dir",
+                str(tmp_path),
+                "--dump",
+                str(out),
+                "--dump-format",
+                "directory",
+            ],
+        )
+
+        assert result.exit_code == 0
+        _, kwargs = mock_build.call_args
+        assert kwargs["dump_format"] == "directory"
+
+    @patch("confiture.cli.commands.schema.build_schema_artifact")
+    def test_invalid_dump_format_exits_5(self, mock_build, tmp_path):
+        _project(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "build",
+                "--env",
+                "local",
+                "--project-dir",
+                str(tmp_path),
+                "--dump",
+                str(tmp_path / "x.pgdump"),
+                "--dump-format",
+                "bogus",
+            ],
+        )
+        assert result.exit_code == 5
+        mock_build.assert_not_called()
+
+    @patch("confiture.cli.commands.schema.build_schema_artifact")
+    def test_no_dump_leaves_behaviour_unchanged(self, mock_build, tmp_path):
+        _project(tmp_path)
+        result = runner.invoke(
+            app,
+            ["build", "--env", "local", "--project-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0
+        mock_build.assert_not_called()

--- a/tests/unit/test_cli_seed_profile.py
+++ b/tests/unit/test_cli_seed_profile.py
@@ -44,18 +44,28 @@ def _project(tmp_path: Path, *, profiles: bool = True) -> None:
 class TestSeedApplyProfile:
     @patch("confiture.cli.seed.SeedApplier")
     @patch("confiture.core.connection.create_connection")
-    def test_profile_threaded_to_applier(
-        self, _mock_conn, mock_applier_cls, tmp_path, monkeypatch
-    ):
+    def test_profile_threaded_to_applier(self, _mock_conn, mock_applier_cls, tmp_path, monkeypatch):
         _project(tmp_path)
         monkeypatch.chdir(tmp_path)
         mock_applier_cls.return_value.apply_sequential.return_value = ApplyResult(total=0)
 
         result = runner.invoke(
             app,
-            ["seed", "apply", "--sequential", "--env", "local",
-             "--seeds-dir", str(tmp_path / "db" / "seeds"),
-             "--database-url", _URL, "--profile", "slim", "--format", "json"],
+            [
+                "seed",
+                "apply",
+                "--sequential",
+                "--env",
+                "local",
+                "--seeds-dir",
+                str(tmp_path / "db" / "seeds"),
+                "--database-url",
+                _URL,
+                "--profile",
+                "slim",
+                "--format",
+                "json",
+            ],
         )
 
         assert result.exit_code == 0, result.output
@@ -68,9 +78,19 @@ class TestSeedApplyProfile:
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(
             app,
-            ["seed", "apply", "--sequential", "--env", "local",
-             "--seeds-dir", str(tmp_path / "db" / "seeds"),
-             "--database-url", _URL, "--profile", "nope"],
+            [
+                "seed",
+                "apply",
+                "--sequential",
+                "--env",
+                "local",
+                "--seeds-dir",
+                str(tmp_path / "db" / "seeds"),
+                "--database-url",
+                _URL,
+                "--profile",
+                "nope",
+            ],
         )
         assert result.exit_code == 5
         assert "Unknown seed profile" in result.output
@@ -81,8 +101,7 @@ class TestBuildSeedProfile:
         _project(tmp_path)
         result = runner.invoke(
             app,
-            ["build", "--env", "local", "--project-dir", str(tmp_path),
-             "--seed-profile", "nope"],
+            ["build", "--env", "local", "--project-dir", str(tmp_path), "--seed-profile", "nope"],
         )
         assert result.exit_code == 5
         assert "Unknown seed profile" in result.output
@@ -103,8 +122,17 @@ class TestBuildSeedProfile:
         mock_build.side_effect = _capture
         result = runner.invoke(
             app,
-            ["build", "--env", "local", "--project-dir", str(tmp_path),
-             "--dump", str(art_dir), "--seed-profile", "slim"],
+            [
+                "build",
+                "--env",
+                "local",
+                "--project-dir",
+                str(tmp_path),
+                "--dump",
+                str(art_dir),
+                "--seed-profile",
+                "slim",
+            ],
         )
         assert result.exit_code == 0, result.output
         # The content-addressed name carries the profile segment.
@@ -117,8 +145,16 @@ class TestProvisionTemplateSeedProfile:
         _project(tmp_path)
         result = runner.invoke(
             app,
-            ["test-db", "provision-template", "--template", "t",
-             "--project-dir", str(tmp_path), "--seed-profile", "nope"],
+            [
+                "test-db",
+                "provision-template",
+                "--template",
+                "t",
+                "--project-dir",
+                str(tmp_path),
+                "--seed-profile",
+                "nope",
+            ],
         )
         assert result.exit_code == 5
 
@@ -130,8 +166,16 @@ class TestProvisionTemplateSeedProfile:
         )
         result = runner.invoke(
             app,
-            ["test-db", "provision-template", "--template", "t",
-             "--project-dir", str(tmp_path), "--seed-profile", "slim"],
+            [
+                "test-db",
+                "provision-template",
+                "--template",
+                "t",
+                "--project-dir",
+                str(tmp_path),
+                "--seed-profile",
+                "slim",
+            ],
         )
         assert result.exit_code == 0, result.output
         _, kwargs = mock_cls.return_value.provision_template.call_args

--- a/tests/unit/test_cli_seed_profile.py
+++ b/tests/unit/test_cli_seed_profile.py
@@ -32,12 +32,16 @@ def _project(tmp_path: Path, *, profiles: bool = True) -> None:
     (seeds_dir / "stats_1.sql").write_text("SELECT 1;")
     env_dir = tmp_path / "db" / "environments"
     env_dir.mkdir(parents=True)
-    profiles_yaml = (
-        "  profiles:\n    slim:\n      exclude:\n        - 'stats_*.sql'\n" if profiles else ""
+    # NB: do NOT set execution_mode: sequential here — it would make `build`
+    # apply seeds to a real database (this is a unit test; CI's role needs a
+    # password). The profile filtering/naming under test is DB-free.
+    seed_block = (
+        "seed:\n  profiles:\n    slim:\n      exclude:\n        - 'stats_*.sql'\n"
+        if profiles
+        else ""
     )
     (env_dir / "local.yaml").write_text(
-        f'name: local\ndatabase_url: "{_URL}"\n'
-        f"include_dirs:\n  - {schema_dir}\nseed:\n  execution_mode: sequential\n{profiles_yaml}"
+        f'name: local\ndatabase_url: "{_URL}"\ninclude_dirs:\n  - {schema_dir}\n{seed_block}'
     )
 
 

--- a/tests/unit/test_cli_seed_profile.py
+++ b/tests/unit/test_cli_seed_profile.py
@@ -1,0 +1,139 @@
+"""Unit tests for seed-profile CLI surfaces (P4, Cycle 3).
+
+Covers `seed apply --profile`, `build --seed-profile`, and
+`test-db provision-template --seed-profile`: profile resolution, the
+unknown-profile exit-5 gate, and that the profile is threaded to the applier.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.config.environment import SeedProfile
+from confiture.core.seed_applier import ApplyResult
+from confiture.core.test_db import TemplateState, TemplateStatus
+
+runner = CliRunner()
+
+_URL = "postgresql://localhost/confiture_test"
+
+
+def _project(tmp_path: Path, *, profiles: bool = True) -> None:
+    schema_dir = tmp_path / "db" / "schema"
+    schema_dir.mkdir(parents=True)
+    (schema_dir / "01.sql").write_text("CREATE TABLE t (id int);")
+    seeds_dir = tmp_path / "db" / "seeds"
+    seeds_dir.mkdir(parents=True)
+    (seeds_dir / "core_1.sql").write_text("SELECT 1;")
+    (seeds_dir / "stats_1.sql").write_text("SELECT 1;")
+    env_dir = tmp_path / "db" / "environments"
+    env_dir.mkdir(parents=True)
+    profiles_yaml = (
+        "  profiles:\n    slim:\n      exclude:\n        - 'stats_*.sql'\n" if profiles else ""
+    )
+    (env_dir / "local.yaml").write_text(
+        f'name: local\ndatabase_url: "{_URL}"\n'
+        f"include_dirs:\n  - {schema_dir}\nseed:\n  execution_mode: sequential\n{profiles_yaml}"
+    )
+
+
+class TestSeedApplyProfile:
+    @patch("confiture.cli.seed.SeedApplier")
+    @patch("confiture.core.connection.create_connection")
+    def test_profile_threaded_to_applier(
+        self, _mock_conn, mock_applier_cls, tmp_path, monkeypatch
+    ):
+        _project(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        mock_applier_cls.return_value.apply_sequential.return_value = ApplyResult(total=0)
+
+        result = runner.invoke(
+            app,
+            ["seed", "apply", "--sequential", "--env", "local",
+             "--seeds-dir", str(tmp_path / "db" / "seeds"),
+             "--database-url", _URL, "--profile", "slim", "--format", "json"],
+        )
+
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_applier_cls.return_value.apply_sequential.call_args
+        assert isinstance(kwargs["profile"], SeedProfile)
+        assert kwargs["profile"].exclude == ["stats_*.sql"]
+
+    def test_unknown_profile_exits_5(self, tmp_path, monkeypatch):
+        _project(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            app,
+            ["seed", "apply", "--sequential", "--env", "local",
+             "--seeds-dir", str(tmp_path / "db" / "seeds"),
+             "--database-url", _URL, "--profile", "nope"],
+        )
+        assert result.exit_code == 5
+        assert "Unknown seed profile" in result.output
+
+
+class TestBuildSeedProfile:
+    def test_unknown_profile_exits_5(self, tmp_path):
+        _project(tmp_path)
+        result = runner.invoke(
+            app,
+            ["build", "--env", "local", "--project-dir", str(tmp_path),
+             "--seed-profile", "nope"],
+        )
+        assert result.exit_code == 5
+        assert "Unknown seed profile" in result.output
+
+    @patch("confiture.cli.commands.schema.build_schema_artifact")
+    def test_seed_profile_in_artifact_name(self, mock_build, tmp_path):
+        from confiture.core.schema_artifact import ArtifactResult
+
+        _project(tmp_path)
+        art_dir = tmp_path / "art"
+        art_dir.mkdir()
+        captured = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return ArtifactResult(kwargs["output_path"], "hash", "custom")
+
+        mock_build.side_effect = _capture
+        result = runner.invoke(
+            app,
+            ["build", "--env", "local", "--project-dir", str(tmp_path),
+             "--dump", str(art_dir), "--seed-profile", "slim"],
+        )
+        assert result.exit_code == 0, result.output
+        # The content-addressed name carries the profile segment.
+        assert ".slim." in Path(captured["output_path"]).name
+
+
+class TestProvisionTemplateSeedProfile:
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_unknown_profile_exits_5(self, _mock_cls, tmp_path):
+        _project(tmp_path)
+        result = runner.invoke(
+            app,
+            ["test-db", "provision-template", "--template", "t",
+             "--project-dir", str(tmp_path), "--seed-profile", "nope"],
+        )
+        assert result.exit_code == 5
+
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_profile_filters_seed_files(self, mock_cls, tmp_path):
+        _project(tmp_path)
+        mock_cls.return_value.provision_template.return_value = TemplateStatus(
+            "t", TemplateState.CURRENT, "h", "h"
+        )
+        result = runner.invoke(
+            app,
+            ["test-db", "provision-template", "--template", "t",
+             "--project-dir", str(tmp_path), "--seed-profile", "slim"],
+        )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_cls.return_value.provision_template.call_args
+        names = [Path(p).name for p in (kwargs.get("seed_files") or [])]
+        assert "stats_1.sql" not in names  # excluded by slim

--- a/tests/unit/test_cli_test_db.py
+++ b/tests/unit/test_cli_test_db.py
@@ -1,0 +1,144 @@
+"""Unit tests for the `confiture test-db` CLI group (P2).
+
+TestDbProvisioner is mocked, so no database is needed. Builder-backed commands
+(provision-template, status) run against a tiny tmp project.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.test_db import (
+    CloneResult,
+    ManagedDatabase,
+    TemplateState,
+    TemplateStatus,
+)
+from confiture.exceptions import ConfigurationError
+
+runner = CliRunner()
+
+_URL = "postgresql://localhost/confiture_test"
+
+
+def _project(tmp_path: Path) -> None:
+    schema_dir = tmp_path / "db" / "schema"
+    schema_dir.mkdir(parents=True)
+    (schema_dir / "01.sql").write_text("CREATE TABLE t (id int);")
+    env_dir = tmp_path / "db" / "environments"
+    env_dir.mkdir(parents=True)
+    (env_dir / "local.yaml").write_text(
+        f'name: local\ndatabase_url: "{_URL}"\ninclude_dirs:\n  - {schema_dir}\n'
+    )
+
+
+class TestClone:
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_clone_invokes_provisioner(self, mock_cls: MagicMock) -> None:
+        prov = mock_cls.return_value
+        prov.clone.return_value = CloneResult("tmpl", "c0", f"{_URL[:-15]}/c0")
+        result = runner.invoke(
+            app,
+            ["test-db", "clone", "--template", "tmpl", "--target", "c0",
+             "--database-url", _URL, "--format", "json"],
+        )
+        assert result.exit_code == 0
+        prov.clone.assert_called_once_with("tmpl", "c0")
+        assert '"target": "c0"' in result.stdout
+
+
+class TestDrop:
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_drop_invokes_provisioner(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value.drop.return_value = True
+        result = runner.invoke(
+            app, ["test-db", "drop", "--target", "c0", "--database-url", _URL]
+        )
+        assert result.exit_code == 0
+        mock_cls.return_value.drop.assert_called_once_with("c0", force=False)
+
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_drop_unmanaged_exits_5(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value.drop.side_effect = ConfigurationError(
+            "Refusing to drop 'postgres': not a confiture-managed template/clone.",
+            error_code="CONFIG_010",
+        )
+        result = runner.invoke(
+            app, ["test-db", "drop", "--target", "postgres", "--database-url", _URL]
+        )
+        assert result.exit_code == 5
+
+
+class TestStatus:
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_status_current_exits_0(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        _project(tmp_path)
+        mock_cls.return_value.template_status.return_value = TemplateStatus(
+            "tmpl", TemplateState.CURRENT, "h", "h"
+        )
+        result = runner.invoke(
+            app,
+            ["test-db", "status", "--template", "tmpl", "--project-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0
+
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_status_stale_exits_1(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        _project(tmp_path)
+        mock_cls.return_value.template_status.return_value = TemplateStatus(
+            "tmpl", TemplateState.STALE, "old", "new"
+        )
+        result = runner.invoke(
+            app,
+            ["test-db", "status", "--template", "tmpl", "--project-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 1
+
+
+class TestProvisionTemplate:
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_provision_ddl_path(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+        _project(tmp_path)
+        mock_cls.return_value.provision_template.return_value = TemplateStatus(
+            "tmpl", TemplateState.CURRENT, "h", "h"
+        )
+        result = runner.invoke(
+            app,
+            ["test-db", "provision-template", "--template", "tmpl",
+             "--project-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0
+        # DDL path → schema_sql passed, not from_artifact.
+        _, kwargs = mock_cls.return_value.provision_template.call_args
+        assert kwargs.get("schema_sql") is not None
+        assert kwargs.get("from_artifact") is None
+
+
+class TestListAndPrune:
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_list_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value.list_databases.return_value = [
+            ManagedDatabase("tmpl", "template", "h"),
+            ManagedDatabase("c0", "clone", "tmpl"),
+        ]
+        result = runner.invoke(
+            app, ["test-db", "list", "--database-url", _URL, "--format", "json"]
+        )
+        assert result.exit_code == 0
+        assert '"name": "c0"' in result.stdout
+
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_prune_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value.prune.return_value = ["c0", "c1"]
+        result = runner.invoke(
+            app,
+            ["test-db", "prune", "--template", "tmpl", "--database-url", _URL,
+             "--format", "json"],
+        )
+        assert result.exit_code == 0
+        mock_cls.return_value.prune.assert_called_once_with("tmpl")
+        assert '"dropped": [' in result.stdout

--- a/tests/unit/test_cli_test_db.py
+++ b/tests/unit/test_cli_test_db.py
@@ -50,6 +50,22 @@ class TestClone:
         prov.clone.assert_called_once_with("tmpl", "c0")
         assert '"target": "c0"' in result.stdout
 
+    @patch("confiture.cli.test_db.TestDbProvisioner")
+    def test_clone_json_redacts_dsn_password(self, mock_cls: MagicMock) -> None:
+        prov = mock_cls.return_value
+        prov.clone.return_value = CloneResult(
+            "tmpl", "c0", "postgresql://user:secretpw@host:5432/c0"
+        )
+        result = runner.invoke(
+            app,
+            ["test-db", "clone", "--template", "tmpl", "--target", "c0",
+             "--database-url", "postgresql://user:secretpw@host:5432/db",
+             "--format", "json"],
+        )
+        assert result.exit_code == 0
+        assert "secretpw" not in result.stdout
+        assert "***" in result.stdout
+
 
 class TestDrop:
     @patch("confiture.cli.test_db.TestDbProvisioner")

--- a/tests/unit/test_cli_test_db.py
+++ b/tests/unit/test_cli_test_db.py
@@ -43,8 +43,18 @@ class TestClone:
         prov.clone.return_value = CloneResult("tmpl", "c0", f"{_URL[:-15]}/c0")
         result = runner.invoke(
             app,
-            ["test-db", "clone", "--template", "tmpl", "--target", "c0",
-             "--database-url", _URL, "--format", "json"],
+            [
+                "test-db",
+                "clone",
+                "--template",
+                "tmpl",
+                "--target",
+                "c0",
+                "--database-url",
+                _URL,
+                "--format",
+                "json",
+            ],
         )
         assert result.exit_code == 0
         prov.clone.assert_called_once_with("tmpl", "c0")
@@ -58,9 +68,18 @@ class TestClone:
         )
         result = runner.invoke(
             app,
-            ["test-db", "clone", "--template", "tmpl", "--target", "c0",
-             "--database-url", "postgresql://user:secretpw@host:5432/db",
-             "--format", "json"],
+            [
+                "test-db",
+                "clone",
+                "--template",
+                "tmpl",
+                "--target",
+                "c0",
+                "--database-url",
+                "postgresql://user:secretpw@host:5432/db",
+                "--format",
+                "json",
+            ],
         )
         assert result.exit_code == 0
         assert "secretpw" not in result.stdout
@@ -71,9 +90,7 @@ class TestDrop:
     @patch("confiture.cli.test_db.TestDbProvisioner")
     def test_drop_invokes_provisioner(self, mock_cls: MagicMock) -> None:
         mock_cls.return_value.drop.return_value = True
-        result = runner.invoke(
-            app, ["test-db", "drop", "--target", "c0", "--database-url", _URL]
-        )
+        result = runner.invoke(app, ["test-db", "drop", "--target", "c0", "--database-url", _URL])
         assert result.exit_code == 0
         mock_cls.return_value.drop.assert_called_once_with("c0", force=False)
 
@@ -124,8 +141,7 @@ class TestProvisionTemplate:
         )
         result = runner.invoke(
             app,
-            ["test-db", "provision-template", "--template", "tmpl",
-             "--project-dir", str(tmp_path)],
+            ["test-db", "provision-template", "--template", "tmpl", "--project-dir", str(tmp_path)],
         )
         assert result.exit_code == 0
         # DDL path → schema_sql passed, not from_artifact.
@@ -141,9 +157,7 @@ class TestListAndPrune:
             ManagedDatabase("tmpl", "template", "h"),
             ManagedDatabase("c0", "clone", "tmpl"),
         ]
-        result = runner.invoke(
-            app, ["test-db", "list", "--database-url", _URL, "--format", "json"]
-        )
+        result = runner.invoke(app, ["test-db", "list", "--database-url", _URL, "--format", "json"])
         assert result.exit_code == 0
         assert '"name": "c0"' in result.stdout
 
@@ -152,8 +166,7 @@ class TestListAndPrune:
         mock_cls.return_value.prune.return_value = ["c0", "c1"]
         result = runner.invoke(
             app,
-            ["test-db", "prune", "--template", "tmpl", "--database-url", _URL,
-             "--format", "json"],
+            ["test-db", "prune", "--template", "tmpl", "--database-url", _URL, "--format", "json"],
         )
         assert result.exit_code == 0
         mock_cls.return_value.prune.assert_called_once_with("tmpl")

--- a/tests/unit/test_no_raw_exit_convention.py
+++ b/tests/unit/test_no_raw_exit_convention.py
@@ -89,6 +89,7 @@ _ALLOWLIST: dict[str, int] = {
     "helpers.py": 2,  # success-signal: idempotency gate → Exit(1) on findings
     # commands/mcp.py: fully converted (Cycle 1) — connection → CONFIG_006,
     # missing-extra → generic ConfiturError, both via fail().
+    "test_db.py": 1,  # success-signal: test-db status → Exit(1) on stale/absent template (CI gate)
 }
 
 _EXCLUDED = {"error_json.py"}

--- a/tests/unit/test_schema_artifact.py
+++ b/tests/unit/test_schema_artifact.py
@@ -60,9 +60,7 @@ class TestDump:
     @patch("confiture.core.schema_artifact.subprocess.run")
     def test_dump_invokes_pg_dump(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
-        SchemaArtifactDumper().dump(
-            "postgresql://localhost/tmp", Path("/out/a.pgdump"), "custom"
-        )
+        SchemaArtifactDumper().dump("postgresql://localhost/tmp", Path("/out/a.pgdump"), "custom")
         argv = mock_run.call_args.args[0]
         assert argv[0] == "pg_dump"
         assert "-Fc" in argv
@@ -130,9 +128,7 @@ class TestBuildArtifactSkip:
         dumper.dump.assert_not_called()
 
     @patch("confiture.core.schema_artifact.TempDatabase")
-    def test_builds_and_dumps_when_absent(
-        self, mock_tempdb: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_builds_and_dumps_when_absent(self, mock_tempdb: MagicMock, tmp_path: Path) -> None:
         # TempDatabase context yields a temp URL; apply_schema is a no-op mock.
         instance = mock_tempdb.return_value
         instance.__enter__.return_value = "postgresql://localhost/confiture_tmp_x"

--- a/tests/unit/test_schema_artifact.py
+++ b/tests/unit/test_schema_artifact.py
@@ -1,0 +1,153 @@
+"""Unit tests for the cacheable schema-artifact dumper (P1).
+
+Subprocess and TempDatabase are mocked; no real database or pg_dump is needed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from confiture.core.schema_artifact import (
+    ArtifactResult,
+    SchemaArtifactDumper,
+    build_schema_artifact,
+    default_artifact_path,
+)
+from confiture.exceptions import SchemaError
+
+# ---------------------------------------------------------------------------
+# Cycle 1: dumper core — argv construction + error paths
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgv:
+    def test_custom_format_argv(self) -> None:
+        argv = SchemaArtifactDumper().build_argv(
+            "postgresql://localhost/tmp", Path("/out/a.pgdump"), "custom"
+        )
+        assert argv == [
+            "pg_dump",
+            "-Fc",
+            "-d",
+            "postgresql://localhost/tmp",
+            "-f",
+            "/out/a.pgdump",
+        ]
+
+    def test_directory_format_argv_has_parallel_jobs(self) -> None:
+        argv = SchemaArtifactDumper(jobs=8).build_argv(
+            "postgresql://localhost/tmp", Path("/out/a.pgdir"), "directory"
+        )
+        assert argv[:4] == ["pg_dump", "-Fd", "-j", "8"]
+        assert argv[-4:] == ["-d", "postgresql://localhost/tmp", "-f", "/out/a.pgdir"]
+
+    def test_directory_format_single_job_omits_j(self) -> None:
+        argv = SchemaArtifactDumper(jobs=1).build_argv(
+            "postgresql://localhost/tmp", Path("/out/a.pgdir"), "directory"
+        )
+        assert "-j" not in argv
+
+    def test_unsupported_format_raises(self) -> None:
+        with pytest.raises(SchemaError, match="dump format"):
+            SchemaArtifactDumper().build_argv("postgresql://x/y", Path("/o"), "plain")
+
+
+class TestDump:
+    @patch("confiture.core.schema_artifact.subprocess.run")
+    def test_dump_invokes_pg_dump(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        SchemaArtifactDumper().dump(
+            "postgresql://localhost/tmp", Path("/out/a.pgdump"), "custom"
+        )
+        argv = mock_run.call_args.args[0]
+        assert argv[0] == "pg_dump"
+        assert "-Fc" in argv
+
+    @patch("confiture.core.schema_artifact.subprocess.run")
+    def test_dump_raises_on_nonzero_returncode(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            [], 1, "", "pg_dump: error: connection failed\n"
+        )
+        with pytest.raises(SchemaError, match="connection failed"):
+            SchemaArtifactDumper().dump("postgresql://x/y", Path("/o"), "custom")
+
+    @patch(
+        "confiture.core.schema_artifact.subprocess.run",
+        side_effect=FileNotFoundError("pg_dump"),
+    )
+    def test_dump_raises_when_pg_dump_missing(self, _mock_run: MagicMock) -> None:
+        with pytest.raises(SchemaError, match="pg_dump not found"):
+            SchemaArtifactDumper().dump("postgresql://x/y", Path("/o"), "custom")
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2: content-addressing + idempotent skip
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultArtifactPath:
+    def test_name_embeds_short_hash(self) -> None:
+        path = default_artifact_path(Path("/art"), "test", "abcdef0123456789", profile=None)
+        assert path.name == "schema_test.full.abcdef012345.pgdump"
+
+    def test_name_embeds_profile(self) -> None:
+        path = default_artifact_path(Path("/art"), "test", "abcdef0123456789", profile="slim")
+        assert path.name == "schema_test.slim.abcdef012345.pgdump"
+
+    def test_directory_format_uses_pgdir_extension(self) -> None:
+        path = default_artifact_path(
+            Path("/art"), "test", "abcdef0123456789", dump_format="directory"
+        )
+        assert path.suffix == ".pgdir"
+
+    def test_distinct_profiles_do_not_collide(self) -> None:
+        full = default_artifact_path(Path("/a"), "test", "deadbeefcafe", profile="full")
+        slim = default_artifact_path(Path("/a"), "test", "deadbeefcafe", profile="slim")
+        assert full != slim
+
+
+class TestBuildArtifactSkip:
+    def test_skips_when_artifact_already_exists(self, tmp_path: Path) -> None:
+        existing = tmp_path / "schema_test.full.abcdef012345.pgdump"
+        existing.write_bytes(b"PGDMP-stub")
+        dumper = MagicMock(spec=SchemaArtifactDumper)
+
+        result = build_schema_artifact(
+            server_url="postgresql://localhost/postgres",
+            schema_sql="CREATE TABLE t (id int);",
+            output_path=existing,
+            schema_hash="abcdef0123456789",
+            dumper=dumper,
+        )
+
+        assert isinstance(result, ArtifactResult)
+        assert result.skipped is True
+        assert result.artifact_hash == "abcdef0123456789"
+        dumper.dump.assert_not_called()
+
+    @patch("confiture.core.schema_artifact.TempDatabase")
+    def test_builds_and_dumps_when_absent(
+        self, mock_tempdb: MagicMock, tmp_path: Path
+    ) -> None:
+        # TempDatabase context yields a temp URL; apply_schema is a no-op mock.
+        instance = mock_tempdb.return_value
+        instance.__enter__.return_value = "postgresql://localhost/confiture_tmp_x"
+        instance.__exit__.return_value = False
+        dumper = MagicMock(spec=SchemaArtifactDumper)
+        out = tmp_path / "schema_test.full.abcdef012345.pgdump"
+
+        result = build_schema_artifact(
+            server_url="postgresql://localhost/postgres",
+            schema_sql="CREATE TABLE t (id int);",
+            output_path=out,
+            schema_hash="abcdef0123456789",
+            dumper=dumper,
+        )
+
+        assert result.skipped is False
+        instance.apply_schema.assert_called_once()
+        dumper.dump.assert_called_once()

--- a/tests/unit/test_seed_profile_filter.py
+++ b/tests/unit/test_seed_profile_filter.py
@@ -1,0 +1,76 @@
+"""Unit tests for seed-profile filtering and config (P4, Cycles 1–2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from confiture.config.environment import SeedConfig, SeedProfile
+from confiture.core.seed_applier import SeedApplier
+from confiture.exceptions import ConfigurationError
+
+
+def _seeds(tmp_path: Path, names: list[str]) -> Path:
+    d = tmp_path / "seeds"
+    d.mkdir()
+    for n in names:
+        (d / n).write_text("SELECT 1;")
+    return d
+
+
+class TestFindSeedFilesProfile:
+    def test_none_returns_all_sorted(self, tmp_path: Path) -> None:
+        d = _seeds(tmp_path, ["c.sql", "a.sql", "b.sql"])
+        applier = SeedApplier(seeds_dir=d)
+        assert [f.name for f in applier.find_seed_files()] == ["a.sql", "b.sql", "c.sql"]
+
+    def test_exclude_filters_matching(self, tmp_path: Path) -> None:
+        d = _seeds(tmp_path, ["a.sql", "stats_1.sql", "stats_2.sql", "c.sql"])
+        applier = SeedApplier(seeds_dir=d)
+        files = applier.find_seed_files(profile=SeedProfile(exclude=["stats_*.sql"]))
+        assert [f.name for f in files] == ["a.sql", "c.sql"]
+
+    def test_include_selects_only_matching(self, tmp_path: Path) -> None:
+        d = _seeds(tmp_path, ["a.sql", "core_1.sql", "core_2.sql"])
+        applier = SeedApplier(seeds_dir=d)
+        files = applier.find_seed_files(profile=SeedProfile(include=["core_*.sql"]))
+        assert [f.name for f in files] == ["core_1.sql", "core_2.sql"]
+
+    def test_include_then_exclude(self, tmp_path: Path) -> None:
+        d = _seeds(tmp_path, ["core_1.sql", "core_2.sql", "core_big.sql"])
+        applier = SeedApplier(seeds_dir=d)
+        files = applier.find_seed_files(
+            profile=SeedProfile(include=["core_*.sql"], exclude=["core_big.sql"])
+        )
+        assert [f.name for f in files] == ["core_1.sql", "core_2.sql"]
+
+    def test_order_preserved_after_filter(self, tmp_path: Path) -> None:
+        d = _seeds(tmp_path, ["01_a.sql", "02_stats.sql", "03_b.sql"])
+        applier = SeedApplier(seeds_dir=d)
+        files = applier.find_seed_files(profile=SeedProfile(exclude=["*stats*"]))
+        assert [f.name for f in files] == ["01_a.sql", "03_b.sql"]
+
+
+class TestSeedConfigProfiles:
+    def test_absent_profiles_defaults_empty(self) -> None:
+        assert SeedConfig().profiles == {}
+
+    def test_parses_profiles(self) -> None:
+        cfg = SeedConfig(profiles={"slim": {"exclude": ["stats_*.sql"]}})
+        assert cfg.profiles["slim"].exclude == ["stats_*.sql"]
+        assert cfg.profiles["slim"].include == []
+
+    def test_get_profile_returns_defined(self) -> None:
+        cfg = SeedConfig(profiles={"slim": {"include": ["core_*.sql"]}})
+        assert cfg.get_profile("slim").include == ["core_*.sql"]
+
+    def test_get_profile_unknown_raises_config_error(self) -> None:
+        cfg = SeedConfig(profiles={"slim": {}})
+        with pytest.raises(ConfigurationError, match="Unknown seed profile"):
+            cfg.get_profile("nope")
+
+    def test_get_profile_lists_defined_in_message(self) -> None:
+        cfg = SeedConfig(profiles={"slim": {}, "full": {}})
+        with pytest.raises(ConfigurationError, match="full, slim"):
+            cfg.get_profile("nope")

--- a/tests/unit/test_test_db.py
+++ b/tests/unit/test_test_db.py
@@ -1,0 +1,119 @@
+"""Unit tests for the test-db provisioner's pure logic (P2).
+
+Identifier validation, SQL composition, and template-status classification are
+testable without a database. DB-touching behaviour is integration-tested.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.test_db import (
+    TemplateState,
+    TestDbProvisioner,
+    _classify_template,
+    _clone_sql,
+    _comment_sql,
+    _create_db_sql,
+    _managed_kind,
+    _validate_identifier,
+)
+from confiture.exceptions import ConfigurationError
+
+# ---------------------------------------------------------------------------
+# Identifier validation (injection guard)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateIdentifier:
+    @pytest.mark.parametrize("name", ["t", "t_gw0", "confiture_template", "App_DB_1", "_x"])
+    def test_accepts_valid(self, name: str) -> None:
+        _validate_identifier(name)  # does not raise
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",
+            "1abc",  # leading digit
+            "a b",  # space
+            'a"; DROP DATABASE postgres; --',  # injection attempt
+            "a-b",  # hyphen
+            "a" * 64,  # too long (>63)
+            "naïve",  # non-ascii
+        ],
+    )
+    def test_rejects_invalid(self, name: str) -> None:
+        with pytest.raises(ConfigurationError):
+            _validate_identifier(name)
+
+
+# ---------------------------------------------------------------------------
+# SQL composition — identifiers are quoted, never interpolated
+# ---------------------------------------------------------------------------
+
+
+class TestSqlComposition:
+    def test_clone_sql_quotes_identifiers(self) -> None:
+        assert (
+            _clone_sql("t_gw0", "tmpl").as_string(None)
+            == 'CREATE DATABASE "t_gw0" WITH TEMPLATE "tmpl"'
+        )
+
+    def test_create_db_sql(self) -> None:
+        assert _create_db_sql("tmpl").as_string(None) == 'CREATE DATABASE "tmpl"'
+
+    def test_comment_sql_quotes_name_and_literal(self) -> None:
+        sql = _comment_sql("tmpl", "confiture:template:deadbeef").as_string(None)
+        assert sql == "COMMENT ON DATABASE \"tmpl\" IS 'confiture:template:deadbeef'"
+
+
+# ---------------------------------------------------------------------------
+# Template-status classification (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTemplate:
+    def test_absent_when_db_missing(self) -> None:
+        st = _classify_template(comment=None, current_hash="h1", exists=False)
+        assert st.state is TemplateState.ABSENT
+
+    def test_current_when_hash_matches(self) -> None:
+        st = _classify_template(
+            comment="confiture:template:h1", current_hash="h1", exists=True
+        )
+        assert st.state is TemplateState.CURRENT
+        assert st.stored_hash == "h1"
+
+    def test_stale_when_hash_differs(self) -> None:
+        st = _classify_template(
+            comment="confiture:template:OLD", current_hash="NEW", exists=True
+        )
+        assert st.state is TemplateState.STALE
+        assert st.stored_hash == "OLD"
+
+    def test_absent_when_db_exists_but_unmanaged(self) -> None:
+        st = _classify_template(comment=None, current_hash="h1", exists=True)
+        assert st.state is TemplateState.ABSENT
+
+
+class TestManagedKind:
+    def test_template(self) -> None:
+        assert _managed_kind("confiture:template:abc") == "template"
+
+    def test_clone(self) -> None:
+        assert _managed_kind("confiture:clone:tmpl") == "clone"
+
+    def test_unmanaged(self) -> None:
+        assert _managed_kind(None) is None
+        assert _managed_kind("some user comment") is None
+
+
+# ---------------------------------------------------------------------------
+# Provisioner wiring (maintenance URL derivation)
+# ---------------------------------------------------------------------------
+
+
+class TestProvisionerInit:
+    def test_derives_maintenance_url(self) -> None:
+        prov = TestDbProvisioner("postgresql://localhost/myapp")
+        assert prov.maintenance_url == "postgresql://localhost/postgres"

--- a/tests/unit/test_test_db.py
+++ b/tests/unit/test_test_db.py
@@ -78,16 +78,12 @@ class TestClassifyTemplate:
         assert st.state is TemplateState.ABSENT
 
     def test_current_when_hash_matches(self) -> None:
-        st = _classify_template(
-            comment="confiture:template:h1", current_hash="h1", exists=True
-        )
+        st = _classify_template(comment="confiture:template:h1", current_hash="h1", exists=True)
         assert st.state is TemplateState.CURRENT
         assert st.stored_hash == "h1"
 
     def test_stale_when_hash_differs(self) -> None:
-        st = _classify_template(
-            comment="confiture:template:OLD", current_hash="NEW", exists=True
-        )
+        st = _classify_template(comment="confiture:template:OLD", current_hash="NEW", exists=True)
         assert st.state is TemplateState.STALE
         assert st.stored_hash == "OLD"
 

--- a/tests/unit/test_worker_db_name.py
+++ b/tests/unit/test_worker_db_name.py
@@ -1,0 +1,73 @@
+"""Unit tests for per-worker DB name/URL resolution (P3, Cycle 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.testing.worker_db import (
+    current_worker_id,
+    resolve_worker_db_name,
+    resolve_worker_db_url,
+)
+
+
+class TestResolveWorkerDbName:
+    def test_gw0_appends_suffix(self) -> None:
+        assert resolve_worker_db_name("app", worker_id="gw0") == "app_gw0"
+
+    def test_gw11_appends_suffix(self) -> None:
+        assert resolve_worker_db_name("app", worker_id="gw11") == "app_gw11"
+
+    def test_none_returns_base(self) -> None:
+        assert resolve_worker_db_name("app", worker_id=None) == "app"
+
+    def test_master_returns_base(self) -> None:
+        assert resolve_worker_db_name("app", worker_id="master") == "app"
+
+    def test_idempotent_same_suffix(self) -> None:
+        assert resolve_worker_db_name("app_gw0", worker_id="gw0") == "app_gw0"
+
+    def test_re_resolves_different_worker(self) -> None:
+        # An already-suffixed base must not double-suffix.
+        assert resolve_worker_db_name("app_gw0", worker_id="gw1") == "app_gw1"
+
+    def test_unknown_worker_form_falls_back_to_base(self) -> None:
+        assert resolve_worker_db_name("app", worker_id="weird") == "app"
+
+    def test_reads_env_var_when_unspecified(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+        assert resolve_worker_db_name("app") == "app_gw3"
+
+
+class TestResolveWorkerDbUrl:
+    def test_replaces_dbname(self) -> None:
+        assert (
+            resolve_worker_db_url("postgresql://localhost/app", worker_id="gw2")
+            == "postgresql://localhost/app_gw2"
+        )
+
+    def test_preserves_credentials_and_port(self) -> None:
+        url = resolve_worker_db_url(
+            "postgresql://u:p@host:5433/app", worker_id="gw0"
+        )
+        assert url == "postgresql://u:p@host:5433/app_gw0"
+
+    def test_no_worker_keeps_url(self) -> None:
+        assert (
+            resolve_worker_db_url("postgresql://localhost/app", worker_id=None)
+            == "postgresql://localhost/app"
+        )
+
+
+class TestCurrentWorkerId:
+    def test_none_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+        assert current_worker_id() is None
+
+    def test_master_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", "master")
+        assert current_worker_id() is None
+
+    def test_returns_worker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw5")
+        assert current_worker_id() == "gw5"

--- a/tests/unit/test_worker_db_name.py
+++ b/tests/unit/test_worker_db_name.py
@@ -47,9 +47,7 @@ class TestResolveWorkerDbUrl:
         )
 
     def test_preserves_credentials_and_port(self) -> None:
-        url = resolve_worker_db_url(
-            "postgresql://u:p@host:5433/app", worker_id="gw0"
-        )
+        url = resolve_worker_db_url("postgresql://u:p@host:5433/app", worker_id="gw0")
         assert url == "postgresql://u:p@host:5433/app_gw0"
 
     def test_no_worker_keeps_url(self) -> None:


### PR DESCRIPTION
Closes the plumbing gap behind issue #156: three pieces every confiture project hand-rolls for parallel-test CI, folded into one **purely additive** 0.24.0. This is a **CI-path** capability — the fraisier deploy adapter contract is unaffected.

## What's in the bundle

- **P1 — `build --dump`**: emits a content-addressed `pg_dump -Fc`/`-Fd` artifact restorable by the existing three-phase `confiture restore`. The schema (+ seeds) is built into an **ephemeral throwaway DB** and dumped from there, so the artifact content always matches the `db/` hash that names it. Unchanged `db/` ⇒ cache-hit no-op. `--dump-format custom|directory`.
- **P2 — `confiture test-db`**: `provision-template` / `clone` / `drop` / `status` / `list` / `prune`. Build a template once, hand out lock-free `CREATE DATABASE … WITH TEMPLATE` clones. Staleness is a `COMMENT ON DATABASE` read connection-free via `shobj_description`, so `status` never connects to the template (no concurrent-clone race); the comment also marks managed DBs so `drop` refuses to fat-finger a real database.
- **P3 — per-worker pytest-xdist fixtures**: each worker gets its own DB cloned from a shared, single-flight (advisory-lock) template. The **primary** integration surface is the import-time helper `confiture.testing.worker_db.resolve_worker_db_url` (callable from conftest before an app freezes its settings singleton); the fixture is convenience. `pytest-xdist` added to the `[testing]` extra.
- **P4 — slim seed profiles**: `seed.profiles.<name>` include/exclude globs, surfaced on `seed apply --profile`, `build --seed-profile`, `test-db provision-template --seed-profile`. Apply a lean test seed for faster, higher-parallel test DBs.

## Design notes (review-driven)

- Dump from an **ephemeral `TempDatabase`** (not a user live DB) so hash ≡ content; artifact name encodes env + profile + hash (no slim/full collision).
- Reuses `core/temp_database.py`'s injection-safe `CREATE`/`DROP` machinery (identifiers always quoted via `psycopg.sql.Identifier`).
- **Security:** `test-db clone --format json` redacts DSN passwords in `target_url`.

## Verification

- ✅ ruff 0.15.15 + ty 0.0.43 (CI-pinned) clean; bandit High/High: no issues
- ✅ 7278 unit + 522 integration/e2e/contract pass locally; real `pytest -n2` E2E asserts isolated per-worker DBs
- ✅ Local Dagger gate: lint / type-check / security green in-container (test/rust jobs hit Docker Hub rate limits locally — running here on GitHub)

Docs: `docs/guides/parallel-ci-provisioning.md` + CLI reference. CHANGELOG updated (additive). **Tag `v0.24.0` is intentionally held until this PR's CI is green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)