### PR TITLE
feat(grant): semantic --require-grant-migration + Python-migration recognition (#162) — 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-06-13
+
+Makes `migrate validate --require-grant-migration` **semantic** (issue #162):
+it verifies that each *changed* `GRANT`/`REVOKE` in the grant directory is
+actually carried by an accompanying migration — not merely that some migration
+happens to be in the changeset. Also recognizes Python (`.py`) migrations
+everywhere `.up.sql` migrations were recognized. (This single release folds in
+what was scoped as 0.29.0 — the Python-migration recognition fix — together
+with the semantic engine; the 0.29.0 version number was not separately cut.)
+
+### Fixed
+
+- **`--require-grant-migration` recognizes Python migrations.** `db/migrations/*.py`
+  now counts as an accompanying migration alongside `.up.sql`
+  (`_`-prefixed modules and `__init__.py` excluded), matching the canonical
+  migration loader. Previously the gate false-positived on every grant change in
+  Python-migration projects. (#162)
+- **`--check-acls` (ACL coverage lint) scans Python migrations too.** The same
+  blind spot is closed in `Acl001GrantCoverage`: a `CREATE TABLE` / `GRANT`
+  carried by a `.py` migration is now seen. (#162)
+
+### Changed
+
+- ⚠️ **`migrate validate --require-grant-migration` is now semantic.** It verifies
+  that each *changed* `GRANT`/`REVOKE` in the grant directory is actually carried
+  by an accompanying migration, for both SQL (`.up.sql`) and Python (`.py`)
+  migrations. Coverage spans GRANT/REVOKE across table, schema-wide
+  (`… IN SCHEMA`), sequence, and function objects. The required set is diffed
+  against the **merge-base** of your base and target refs.
+  - **Tightening:** a branch that previously passed because an *unrelated*
+    migration happened to be present may now fail — the failure names the
+    missing grant (object, privilege, grantee) and the migration(s) inspected.
+  - **Loosening:** a comment-only / whitespace-only / reorder-only edit to a
+    grant file (nothing semantically changed) now passes without requiring a
+    migration.
+  - **Honest degradation (never silent-pass):** grants that can't be statically
+    verified — dynamic SQL, parse failures, object classes outside
+    table/schema/sequence/function (`ON DATABASE`, `LANGUAGE`, `TYPE`,
+    `DOMAIN`, `FOREIGN DATA WRAPPER`, `TABLESPACE`, …), `ALTER DEFAULT
+    PRIVILEGES`, column-level privileges, `WITH GRANT OPTION`-only changes,
+    grants behind a non-public `SET search_path`, or a grant *removed* from a
+    file — fall back to the previous file-presence check and are surfaced as
+    notes.
+  - `migrate validate --require-grant-migration --format json` now carries
+    `unmatched_grants` and `unverifiable_notes`; a new (non-adapter-contract)
+    schema is published at `docs/reference/json-schemas/migrate-validate-grant.schema.json`.
+  - `MigrationGrantExtractor` gains `extract_grant_statements()` (the richer
+    `GrantStatement` API); the legacy `extract_grants()` is unchanged.
+  (#162)
+
 ## [0.28.0] - 2026-06-11
 
 Adds **`sec_002`** — a static lint rule that flags `SECURITY DEFINER`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.27.0
-**Last Updated**: 2026-06-10
+**Version**: 0.30.0
+**Last Updated**: 2026-06-13
 **Current Status**: Production-Ready
 
 > **Status**: Production-ready. Actively used in production since March 2026.
@@ -925,8 +925,8 @@ When stuck, ask:
 
 ---
 
-**Last Updated**: 2026-06-10
-**Version**: 0.27.0
+**Last Updated**: 2026-06-13
+**Version**: 0.30.0
 
 ---
 

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -21,6 +21,9 @@ confiture migrate validate --idempotent --strict-cor
 # Python migrations are detected but never rewritten — they're listed
 # under "manual_fix_required" so you know to edit them by hand.
 confiture migrate fix --idempotent
+
+# Verify changed grants are carried by an accompanying migration
+confiture migrate validate --require-grant-migration --staged
 ```
 
 JSON output is available with `--format json` for every variant.
@@ -313,6 +316,60 @@ written before 0.12.1 keep working.
 Python migrations are intentionally **not** auto-rewritten — unparsing
 the AST would lose comments and formatting. Violations in `.py` files
 must be fixed by hand.
+
+## `--require-grant-migration`
+
+Build environments apply grants straight from the grant sweep directory
+(`db/7_grant/` by default); migrate environments (staging, production) apply
+grants **only** through migrations. So a grant changed in the sweep directory
+without a migration that carries it silently never reaches production. This
+flag closes that gap.
+
+It is **semantic** (issue #162): it verifies that each *changed* `GRANT` /
+`REVOKE` statement is actually present in an accompanying migration — not
+merely that *some* migration happens to be in the changeset.
+
+- **Both migration formats are recognized.** A `.up.sql` migration *or* a `.py`
+  migration (its `self.execute("GRANT …")` / `self.execute_file(...)` calls are
+  statically extracted) can carry the grant. `_`-prefixed modules
+  (`__init__.py`, `_helpers.py`) are not migrations.
+- **Diff-aware.** Only the *added or changed* grants are required. Editing one
+  grant in a 50-grant file requires only that one grant in a migration; the
+  required set is diffed against the **merge-base** of your base and target
+  refs (consistent with three-dot changed-file semantics).
+- **Broad coverage.** `GRANT` and `REVOKE`, across **table**, **schema-wide**
+  (`… IN SCHEMA`), **sequence**, and **function** objects. `GRANT ALL` and an
+  explicit privilege list compare equal (both expand to the same per-object-type
+  set), so you can write `ALL` in the sweep and enumerate in the migration.
+
+### Honest degradation — what is *not* semantically verified
+
+Some grant forms parse cleanly but can't be turned into a comparable key. Rather
+than silently pass them (the exact bug this flag exists to prevent), they
+**degrade to a file-presence check** — a migration must be present — and the
+reason is surfaced as a note. These are:
+
+- Object classes outside table/schema/sequence/function: `GRANT … ON DATABASE`,
+  `LANGUAGE`, `TYPE`, `DOMAIN`, `FOREIGN DATA WRAPPER`, `TABLESPACE`, …
+- `ALTER DEFAULT PRIVILEGES … GRANT/REVOKE …`
+- Column-level privileges (`GRANT SELECT (col) ON t …`)
+- `WITH GRANT OPTION`-only changes (the option is outside the match key)
+- Grants behind a non-public `SET search_path` (the unqualified object name is
+  ambiguous — qualify it explicitly to get full semantic verification)
+- Dynamic SQL (`EXECUTE format('GRANT …')`) and parse failures
+- A grant *removed* from a file (v1 does not auto-require a `REVOKE` migration)
+
+A no-op edit (comment-only, whitespace, reorder) changes nothing representable
+and is **not** unverifiable, so it passes without requiring a migration.
+
+### Bypass
+
+`--allow-grant-only` suppresses the check for build-only branches that don't
+deploy through migrations.
+
+```bash
+confiture migrate validate --require-grant-migration --allow-grant-only --staged
+```
 
 ## Known limitations
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1195,6 +1195,8 @@ confiture migrate validate [OPTIONS]
 |--------|-------|------|---------|-------------|
 | `--migrations-dir` | - | Path | `db/migrations` | Directory containing migration files |
 | `--fix-naming` | - | Flag | `False` | Automatically rename orphaned migration files to match naming convention |
+| `--require-grant-migration` | - | Flag | `False` | Verify each changed `GRANT`/`REVOKE` in the grant directory is carried by an accompanying migration (`.up.sql` or `.py`). Semantic match across table/schema/sequence/function objects; unverifiable grants degrade to a file-presence check with a surfaced note. See the [migrate validate guide](../guides/migrate-validate.md#--require-grant-migration). |
+| `--allow-grant-only` | - | Flag | `False` | Suppress `--require-grant-migration` for build-only branches |
 | `--dry-run` | - | Flag | `False` | Preview changes without actually renaming files |
 | `--format` | `-f` | Text | `text` | Output format: `text` (default) or `json` |
 | `--output` | `-o` | Path | None | Save output to file |
@@ -1214,6 +1216,9 @@ confiture migrate validate --fix-naming
 # Output as JSON for CI/CD integration
 confiture migrate validate --format json
 confiture migrate validate --fix-naming --format json
+
+# Verify changed grants are carried by an accompanying migration (pre-commit)
+confiture migrate validate --require-grant-migration --staged
 ```
 
 #### Recognized Migration File Patterns

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -154,6 +154,39 @@ Static check that every `CREATE TABLE` in `db/migrations/` has a matching `GRANT
 }
 ```
 
+### `confiture migrate validate --require-grant-migration --format json`
+
+[migrate-validate-grant.schema.json](./json-schemas/migrate-validate-grant.schema.json)
+
+Semantic grant-accompaniment report (issue #162): verifies that each *changed* `GRANT`/`REVOKE` in the grant directory is carried by an accompanying migration (`.up.sql` or `.py`). Emitted as a failure envelope. **Not part of the fraisier adapter contract** — provided for completeness.
+
+```json
+{
+  "status": "failed",
+  "check": "grant_accompaniment",
+  "is_valid": false,
+  "has_grant_changes": true,
+  "has_migration_changes": true,
+  "grant_files_changed": ["db/7_grant/71_grant.sql"],
+  "migration_files_staged": ["db/migrations/20260613130000_x.py"],
+  "unmatched_grants": [
+    {
+      "statement": "GRANT SELECT ON s.t TO reporter",
+      "action": "GRANT",
+      "objtype": "TABLE",
+      "target_kind": "OBJECT",
+      "schema": "s",
+      "object": "t",
+      "grantee": "reporter",
+      "privilege": "SELECT",
+      "changed_in": "db/7_grant/71_grant.sql",
+      "migrations_inspected": ["db/migrations/20260613130000_x.py"]
+    }
+  ],
+  "unverifiable_notes": []
+}
+```
+
 ### `confiture migrate validate --check-function-uniqueness --format json`
 
 [migrate-validate-check-function-uniqueness.schema.json](./json-schemas/migrate-validate-check-function-uniqueness.schema.json)

--- a/docs/reference/json-schemas/migrate-validate-grant.schema.json
+++ b/docs/reference/json-schemas/migrate-validate-grant.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-validate-grant.schema.json",
+  "title": "confiture migrate validate --require-grant-migration --format json",
+  "description": "Semantic grant-accompaniment report (issue #162). Emitted as a failure envelope when a changed GRANT/REVOKE in the grant directory is not carried by an accompanying migration, or could not be statically verified and no migration is present. NOTE: this is NOT part of the fraisier adapter contract (which covers current/up/down-to/verify/preflight) — it is provided for completeness.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "status",
+    "check",
+    "is_valid",
+    "has_grant_changes",
+    "has_migration_changes",
+    "grant_files_changed",
+    "migration_files_staged",
+    "unmatched_grants",
+    "unverifiable_notes"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["failed", "passed"]
+    },
+    "check": {
+      "type": "string",
+      "const": "grant_accompaniment"
+    },
+    "is_valid": { "type": "boolean" },
+    "has_grant_changes": { "type": "boolean" },
+    "has_migration_changes": { "type": "boolean" },
+    "grant_files_changed": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "migration_files_staged": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "unmatched_grants": {
+      "type": "array",
+      "description": "Changed grants not carried by any migration — each is a hard failure.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "statement",
+          "action",
+          "objtype",
+          "target_kind",
+          "schema",
+          "object",
+          "grantee",
+          "privilege",
+          "changed_in",
+          "migrations_inspected"
+        ],
+        "properties": {
+          "statement": { "type": "string" },
+          "action": { "type": "string", "enum": ["GRANT", "REVOKE"] },
+          "objtype": {
+            "type": "string",
+            "enum": ["TABLE", "SEQUENCE", "FUNCTION", "SCHEMA"]
+          },
+          "target_kind": {
+            "type": "string",
+            "enum": ["OBJECT", "ALL_IN_SCHEMA"]
+          },
+          "schema": { "type": "string" },
+          "object": { "type": ["string", "null"] },
+          "grantee": { "type": "string" },
+          "privilege": { "type": "string" },
+          "changed_in": { "type": "string" },
+          "migrations_inspected": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "unverifiable_notes": {
+      "type": "array",
+      "description": "Human-readable notes for grants that degraded to a file-presence check (dynamic SQL, unmodeled object classes, removed grants, search_path-relative schemas, WITH GRANT OPTION-only changes).",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.28.0"
+version = "0.30.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -264,7 +264,12 @@ def migrate_validate(
     require_grant_migration: bool = typer.Option(
         False,
         "--require-grant-migration",
-        help="Fail if staged changes in db/7_grant/ exist without a corresponding migration file (default: off)",
+        help=(
+            "Verify that each changed GRANT/REVOKE in the grant directory is carried by an "
+            "accompanying migration (SQL or Python). Semantic match across "
+            "table/schema/sequence/function objects; grants that can't be statically verified "
+            "degrade to a file-presence check and are surfaced as notes (default: off)."
+        ),
     ),
     allow_grant_only: bool = typer.Option(
         False,
@@ -604,6 +609,21 @@ def migrate_validate(
             # Run grant accompaniment check
             grant_passed = True
             if require_grant_migration and not allow_grant_only:
+                # Honor a non-default grant directory from the config — a
+                # "broad coverage" gate that ignored it would be a trap.
+                grant_dir = "db/7_grant"
+                if config and Path(config).exists():
+                    try:
+                        cfg_data = load_config(Path(config))
+                        configured = (
+                            cfg_data.get("migration", {}).get("grant_dir")
+                            if isinstance(cfg_data, dict)
+                            else None
+                        )
+                        if configured:
+                            grant_dir = configured
+                    except Exception:  # noqa: BLE001 — fall back to the default
+                        pass
                 try:
                     grant_result = validate_grant_accompaniment(
                         base_ref=effective_base_ref,
@@ -611,6 +631,7 @@ def migrate_validate(
                         staged_only=staged,
                         console=console,
                         format_output=format_output,
+                        grant_dir=grant_dir,
                         migrations_dir=str(migrations_dir),
                     )
                 except Exception as e:

--- a/python/confiture/cli/git_validation.py
+++ b/python/confiture/cli/git_validation.py
@@ -157,6 +157,69 @@ def validate_migration_accompaniment(
         raise
 
 
+def _render_grant_report(report, console: Console) -> None:
+    """Render the semantic grant-accompaniment report for human eyes (issue #162).
+
+    Three sections, driven by the report: unmatched grants (the hard failure,
+    naming each grant + where it changed + the migrations inspected),
+    degradation notes (shown, non-fatal when a migration is present), and the
+    pass line. Defensive against partially-stubbed report objects.
+    """
+    unmatched = getattr(report, "unmatched_grants", None)
+    unmatched = unmatched if isinstance(unmatched, list) else []
+    notes = getattr(report, "unverifiable_notes", None)
+    notes = notes if isinstance(notes, list) else []
+
+    if not report.has_grant_changes:
+        console.print("[green]✅ No grant file changes detected[/green]")
+        return
+
+    if unmatched:
+        console.print("[red]❌ Grant changes not carried by any migration:[/red]\n")
+        for grant in unmatched:
+            statement = grant.get("statement", "<grant>") if isinstance(grant, dict) else str(grant)
+            changed_in = grant.get("changed_in") if isinstance(grant, dict) else None
+            inspected = grant.get("migrations_inspected") if isinstance(grant, dict) else None
+            console.print(f"   [bold]{statement}[/bold]")
+            if changed_in:
+                console.print(f"     changed in {changed_in}")
+            if inspected:
+                console.print(f"     not found in: {', '.join(inspected)}")
+            else:
+                console.print("     no accompanying migration carries it")
+            console.print("")
+        console.print(
+            "  Migrate environments (staging, production) apply grants ONLY via migrations;\n"
+            "  these grants will not reach them. Add each to a migration (SQL or Python),\n"
+            "  or run with --allow-grant-only if this branch uses build-only deployment."
+        )
+        if notes:
+            console.print("")
+
+    if notes:
+        if report.is_valid:
+            console.print(
+                "[yellow]⚠️  Could not statically verify (relying on migration presence):[/yellow]"
+            )
+        else:
+            console.print("[yellow]⚠️  Could not statically verify:[/yellow]")
+        for note in notes:
+            console.print(f"     - {note}")
+        if not report.is_valid and not unmatched:
+            console.print(
+                "\n  No accompanying migration was found, so these unverifiable grant\n"
+                "  changes are not guaranteed to reach migrate environments. Add a\n"
+                "  migration, or run with --allow-grant-only for build-only branches."
+            )
+
+    if report.is_valid and not notes:
+        console.print("[green]✅ Grant changes accompanied by migrations[/green]")
+        console.print(f"   Grant files: {len(report.grant_files_changed)}")
+        console.print(f"   Migrations: {len(report.migration_files_staged)}")
+    elif report.is_valid:
+        console.print("\n[green]✅ Grant changes carried by accompanying migrations[/green]")
+
+
 def validate_grant_accompaniment(
     base_ref: str,
     target_ref: str,
@@ -166,10 +229,12 @@ def validate_grant_accompaniment(
     grant_dir: str = "db/7_grant",
     migrations_dir: str = "db/migrations",
 ) -> dict:
-    """Validate that grant file changes have migration files.
+    """Validate that grant file changes are carried by accompanying migrations.
 
-    Uses file-level detection: if any file under grant_dir changed, at least
-    one .up.sql migration must also be present in the changeset.
+    Semantic (issue #162): verifies that each *changed* GRANT/REVOKE statement
+    in ``grant_dir`` is present in an accompanying migration (``.up.sql`` or
+    ``.py``). Grants that can't be statically represented degrade to a
+    file-presence check and are surfaced as notes — never silently passed.
 
     Args:
         base_ref: Base git reference (used when staged_only=False)
@@ -201,28 +266,7 @@ def validate_grant_accompaniment(
         )
 
         if format_output == "text":
-            if not report.has_grant_changes:
-                console.print("[green]✅ No grant file changes detected[/green]")
-            elif report.is_valid:
-                console.print("[green]✅ Grant changes accompanied by migrations[/green]")
-                console.print(f"   Grant files: {len(report.grant_files_changed)}")
-                console.print(f"   Migrations: {len(report.migration_files_staged)}")
-            else:
-                console.print(
-                    "[red]❌ Grant changes without migration files[/red]\n\n  Grant files changed:"
-                )
-                for f in report.grant_files_changed:
-                    console.print(f"    {f}")
-                console.print(
-                    "\n"
-                    "  No migration file (.up.sql) was staged.\n"
-                    "\n"
-                    "  Migrate environments (staging, production) will NOT apply these grants\n"
-                    "  until they appear in a migration file.\n"
-                    "\n"
-                    "  Fix: Add GRANT statements to a new migration, or run with --allow-grant-only\n"
-                    "  if this branch uses build-only deployment."
-                )
+            _render_grant_report(report, console)
 
         return report.to_dict()
 

--- a/python/confiture/core/git.py
+++ b/python/confiture/core/git.py
@@ -102,8 +102,15 @@ class GitRepository:
         if result.returncode != 0:
             error_msg = result.stderr.strip()
 
-            # Check if file doesn't exist at ref (not found)
-            if "does not exist" in error_msg or "not found" in error_msg:
+            # Check if file doesn't exist at ref (not found). A file that is
+            # new in the working tree but absent from the ref's tree reports
+            # "exists on disk, but not in '<ref>'" — also a legitimate "absent
+            # at this ref" signal, not an error.
+            if (
+                "does not exist" in error_msg
+                or "not found" in error_msg
+                or "but not in" in error_msg
+            ):
                 return None
 
             # Check if ref doesn't exist
@@ -183,6 +190,101 @@ class GitRepository:
             GitError: If git command fails for a reason other than missing file
         """
         return self.get_file_at_ref(file_path, ref)
+
+    def get_staged_file_content(self, file_path: Path) -> str | None:
+        """Return a file's content from the staging index (``git show :<path>``).
+
+        This is the index blob, which can differ from the working tree when a
+        file is staged and then edited further. ``get_file_at_ref`` can't reach
+        it: the index is addressed by the bare ``:`` prefix, which
+        ``_VALID_GIT_REF_RE`` rejects.
+
+        Args:
+            file_path: Relative path to file from repo root
+
+        Returns:
+            Staged content as string, or None if the file is not in the index
+
+        Raises:
+            NotAGitRepositoryError: If not in a git repository
+            GitError: If git command fails for a reason other than a missing path
+        """
+        if not self.is_git_repo():
+            raise NotAGitRepositoryError(f"Not a git repository: {self.repo_path}")
+
+        index_path = f":{file_path.as_posix()}"
+        try:
+            result = subprocess.run(
+                ["git", "show", index_path],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise GitError(f"Git command timed out retrieving staged '{file_path}'") from e
+
+        if result.returncode != 0:
+            error_msg = result.stderr.strip()
+            # A path absent from the index reports one of these, depending on
+            # whether it also exists in the working tree. Both mean "not staged".
+            if (
+                "does not exist" in error_msg
+                or "not found" in error_msg
+                or "but not in the index" in error_msg
+            ):
+                return None
+            raise GitError(f"Git command failed reading staged '{file_path}': {error_msg}")
+
+        return result.stdout
+
+    def get_merge_base(self, base_ref: str, target_ref: str) -> str | None:
+        """Return the merge-base commit of two refs (``git merge-base``).
+
+        The merge-base is the common ancestor that three-dot diff semantics
+        (``base...target``, used by :meth:`get_changed_files`) compare against.
+        Anchoring per-file content diffs here — rather than on the tip of
+        ``base_ref`` — keeps the changed-file set and the changed-content set
+        consistent when ``base_ref`` has advanced past the fork point.
+
+        Args:
+            base_ref: Base git reference
+            target_ref: Target git reference
+
+        Returns:
+            The merge-base commit hash, or ``base_ref`` itself when the two
+            histories share no common ancestor (unrelated histories).
+
+        Raises:
+            NotAGitRepositoryError: If not in a git repository
+            GitError: If either ref is syntactically invalid
+        """
+        if not self.is_git_repo():
+            raise NotAGitRepositoryError(f"Not a git repository: {self.repo_path}")
+
+        for ref in (base_ref, target_ref):
+            if not _VALID_GIT_REF_RE.match(ref):
+                raise GitError(f"Invalid git reference: {ref!r}")
+
+        try:
+            result = subprocess.run(
+                ["git", "merge-base", base_ref, target_ref],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise GitError(
+                f"Git command timed out finding merge-base of '{base_ref}' and '{target_ref}'"
+            ) from e
+
+        if result.returncode != 0 or not result.stdout.strip():
+            # No common ancestor (unrelated histories) — fall back to the base
+            # tip so the caller still has a usable anchor.
+            return base_ref
+
+        return result.stdout.strip()
 
     def get_staged_files(self) -> list[Path]:
         """Get list of currently staged files.

--- a/python/confiture/core/grant_accompaniment.py
+++ b/python/confiture/core/grant_accompaniment.py
@@ -18,7 +18,8 @@ class GrantAccompanimentChecker:
 
     Unlike MigrationAccompanimentChecker (semantic DDL diff), this uses
     file-level detection: if any file under grant_dir changed, at least
-    one .up.sql migration must also be present in the changeset.
+    one migration (``.up.sql`` or ``.py``) must also be present in the
+    changeset.
 
     Attributes:
         repo_path: Repository root directory
@@ -107,17 +108,30 @@ class GrantAccompanimentChecker:
         return result
 
     def _filter_migration_files(self, files: list[Path]) -> list[Path]:
-        """Filter to .up.sql files under migrations_dir.
+        """Filter to migration files under migrations_dir.
+
+        Recognizes both SQL (``.up.sql``) and Python (``.py``) migrations,
+        matching the canonical migration loader (``_migrator/discovery.py``)
+        and ``MigrationAccompanimentChecker._get_new_migrations``: a ``.py``
+        file counts as a migration unless its name starts with ``_`` (which
+        excludes ``__init__.py`` and private helper modules). Migrate
+        environments apply both formats, so both must satisfy the gate.
 
         Args:
             files: List of file paths to filter
 
         Returns:
-            Files that are .up.sql files under the migrations directory
+            Files that are migration files under the migrations directory
         """
         migrations_parts = Path(self.migrations_dir).parts
         result = []
         for f in files:
-            if f.parts[: len(migrations_parts)] == migrations_parts and f.name.endswith(".up.sql"):
+            if f.parts[: len(migrations_parts)] != migrations_parts:
+                continue
+            is_sql = f.name.endswith(".up.sql")
+            # "not _-prefixed" excludes __init__.py and _helpers.py. Parity
+            # with the loader: a migration the loader would run must count.
+            is_py = f.name.endswith(".py") and not f.name.startswith("_")
+            if is_sql or is_py:
                 result.append(f)
         return result

--- a/python/confiture/core/grant_accompaniment.py
+++ b/python/confiture/core/grant_accompaniment.py
@@ -1,25 +1,54 @@
 """Grant accompaniment validation.
 
-Validates that changes to grant files (db/7_grant/) are accompanied by
-migration files. Build environments apply grants from the grant directory
-automatically; migrate environments (staging, production) only apply grants
-when they appear in a migration file. This asymmetry causes silent permission
-failures in production when grant files are changed without a migration.
+Validates that changes to grant files (db/7_grant/) are carried by an
+accompanying migration. Build environments apply grants from the grant
+directory automatically; migrate environments (staging, production) only apply
+grants when they appear in a migration. This asymmetry causes silent
+permission failures in production when grant files are changed without a
+migration that carries the change.
+
+The check is **semantic** (issue #162): it verifies that each *changed*
+GRANT/REVOKE statement is actually present in an accompanying migration — not
+merely that some migration exists in the changeset. When a changed grant can't
+be represented statically (dynamic SQL, unmodeled object classes, removed
+grants, search_path-relative schemas), it degrades to the previous
+file-presence check (a migration must be present) and the reason is surfaced as
+a note. It never silently passes an unaccompanied grant.
 """
 
+from __future__ import annotations
+
+import re
+import tempfile
 from pathlib import Path
+from typing import Any
 
 from confiture.core.git import GitRepository
+from confiture.core.idempotency.python_migration_extractor import (
+    ExtractionKind,
+    extract_sql_from_python_migration,
+)
+from confiture.core.migration_grant_extractor import (
+    GrantStatement,
+    MigrationGrantExtractor,
+)
 from confiture.models.git import GrantAccompanimentReport
+
+# A SET search_path naming a schema outside this set makes unqualified object
+# names ambiguous — the extractor would key them as `public`, which can
+# false-fail a correct migration. We degrade such grant files instead (D12).
+_SEARCH_PATH_RE = re.compile(r"\bSET\s+search_path\s*(?:=|TO)\s*(?P<list>[^;]+)", re.IGNORECASE)
+_SEARCH_PATH_SAFE_SCHEMAS = frozenset({"public", "pg_catalog", "$user", '"$user"'})
 
 
 class GrantAccompanimentChecker:
-    """Check if grant file changes are accompanied by migration files.
+    """Check that changed grants are carried by an accompanying migration.
 
-    Unlike MigrationAccompanimentChecker (semantic DDL diff), this uses
-    file-level detection: if any file under grant_dir changed, at least
-    one migration (``.up.sql`` or ``.py``) must also be present in the
-    changeset.
+    Recognizes both SQL (``.up.sql``) and Python (``.py``) migrations. The
+    required set (the *added/changed* grants) is diffed against the merge-base
+    of the base and target refs, consistent with three-dot changed-file
+    semantics; the covered set is the union of grants found in every
+    accompanying migration.
 
     Attributes:
         repo_path: Repository root directory
@@ -51,6 +80,7 @@ class GrantAccompanimentChecker:
         self.git_repo = GitRepository(self.repo_path)
         self.grant_dir = grant_dir
         self.migrations_dir = migrations_dir
+        self._extractor = MigrationGrantExtractor()
 
     def check_accompaniment(
         self,
@@ -58,10 +88,11 @@ class GrantAccompanimentChecker:
         target_ref: str = "HEAD",
         staged_only: bool = False,
     ) -> GrantAccompanimentReport:
-        """Check if grant changes are accompanied by migrations.
+        """Check that grant changes are carried by accompanying migrations.
 
-        When staged_only=True, uses git diff --cached (actual staged files).
-        Otherwise, uses git diff base_ref...target_ref (changed between refs).
+        When staged_only=True, compares the staging index against HEAD.
+        Otherwise, compares ``target_ref`` against the merge-base of
+        ``base_ref`` and ``target_ref``.
 
         Args:
             base_ref: Base git reference (used when staged_only=False)
@@ -83,12 +114,211 @@ class GrantAccompanimentChecker:
         grant_files = self._filter_grant_files(changed_files)
         migration_files = self._filter_migration_files(changed_files)
 
-        return GrantAccompanimentReport(
+        report = GrantAccompanimentReport(
             has_grant_changes=len(grant_files) > 0,
             has_migration_changes=len(migration_files) > 0,
             grant_files_changed=grant_files,
             migration_files_staged=migration_files,
         )
+        if not grant_files:
+            return report
+
+        # The merge-base is the anchor for the required-set content diff (D10).
+        merge_base = base_ref if staged_only else self.git_repo.get_merge_base(base_ref, target_ref)
+
+        required, notes = self._compute_required(grant_files, merge_base, target_ref, staged_only)
+        covered, covered_notes = self._compute_covered(migration_files, target_ref, staged_only)
+        notes.extend(covered_notes)
+
+        unmatched = [stmt for stmt in required if stmt not in covered]
+        report.unmatched_grants = [self._serialize_unmatched(stmt) for stmt in unmatched]
+        report.unverifiable_notes = notes
+        return report
+
+    # ------------------------------------------------------------------ #
+    # Required set (changed grants)                                       #
+    # ------------------------------------------------------------------ #
+
+    def _compute_required(
+        self,
+        grant_files: list[Path],
+        base_ref: str,
+        target_ref: str,
+        staged_only: bool,
+    ) -> tuple[set[GrantStatement], list[str]]:
+        """Return the added/changed grant statements and any degradation notes."""
+        required: set[GrantStatement] = set()
+        notes: list[str] = []
+
+        for grant_file in grant_files:
+            target_content = self._read_at_target(grant_file, target_ref, staged_only)
+            base_content = self._read_at_ref(grant_file, base_ref)
+
+            # A grant file whose content we can't read as text degrades to
+            # file-presence (keeps MagicMock-based unit tests on this path).
+            if not isinstance(target_content, str):
+                notes.append(
+                    f"{grant_file.as_posix()}: grant content unreadable; relying on migration presence"
+                )
+                continue
+
+            # A non-public SET search_path makes unqualified objects ambiguous;
+            # degrade rather than risk false-failing a correct migration (D12).
+            if self._search_path_ambiguous(target_content):
+                notes.append(
+                    f"{grant_file.as_posix()}: SET search_path makes unqualified grants "
+                    "ambiguous; relying on migration presence"
+                )
+                continue
+
+            target_extraction = self._extractor.extract_grant_statements(target_content)
+            base_statements: set[GrantStatement] = set()
+            base_options: dict[GrantStatement, bool] = {}
+            if isinstance(base_content, str):
+                base_extraction = self._extractor.extract_grant_statements(base_content)
+                base_statements = set(base_extraction.statements)
+                base_options = {s: s.grant_option for s in base_extraction.statements}
+
+            target_statements = set(target_extraction.statements)
+
+            # Newly added / changed grants are the required set.
+            for stmt in target_statements - base_statements:
+                required.add(stmt)
+
+            # A grant that differs only by WITH GRANT OPTION yields no key
+            # change (the flag is out of the match key) — surface it (D9).
+            # Iterate the target set so `stmt` is always the target instance.
+            for stmt in target_statements:
+                if stmt in base_statements and stmt.grant_option != base_options.get(stmt, False):
+                    notes.append(
+                        f"{grant_file.as_posix()}: {stmt.describe()} — only WITH GRANT OPTION "
+                        "changed; relying on migration presence"
+                    )
+
+            # A grant removed from the file (present at base, absent at target)
+            # degrades to file-presence — v1 does not auto-require a REVOKE (D8).
+            for stmt in base_statements - target_statements:
+                notes.append(
+                    f"{grant_file.as_posix()}: {stmt.describe()} was removed; relying on "
+                    "migration presence (no automatic REVOKE-migration requirement)"
+                )
+
+            # Surface every grant the extractor couldn't represent (D9).
+            for marker in target_extraction.unrepresentable:
+                notes.append(f"{grant_file.as_posix()}: {marker.detail} ({marker.reason})")
+
+        return required, notes
+
+    # ------------------------------------------------------------------ #
+    # Covered set (accompanying migrations)                               #
+    # ------------------------------------------------------------------ #
+
+    def _compute_covered(
+        self,
+        migration_files: list[Path],
+        target_ref: str,
+        staged_only: bool,
+    ) -> tuple[set[GrantStatement], list[str]]:
+        """Return the union of grant statements carried by accompanying migrations."""
+        covered: set[GrantStatement] = set()
+        notes: list[str] = []
+
+        for migration_file in migration_files:
+            if migration_file.name.endswith(".py"):
+                stmts, py_notes = self._covered_from_python(migration_file, target_ref, staged_only)
+                covered.update(stmts)
+                notes.extend(py_notes)
+                continue
+
+            content = self._read_at_target(migration_file, target_ref, staged_only)
+            if not isinstance(content, str):
+                continue
+            extraction = self._extractor.extract_grant_statements(content)
+            covered.update(extraction.statements)
+
+        return covered, notes
+
+    def _covered_from_python(
+        self,
+        migration_file: Path,
+        target_ref: str,
+        staged_only: bool,
+    ) -> tuple[set[GrantStatement], list[str]]:
+        """Extract grant statements carried by a Python migration at the right ref (D11)."""
+        covered: set[GrantStatement] = set()
+        notes: list[str] = []
+
+        content = self._read_at_target(migration_file, target_ref, staged_only)
+        if not isinstance(content, str):
+            return covered, notes
+
+        # python_migration_extractor reads from disk, so materialize the blob
+        # at the target ref to a temp file (D11). execute_file() targets still
+        # resolve against the working tree — pass the real repo root and note it.
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                tmp = Path(td) / migration_file.name
+                tmp.write_text(content, encoding="utf-8")
+                result = extract_sql_from_python_migration(tmp, project_root=self.repo_path)
+        except Exception:  # noqa: BLE001 — never let a migration crash the gate
+            notes.append(f"{migration_file.as_posix()}: could not statically extract SQL")
+            return covered, notes
+
+        for warning in result.warnings:
+            notes.append(f"{migration_file.as_posix()}: {warning.message}")
+        for snippet in result.snippets:
+            if snippet.kind == ExtractionKind.FILE:
+                notes.append(
+                    f"{migration_file.as_posix()}: execute_file target read from the working "
+                    "tree, not the validated ref"
+                )
+            extraction = self._extractor.extract_grant_statements(snippet.sql)
+            covered.update(extraction.statements)
+            for marker in extraction.unrepresentable:
+                notes.append(f"{migration_file.as_posix()}: {marker.detail} ({marker.reason})")
+
+        return covered, notes
+
+    # ------------------------------------------------------------------ #
+    # Content reading                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _read_at_target(self, path: Path, target_ref: str, staged_only: bool) -> str | None:
+        """Read a file's content at the target (staged index or target ref)."""
+        if staged_only:
+            return self.git_repo.get_staged_file_content(path)
+        return self.git_repo.get_file_at_ref(path, target_ref)
+
+    def _read_at_ref(self, path: Path, ref: str) -> str | None:
+        """Read a file's content at a committed ref (the diff base)."""
+        return self.git_repo.get_file_at_ref(path, ref)
+
+    @staticmethod
+    def _search_path_ambiguous(content: str) -> bool:
+        """True if a SET search_path names a schema outside the safe defaults."""
+        for match in _SEARCH_PATH_RE.finditer(content):
+            for raw in match.group("list").split(","):
+                schema = raw.strip().strip('"').strip("'").lower()
+                if schema and schema.strip('"') not in _SEARCH_PATH_SAFE_SCHEMAS:
+                    return True
+        return False
+
+    @staticmethod
+    def _serialize_unmatched(stmt: GrantStatement) -> dict[str, Any]:
+        return {
+            "statement": stmt.describe(),
+            "action": stmt.action,
+            "objtype": stmt.objtype,
+            "target_kind": stmt.target_kind,
+            "schema": stmt.schema,
+            "object": stmt.object,
+            "grantee": stmt.grantee,
+            "privilege": stmt.privilege,
+        }
+
+    # ------------------------------------------------------------------ #
+    # File filtering                                                      #
+    # ------------------------------------------------------------------ #
 
     def _filter_grant_files(self, files: list[Path]) -> list[Path]:
         """Filter to files under grant_dir.

--- a/python/confiture/core/grant_accompaniment.py
+++ b/python/confiture/core/grant_accompaniment.py
@@ -130,8 +130,12 @@ class GrantAccompanimentChecker:
         covered, covered_notes = self._compute_covered(migration_files, target_ref, staged_only)
         notes.extend(covered_notes)
 
-        unmatched = [stmt for stmt in required if stmt not in covered]
-        report.unmatched_grants = [self._serialize_unmatched(stmt) for stmt in unmatched]
+        inspected = [f.as_posix() for f in migration_files]
+        report.unmatched_grants = [
+            self._serialize_unmatched(stmt, source.as_posix(), inspected)
+            for stmt, source in required.items()
+            if stmt not in covered
+        ]
         report.unverifiable_notes = notes
         return report
 
@@ -145,9 +149,9 @@ class GrantAccompanimentChecker:
         base_ref: str,
         target_ref: str,
         staged_only: bool,
-    ) -> tuple[set[GrantStatement], list[str]]:
-        """Return the added/changed grant statements and any degradation notes."""
-        required: set[GrantStatement] = set()
+    ) -> tuple[dict[GrantStatement, Path], list[str]]:
+        """Return added/changed grants (mapped to their source file) + degrade notes."""
+        required: dict[GrantStatement, Path] = {}
         notes: list[str] = []
 
         for grant_file in grant_files:
@@ -181,9 +185,10 @@ class GrantAccompanimentChecker:
 
             target_statements = set(target_extraction.statements)
 
-            # Newly added / changed grants are the required set.
+            # Newly added / changed grants are the required set (first source
+            # file wins so failure messages can name where it changed).
             for stmt in target_statements - base_statements:
-                required.add(stmt)
+                required.setdefault(stmt, grant_file)
 
             # A grant that differs only by WITH GRANT OPTION yields no key
             # change (the flag is out of the match key) — surface it (D9).
@@ -304,7 +309,9 @@ class GrantAccompanimentChecker:
         return False
 
     @staticmethod
-    def _serialize_unmatched(stmt: GrantStatement) -> dict[str, Any]:
+    def _serialize_unmatched(
+        stmt: GrantStatement, changed_in: str, inspected: list[str]
+    ) -> dict[str, Any]:
         return {
             "statement": stmt.describe(),
             "action": stmt.action,
@@ -314,6 +321,8 @@ class GrantAccompanimentChecker:
             "object": stmt.object,
             "grantee": stmt.grantee,
             "privilege": stmt.privilege,
+            "changed_in": changed_in,
+            "migrations_inspected": inspected,
         }
 
     # ------------------------------------------------------------------ #

--- a/python/confiture/core/linting/libraries/acl.py
+++ b/python/confiture/core/linting/libraries/acl.py
@@ -179,8 +179,8 @@ class Acl001GrantCoverage:
         created: list[tuple[str, str, Path]] = []  # (schema, table, migration file)
         owner_only: set[tuple[str, str]] = set()
 
-        for migration in sorted(migrations_dir.rglob("*.up.sql")):
-            text = migration.read_text()
+        for migration in self._migration_files(migrations_dir):
+            text = self._migration_sql_text(migration)
             creates = self._extractor.extract_creates(text)
             drops = self._extractor.extract_drops(text)
             grants = self._extractor.extract_grants(text)
@@ -233,6 +233,42 @@ class Acl001GrantCoverage:
     # ------------------------------------------------------------------ #
     # Helpers                                                             #
     # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _migration_files(migrations_dir: Path) -> list[Path]:
+        """Migration files to scan: ``.up.sql`` plus ``.py`` (issue #162 twin gap).
+
+        Recognizes Python migrations the same way the loader does — excluding
+        ``__init__.py`` and ``_``-prefixed helper modules — so a CREATE/GRANT
+        carried by a Python migration is no longer a blind spot in the ACL lint.
+        """
+        sql = sorted(migrations_dir.rglob("*.up.sql"))
+        py = sorted(
+            f
+            for f in migrations_dir.rglob("*.py")
+            if f.name != "__init__.py" and not f.name.startswith("_")
+        )
+        return sql + py
+
+    def _migration_sql_text(self, migration: Path) -> str:
+        """Return the SQL text of a migration, statically extracting from ``.py``.
+
+        For Python migrations the resolvable ``self.execute(...)`` /
+        ``self.execute_file(...)`` snippets are concatenated; dynamic SQL is
+        invisible to static parsing and simply isn't scanned (consistent with
+        the rest of the lint).
+        """
+        if migration.name.endswith(".py"):
+            from confiture.core.idempotency.python_migration_extractor import (  # noqa: PLC0415
+                extract_sql_from_python_migration,
+            )
+
+            try:
+                result = extract_sql_from_python_migration(migration)
+            except Exception:  # noqa: BLE001 — never let a migration break the lint
+                return ""
+            return "\n".join(snippet.sql for snippet in result.snippets)
+        return migration.read_text()
 
     def _format_violation(
         self,

--- a/python/confiture/core/migration_grant_extractor.py
+++ b/python/confiture/core/migration_grant_extractor.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import importlib.util
 import re
+from dataclasses import dataclass, field
 
 import sqlparse
 
@@ -34,6 +35,17 @@ _HAS_PGLAST: bool = importlib.util.find_spec("pglast") is not None
 _ALL_TABLE_PRIVILEGES: frozenset[str] = frozenset(
     {"SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"}
 )
+# ``GRANT ALL`` expands differently per object class (issue #162).
+_ALL_SEQUENCE_PRIVILEGES: frozenset[str] = frozenset({"USAGE", "SELECT", "UPDATE"})
+_ALL_FUNCTION_PRIVILEGES: frozenset[str] = frozenset({"EXECUTE"})
+_ALL_SCHEMA_PRIVILEGES: frozenset[str] = frozenset({"USAGE", "CREATE"})
+
+_ALL_PRIVILEGES_BY_OBJTYPE: dict[str, frozenset[str]] = {
+    "TABLE": _ALL_TABLE_PRIVILEGES,
+    "SEQUENCE": _ALL_SEQUENCE_PRIVILEGES,
+    "FUNCTION": _ALL_FUNCTION_PRIVILEGES,
+    "SCHEMA": _ALL_SCHEMA_PRIVILEGES,
+}
 
 # Regex helpers for the sqlparse fallback path.
 #
@@ -86,6 +98,43 @@ _WITH_OPTION_SUFFIX_RE = re.compile(
     re.IGNORECASE,
 )
 _DYNAMIC_SQL_RE = re.compile(r"\bEXECUTE\s+(?:format\s*\(|['\"])", re.IGNORECASE)
+
+# Statement-level GRANT/REVOKE matcher for the regex fallback path of
+# ``extract_grant_statements`` (issue #162). Captures the privilege list, the
+# raw ``ON`` clause (classified separately), and the grantee list, for both
+# ``GRANT … TO …`` and ``REVOKE … FROM …``.
+_GRANT_REVOKE_STMT_RE = re.compile(
+    r"""
+    ^\s*
+    (?P<action>GRANT|REVOKE)\s+
+    (?P<go_for>GRANT\s+OPTION\s+FOR\s+)?   # REVOKE GRANT OPTION FOR …
+    (?P<privs>.+?)
+    \s+ON\s+
+    (?P<onclause>.+?)
+    \s+(?:TO|FROM)\s+
+    (?P<roles>.+?)
+    \s*;?\s*$
+    """,
+    re.IGNORECASE | re.DOTALL | re.VERBOSE,
+)
+_ALL_IN_SCHEMA_RE = re.compile(
+    r"""
+    ^ALL\s+
+    (?P<plural>TABLES|SEQUENCES|FUNCTIONS|ROUTINES|PROCEDURES)\s+
+    IN\s+SCHEMA\s+
+    (?P<schema>.+)$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_ALTER_DEFAULT_PRIVS_RE = re.compile(r"^\s*ALTER\s+DEFAULT\s+PRIVILEGES\b", re.IGNORECASE)
+_WITH_GRANT_OPTION_RE = re.compile(r"\bWITH\s+GRANT\s+OPTION\b", re.IGNORECASE)
+_ALL_IN_SCHEMA_PLURAL_TO_OBJTYPE: dict[str, str] = {
+    "TABLES": "TABLE",
+    "SEQUENCES": "SEQUENCE",
+    "FUNCTIONS": "FUNCTION",
+    "ROUTINES": "FUNCTION",
+    "PROCEDURES": "FUNCTION",
+}
 
 
 def _strip_quotes(ident: str) -> str:
@@ -167,6 +216,83 @@ def _normalize_grantee(name: str) -> str:
     return name
 
 
+def _fold_grantee(name: str) -> str:
+    """Canonicalize a grantee for the semantic match key (D12, issue #162).
+
+    Mirrors PostgreSQL identifier folding so the regex fallback agrees with
+    pglast (which already folds): unquoted names lower-case, quoted names keep
+    their case, and ``PUBLIC`` (any case) maps to the literal ``"PUBLIC"`` so
+    it lines up with pglast's ``ROLESPEC_PUBLIC`` emission.
+    """
+    name = name.strip()
+    if name.startswith('"') and name.endswith('"'):
+        return name[1:-1]
+    folded = name.lower()
+    if folded == "public":
+        return "PUBLIC"
+    return folded
+
+
+@dataclass(frozen=True)
+class GrantStatement:
+    """A single, comparable GRANT/REVOKE fact (issue #162).
+
+    Fanned out to one instance per ``(object × grantee × privilege)`` — the
+    same philosophy as the legacy ``extract_grants`` tuple, but extended to
+    REVOKE and to schema/sequence/function objects. The seven leading fields
+    *are* the match key the semantic engine compares; ``grant_option`` is
+    deliberately excluded from equality/hash (``compare=False``) because
+    Confiture treats the grant itself — not its propagation flag — as the unit
+    of coverage. Phase 3 still reads ``grant_option`` to detect a change that
+    differs *only* by the option.
+    """
+
+    action: str  # "GRANT" | "REVOKE"
+    objtype: str  # "TABLE" | "SEQUENCE" | "FUNCTION" | "SCHEMA"
+    target_kind: str  # "OBJECT" | "ALL_IN_SCHEMA"
+    schema: str  # schema name (or the target schema for ALL_IN_SCHEMA)
+    object: str | None  # table/seq name, function signature, or None for schema-level
+    grantee: str  # role name, or "PUBLIC"
+    privilege: str  # one privilege per statement; ALL expanded per objtype
+    grant_option: bool = field(default=False, compare=False)
+
+
+@dataclass(frozen=True)
+class UnrepresentableGrant:
+    """A parse-clean privilege change the extractor refuses to key (D9).
+
+    Never silently dropped: the semantic gate degrades to file-presence and
+    surfaces a note for each of these rather than passing a grant that would
+    never reach a migrate environment.
+    """
+
+    reason: str  # "unmodeled_objtype" | "column_privileges" |
+    # "alter_default_privileges" | "dynamic_sql" | "parse_error"
+    detail: str  # human text for the surfaced note
+
+
+@dataclass(frozen=True)
+class GrantExtraction:
+    """Result of :meth:`MigrationGrantExtractor.extract_grant_statements`."""
+
+    statements: list[GrantStatement]
+    unrepresentable: list[UnrepresentableGrant]
+
+
+# Object classes that parse cleanly but Confiture does not model (D9). The
+# regex fallback detects them by the leading ``ON <keyword>`` token.
+_UNMODELED_ON_KEYWORDS: tuple[str, ...] = (
+    "DATABASE",
+    "LANGUAGE",
+    "TYPE",
+    "DOMAIN",
+    "FOREIGN DATA WRAPPER",
+    "FOREIGN SERVER",
+    "TABLESPACE",
+    "LARGE OBJECT",
+)
+
+
 class MigrationGrantExtractor:
     """Pull ``CREATE TABLE``, ``DROP TABLE``, and ``GRANT`` statements out of SQL."""
 
@@ -220,6 +346,60 @@ class MigrationGrantExtractor:
         # examples inside documentation.
         cleaned = sqlparse.format(sql, strip_comments=True)
         return bool(_DYNAMIC_SQL_RE.search(cleaned))
+
+    def extract_grant_statements(self, sql: str) -> GrantExtraction:
+        """Extract GRANT/REVOKE facts from *sql* for semantic matching (issue #162).
+
+        Returns a :class:`GrantExtraction` carrying both the representable
+        :class:`GrantStatement` rows (fanned out one per object × grantee ×
+        privilege, across table / schema-wide / sequence / function objects)
+        **and** an explicit list of :class:`UnrepresentableGrant` markers for
+        everything that parses cleanly but can't be keyed (D9): unmodeled
+        object classes (``ON DATABASE``/``LANGUAGE``/``TYPE``/…), ``ALTER
+        DEFAULT PRIVILEGES``, column-level privileges, dynamic SQL, and parse
+        failures. Nothing privilege-shaped is ever silently dropped and the
+        method never raises — the semantic engine must be able to see
+        everything that changed so it can degrade honestly.
+        """
+        statements: list[GrantStatement] = []
+        unrepresentable: list[UnrepresentableGrant] = []
+
+        # Dynamic SQL hides grants from any static parser — surface it so the
+        # gate degrades rather than passing an invisible privilege change.
+        if self.has_dynamic_sql(sql):
+            unrepresentable.append(
+                UnrepresentableGrant(
+                    reason="dynamic_sql",
+                    detail=(
+                        "EXECUTE format(...) / dynamic SQL — grants built at runtime "
+                        "cannot be statically verified"
+                    ),
+                )
+            )
+
+        parsed = False
+        if _HAS_PGLAST:
+            try:
+                self._statements_pglast(sql, statements, unrepresentable)
+                parsed = True
+            except Exception:  # noqa: BLE001 — fall through to the regex backend
+                statements.clear()
+                parsed = False
+        if not parsed:
+            try:
+                self._statements_sqlparse(sql, statements, unrepresentable)
+                parsed = True
+            except Exception:  # noqa: BLE001 — report rather than raise
+                parsed = False
+        if not parsed:
+            unrepresentable.append(
+                UnrepresentableGrant(
+                    reason="parse_error",
+                    detail="SQL could not be parsed by pglast or the regex fallback",
+                )
+            )
+
+        return GrantExtraction(statements=statements, unrepresentable=unrepresentable)
 
     # ------------------------------------------------------------------ #
     # pglast primary path                                                 #
@@ -324,6 +504,191 @@ class MigrationGrantExtractor:
                     out.append((schema, table, role, privs))
         return out
 
+    def _statements_pglast(
+        self,
+        sql: str,
+        statements: list[GrantStatement],
+        unrepresentable: list[UnrepresentableGrant],
+    ) -> None:
+        """pglast backend for :meth:`extract_grant_statements` (issue #162)."""
+        import pglast  # noqa: PLC0415
+        from pglast.enums.parsenodes import (  # noqa: PLC0415
+            GrantTargetType,
+            ObjectType,
+            RoleSpecType,
+        )
+
+        objtype_map = {
+            ObjectType.OBJECT_TABLE: "TABLE",
+            ObjectType.OBJECT_SEQUENCE: "SEQUENCE",
+            ObjectType.OBJECT_FUNCTION: "FUNCTION",
+            ObjectType.OBJECT_ROUTINE: "FUNCTION",
+            ObjectType.OBJECT_PROCEDURE: "FUNCTION",
+            ObjectType.OBJECT_SCHEMA: "SCHEMA",
+        }
+
+        for raw in pglast.parse_sql(sql):
+            stmt = raw.stmt
+            kind = type(stmt).__name__
+
+            if kind == "AlterDefaultPrivilegesStmt":
+                unrepresentable.append(
+                    UnrepresentableGrant(
+                        reason="alter_default_privileges",
+                        detail="ALTER DEFAULT PRIVILEGES affects future objects; not statically modeled",
+                    )
+                )
+                continue
+            if kind != "GrantStmt":
+                continue
+
+            action = "GRANT" if stmt.is_grant else "REVOKE"
+            modeled = objtype_map.get(stmt.objtype)
+            if modeled is None:
+                unrepresentable.append(
+                    UnrepresentableGrant(
+                        reason="unmodeled_objtype",
+                        detail=f"{action} on an object class outside table/schema/sequence/function",
+                    )
+                )
+                continue
+
+            # Column-level privileges (``GRANT SELECT (col) …``) carry a
+            # non-empty ``cols`` list — keying them as table grants would let a
+            # column grant match (or vanish against) a whole-table grant.
+            if any(p.cols for p in (stmt.privileges or [])):
+                unrepresentable.append(
+                    UnrepresentableGrant(
+                        reason="column_privileges",
+                        detail=f"{action} with a column-level privilege list is not modeled",
+                    )
+                )
+                continue
+
+            if stmt.privileges is None:
+                privs = _ALL_PRIVILEGES_BY_OBJTYPE[modeled]
+            else:
+                privs = frozenset(p.priv_name.upper() for p in stmt.privileges if p.priv_name)
+                if not privs:  # an empty/None priv name means ALL
+                    privs = _ALL_PRIVILEGES_BY_OBJTYPE[modeled]
+
+            grant_option = bool(stmt.grant_option)
+
+            grantees: list[str] = []
+            for g in stmt.grantees or []:
+                if g.roletype == RoleSpecType.ROLESPEC_PUBLIC:
+                    grantees.append("PUBLIC")
+                elif g.rolename:
+                    grantees.append(g.rolename)  # pglast already folds case
+
+            if stmt.targtype == GrantTargetType.ACL_TARGET_ALL_IN_SCHEMA:
+                # objects are String nodes naming the target schema(s).
+                for o in stmt.objects or []:
+                    schema_name = getattr(o, "sval", None)
+                    if not schema_name:
+                        continue
+                    self._emit_statements(
+                        statements,
+                        action,
+                        modeled,
+                        "ALL_IN_SCHEMA",
+                        schema_name,
+                        None,
+                        grantees,
+                        privs,
+                        grant_option,
+                    )
+                continue
+
+            for o in stmt.objects or []:
+                schema_name, obj_name, reason = self._pglast_object_identity(modeled, o)
+                if reason is not None:
+                    unrepresentable.append(
+                        UnrepresentableGrant(
+                            reason=reason,
+                            detail=f"{action} {modeled} target could not be resolved to a stable key",
+                        )
+                    )
+                    continue
+                self._emit_statements(
+                    statements,
+                    action,
+                    modeled,
+                    "OBJECT",
+                    schema_name,
+                    obj_name,
+                    grantees,
+                    privs,
+                    grant_option,
+                )
+
+    @staticmethod
+    def _emit_statements(
+        statements: list[GrantStatement],
+        action: str,
+        objtype: str,
+        target_kind: str,
+        schema: str,
+        obj: str | None,
+        grantees: list[str],
+        privs: frozenset[str],
+        grant_option: bool,
+    ) -> None:
+        for grantee in grantees:
+            for priv in sorted(privs):
+                statements.append(
+                    GrantStatement(
+                        action=action,
+                        objtype=objtype,
+                        target_kind=target_kind,
+                        schema=schema,
+                        object=obj,
+                        grantee=grantee,
+                        privilege=priv,
+                        grant_option=grant_option,
+                    )
+                )
+
+    @staticmethod
+    def _pglast_object_identity(objtype: str, obj: object) -> tuple[str, str | None, str | None]:
+        """Resolve a pglast grant target to ``(schema, object, unrepresentable_reason)``.
+
+        On success the third element is None. When the object can't be keyed
+        reliably (an overload-ambiguous function, an unexpected node shape), it
+        names an unrepresentable reason instead so the caller degrades.
+        """
+        if objtype == "SCHEMA":
+            # ``GRANT … ON SCHEMA s`` — the object IS the schema; no nested name.
+            name = getattr(obj, "sval", None)
+            if not name:
+                return ("", None, "unmodeled_objtype")
+            return (name, None, None)
+
+        if objtype == "FUNCTION":
+            # ObjectWithArgs: objname is the qualified name, objargs the types.
+            if getattr(obj, "args_unspecified", False):
+                # ``GRANT … ON FUNCTION s.fn`` (no parens) can't pin an overload.
+                return ("", None, "unmodeled_objtype")
+            names = [n.sval for n in (getattr(obj, "objname", None) or [])]
+            if not names:
+                return ("", None, "unmodeled_objtype")
+            schema = names[-2] if len(names) >= 2 else "public"
+            fn = names[-1]
+            argtypes: list[str] = []
+            for a in getattr(obj, "objargs", None) or []:
+                type_parts = [n.sval for n in (getattr(a, "names", None) or [])]
+                if not type_parts:
+                    return ("", None, "unmodeled_objtype")
+                argtypes.append(".".join(type_parts))
+            return (schema, f"{fn}({','.join(argtypes)})", None)
+
+        # TABLE / SEQUENCE → RangeVar.
+        schema = getattr(obj, "schemaname", None) or "public"
+        relname = getattr(obj, "relname", None)
+        if not relname:
+            return ("", None, "unmodeled_objtype")
+        return (schema, relname, None)
+
     # ------------------------------------------------------------------ #
     # sqlparse fallback path                                              #
     # ------------------------------------------------------------------ #
@@ -377,8 +742,144 @@ class MigrationGrantExtractor:
                         out.append((schema, table, role, privs))
         return out
 
+    def _statements_sqlparse(
+        self,
+        sql: str,
+        statements: list[GrantStatement],
+        unrepresentable: list[UnrepresentableGrant],
+    ) -> None:
+        """Regex fallback backend for :meth:`extract_grant_statements` (issue #162).
+
+        Intentionally weaker than pglast for non-table objects: function
+        signatures and exotic object classes are reported as unrepresentable
+        rather than guessed, leaning on the honest-degradation contract.
+        """
+        cleaned = sqlparse.format(sql, strip_comments=True)
+        for stmt_text in sqlparse.split(cleaned):
+            stmt_text = stmt_text.strip()
+            if not stmt_text:
+                continue
+            if _ALTER_DEFAULT_PRIVS_RE.match(stmt_text):
+                unrepresentable.append(
+                    UnrepresentableGrant(
+                        reason="alter_default_privileges",
+                        detail="ALTER DEFAULT PRIVILEGES affects future objects; not statically modeled",
+                    )
+                )
+                continue
+            m = _GRANT_REVOKE_STMT_RE.match(stmt_text)
+            if m is None:
+                continue
+
+            action = m.group("action").upper()
+            priv_text = m.group("privs").strip()
+            # Column-level privileges carry a parenthesised column list.
+            if "(" in priv_text:
+                unrepresentable.append(
+                    UnrepresentableGrant(
+                        reason="column_privileges",
+                        detail=f"{action} with a column-level privilege list is not modeled",
+                    )
+                )
+                continue
+
+            items, reason = self._classify_on_clause(m.group("onclause").strip())
+            if reason is not None:
+                unrepresentable.append(
+                    UnrepresentableGrant(
+                        reason=reason,
+                        detail=f"{action} on an object class outside table/schema/sequence/function",
+                    )
+                )
+                continue
+            if not items:
+                continue
+
+            objtype = items[0][0]
+            priv_upper = priv_text.upper()
+            if priv_upper in ("ALL", "ALL PRIVILEGES"):
+                privs = _ALL_PRIVILEGES_BY_OBJTYPE.get(objtype, _ALL_TABLE_PRIVILEGES)
+            else:
+                privs = frozenset(p.strip().upper() for p in priv_upper.split(",") if p.strip())
+
+            roles_text = m.group("roles")
+            grant_option = bool(m.group("go_for")) or bool(_WITH_GRANT_OPTION_RE.search(roles_text))
+            roles_text = _WITH_OPTION_SUFFIX_RE.sub("", roles_text)
+            grantees = [
+                _fold_grantee(r.rstrip(";")) for r in roles_text.split(",") if r.strip().rstrip(";")
+            ]
+            grantees = [g for g in grantees if g]
+
+            for objtype_i, target_kind, schema, obj in items:
+                self._emit_statements(
+                    statements,
+                    action,
+                    objtype_i,
+                    target_kind,
+                    schema,
+                    obj,
+                    grantees,
+                    privs,
+                    grant_option,
+                )
+
+    @staticmethod
+    def _classify_on_clause(
+        onclause: str,
+    ) -> tuple[list[tuple[str, str, str, str | None]], str | None]:
+        """Classify a regex-path ``ON`` clause into grant targets or a degrade reason.
+
+        Returns ``(items, reason)`` where each item is
+        ``(objtype, target_kind, schema, object)``. When ``reason`` is set the
+        item list is empty and the caller marks the statement unrepresentable.
+        """
+        onclause = onclause.strip()
+
+        all_match = _ALL_IN_SCHEMA_RE.match(onclause)
+        if all_match:
+            objtype = _ALL_IN_SCHEMA_PLURAL_TO_OBJTYPE[all_match.group("plural").upper()]
+            if objtype == "FUNCTION":
+                # Function/routine signatures are beyond the regex fallback.
+                return ([], "unmodeled_objtype")
+            schema = _strip_quotes(all_match.group("schema").strip())
+            return ([(objtype, "ALL_IN_SCHEMA", schema, None)], None)
+
+        upper = onclause.upper()
+        for keyword in _UNMODELED_ON_KEYWORDS:
+            if upper.startswith(keyword):
+                return ([], "unmodeled_objtype")
+
+        if upper.startswith(("FUNCTION", "ROUTINE", "PROCEDURE")):
+            # Signatures are too ambiguous for the regex fallback — degrade.
+            return ([], "unmodeled_objtype")
+
+        if upper.startswith("SCHEMA"):
+            names = _split_qname_list(onclause[len("SCHEMA") :].strip())
+            return ([("SCHEMA", "OBJECT", _strip_quotes(n), None) for n in names], None)
+
+        if upper.startswith("SEQUENCE"):
+            qnames = _split_qname_list(onclause[len("SEQUENCE") :].strip())
+            items = []
+            for qname in qnames:
+                schema, seq = _parse_qualified_name(qname)
+                items.append(("SEQUENCE", "OBJECT", schema, seq))
+            return (items, None)
+
+        rest = onclause[len("TABLE") :].strip() if upper.startswith("TABLE") else onclause
+        items = []
+        for qname in _split_qname_list(rest):
+            schema, table = _parse_qualified_name(qname)
+            items.append(("TABLE", "OBJECT", schema, table))
+        return (items, None)
+
 
 __all__ = [
+    "GrantExtraction",
+    "GrantStatement",
     "MigrationGrantExtractor",
+    "UnrepresentableGrant",
+    "_ALL_FUNCTION_PRIVILEGES",
+    "_ALL_SCHEMA_PRIVILEGES",
+    "_ALL_SEQUENCE_PRIVILEGES",
     "_ALL_TABLE_PRIVILEGES",
 ]

--- a/python/confiture/core/migration_grant_extractor.py
+++ b/python/confiture/core/migration_grant_extractor.py
@@ -256,6 +256,25 @@ class GrantStatement:
     privilege: str  # one privilege per statement; ALL expanded per objtype
     grant_option: bool = field(default=False, compare=False)
 
+    def describe(self) -> str:
+        """Render a human-readable SQL-ish form for failure messages."""
+        if self.target_kind == "ALL_IN_SCHEMA":
+            plural = {
+                "TABLE": "TABLES",
+                "SEQUENCE": "SEQUENCES",
+                "FUNCTION": "FUNCTIONS",
+            }.get(self.objtype, f"{self.objtype}S")
+            target = f"ALL {plural} IN SCHEMA {self.schema}"
+        elif self.objtype == "SCHEMA":
+            target = f"SCHEMA {self.schema}"
+        elif self.objtype == "TABLE":
+            target = f"{self.schema}.{self.object}"
+        else:
+            target = f"{self.objtype} {self.schema}.{self.object}"
+        preposition = "TO" if self.action == "GRANT" else "FROM"
+        suffix = " WITH GRANT OPTION" if self.grant_option and self.action == "GRANT" else ""
+        return f"{self.action} {self.privilege} ON {target} {preposition} {self.grantee}{suffix}"
+
 
 @dataclass(frozen=True)
 class UnrepresentableGrant:

--- a/python/confiture/core/migration_grant_extractor.py
+++ b/python/confiture/core/migration_grant_extractor.py
@@ -243,8 +243,8 @@ class GrantStatement:
     *are* the match key the semantic engine compares; ``grant_option`` is
     deliberately excluded from equality/hash (``compare=False``) because
     Confiture treats the grant itself — not its propagation flag — as the unit
-    of coverage. Phase 3 still reads ``grant_option`` to detect a change that
-    differs *only* by the option.
+    of coverage. The accompaniment engine still reads ``grant_option`` to detect
+    a change that differs *only* by the option.
     """
 
     action: str  # "GRANT" | "REVOKE"

--- a/python/confiture/models/git.py
+++ b/python/confiture/models/git.py
@@ -118,15 +118,23 @@ class MigrationAccompanimentReport:
 class GrantAccompanimentReport:
     """Report of grant accompaniment validation.
 
-    Validates that changes to grant files (db/7_grant/) are accompanied
-    by migration files, since migrate environments only apply grants
-    through migration files.
+    Validates that the *changed* GRANT/REVOKE statements in the grant
+    directory (db/7_grant/) are actually carried by an accompanying migration
+    (``.up.sql`` or ``.py``), since migrate environments apply grants only
+    through migrations. Grants that can't be statically represented degrade to
+    a file-presence check (a migration must be present) and are surfaced as
+    notes — never silently passed.
 
     Attributes:
         has_grant_changes: Whether any grant files changed
-        has_migration_changes: Whether any .up.sql migration files changed
+        has_migration_changes: Whether any migration files (``.up.sql``/``.py``) changed
         grant_files_changed: List of changed grant file paths
-        migration_files_staged: List of staged migration file paths
+        migration_files_staged: List of accompanying migration file paths
+        unmatched_grants: Changed grants (serialized) not carried by any
+            migration — each a hard failure
+        unverifiable_notes: Human-readable notes for grants that degraded to
+            file-presence (dynamic SQL, unmodeled object classes, removed
+            grants, search_path-relative schemas, …)
 
     Example:
         >>> report = GrantAccompanimentReport(
@@ -134,6 +142,7 @@ class GrantAccompanimentReport:
         ...     has_migration_changes=False,
         ...     grant_files_changed=[Path("db/7_grant/grants.sql")],
         ...     migration_files_staged=[],
+        ...     unmatched_grants=[{"statement": "GRANT SELECT ON s.t TO r"}],
         ... )
         >>> print(f"Valid: {report.is_valid}")
         Valid: False
@@ -143,16 +152,34 @@ class GrantAccompanimentReport:
     has_migration_changes: bool
     grant_files_changed: list[Path] = field(default_factory=list)
     migration_files_staged: list[Path] = field(default_factory=list)
+    unmatched_grants: list[dict[str, Any]] = field(default_factory=list)
+    unverifiable_notes: list[str] = field(default_factory=list)
 
     @property
     def is_valid(self) -> bool:
-        """Valid when no grant changes, or grant changes + migration present."""
-        return (not self.has_grant_changes) or self.has_migration_changes
+        """Valid when no grant changes; else every changed grant is carried.
+
+        A representable grant change must be matched by an accompanying
+        migration (no ``unmatched_grants``). Grants that couldn't be verified
+        statically (``unverifiable_notes``) degrade to the file-presence
+        check: at least one migration must be present.
+        """
+        if not self.has_grant_changes:
+            return True
+        if self.unmatched_grants:
+            return False
+        if self.unverifiable_notes:
+            return self.has_migration_changes
+        return True
 
     def summary(self) -> str:
         """Get human-readable summary of validation result."""
         if not self.has_grant_changes:
             return "No grant file changes"
+        if self.unmatched_grants:
+            return f"{len(self.unmatched_grants)} grant change(s) not carried by any migration"
+        if self.unverifiable_notes and not self.has_migration_changes:
+            return "Grant changes could not be statically verified and no migration is present"
         if self.is_valid:
             return f"Grant changes accompanied by {len(self.migration_files_staged)} migration(s)"
         return f"Grant changes without migration files ({len(self.grant_files_changed)} file(s) changed)"
@@ -165,4 +192,6 @@ class GrantAccompanimentReport:
             "has_migration_changes": self.has_migration_changes,
             "grant_files_changed": [f.as_posix() for f in self.grant_files_changed],
             "migration_files_staged": [f.as_posix() for f in self.migration_files_staged],
+            "unmatched_grants": self.unmatched_grants,
+            "unverifiable_notes": self.unverifiable_notes,
         }

--- a/tests/integration/test_grant_accompaniment_semantic.py
+++ b/tests/integration/test_grant_accompaniment_semantic.py
@@ -1,0 +1,219 @@
+"""Integration tests for the semantic grant-accompaniment engine (issue #162).
+
+These drive ``GrantAccompanimentChecker`` against a *real* git repository so
+the file-content diffing, the merge-base anchoring (D10), and the
+``.py``-at-ref read (D11) are exercised end to end — none of which MagicMock
+can prove.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from confiture.core.grant_accompaniment import GrantAccompanimentChecker
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _init(repo: Path) -> None:
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "t@t.com")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "db" / "7_grant").mkdir(parents=True)
+    (repo / "db" / "migrations").mkdir(parents=True)
+
+
+def _write(repo: Path, rel: str, content: str) -> None:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _default_branch(repo: Path) -> str:
+    return _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+
+
+@pytest.fixture
+def repo():
+    with TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+class TestSemanticAccompanimentRefMode:
+    def test_matching_grant_in_migration_passes(self, repo: Path):
+        _init(repo)
+        _write(repo, "README.md", "# r")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+        base = _default_branch(repo)
+
+        _git(repo, "checkout", "-b", "feature")
+        _write(repo, "db/7_grant/71_grant.sql", "GRANT SELECT ON s.t TO reporter;\n")
+        _write(
+            repo,
+            "db/migrations/20260613130000_x.up.sql",
+            "GRANT SELECT ON s.t TO reporter;\n",
+        )
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "grant + migration")
+
+        checker = GrantAccompanimentChecker(repo_path=repo)
+        report = checker.check_accompaniment(base_ref=base, target_ref="feature")
+        assert report.is_valid is True
+        assert report.unmatched_grants == []
+
+    def test_missing_grant_in_migration_fails(self, repo: Path):
+        _init(repo)
+        _write(repo, "README.md", "# r")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+        base = _default_branch(repo)
+
+        _git(repo, "checkout", "-b", "feature")
+        _write(repo, "db/7_grant/71_grant.sql", "GRANT SELECT ON s.t TO reporter;\n")
+        _write(
+            repo,
+            "db/migrations/20260613130000_x.up.sql",
+            "GRANT SELECT ON other.tbl TO someone;\n",
+        )
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "grant + wrong migration")
+
+        checker = GrantAccompanimentChecker(repo_path=repo)
+        report = checker.check_accompaniment(base_ref=base, target_ref="feature")
+        assert report.is_valid is False
+        assert len(report.unmatched_grants) == 1
+        assert report.unmatched_grants[0]["grantee"] == "reporter"
+
+    def test_python_migration_carries_grant_at_ref(self, repo: Path):
+        """D11: the .py covered-set is read from the committed ref."""
+        _init(repo)
+        _write(repo, "README.md", "# r")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+        base = _default_branch(repo)
+
+        _git(repo, "checkout", "-b", "feature")
+        _write(repo, "db/7_grant/71_grant.sql", "GRANT SELECT ON s.t TO reporter;\n")
+        _write(
+            repo,
+            "db/migrations/20260613130000_x.py",
+            "from confiture import Migration\n"
+            "class M(Migration):\n"
+            "    def up(self):\n"
+            "        self.execute('GRANT SELECT ON s.t TO reporter;')\n",
+        )
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "grant + py migration")
+
+        checker = GrantAccompanimentChecker(repo_path=repo)
+        report = checker.check_accompaniment(base_ref=base, target_ref="feature")
+        assert report.is_valid is True
+        assert report.unmatched_grants == []
+
+    def test_merge_base_anchoring_ignores_post_fork_base_grant(self, repo: Path):
+        """D10: a grant added on base *after* the fork must not be 'required'.
+
+        Three commits: fork point, a grant added on base after it, and a
+        feature branch that touches an unrelated file. The feature branch
+        introduces no grant change of its own, so the gate must pass — the
+        base-side grant lives past the merge-base and must not leak into the
+        required set as a phantom unaccompanied grant.
+        """
+        _init(repo)
+        _write(repo, "db/7_grant/71_grant.sql", "GRANT SELECT ON s.a TO r;\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "fork point")
+        base = _default_branch(repo)
+
+        # Feature branch forks here and changes only an unrelated file.
+        _git(repo, "checkout", "-b", "feature")
+        _write(repo, "db/migrations/README.md", "notes")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "unrelated change on feature")
+
+        # Base advances past the fork with a brand-new grant (no migration).
+        _git(repo, "checkout", base)
+        _write(
+            repo,
+            "db/7_grant/71_grant.sql",
+            "GRANT SELECT ON s.a TO r;\nGRANT SELECT ON s.b TO r;\n",
+        )
+        _git(repo, "commit", "-am", "add grant on base after fork")
+
+        checker = GrantAccompanimentChecker(repo_path=repo)
+        report = checker.check_accompaniment(base_ref=base, target_ref="feature")
+
+        # If the diff anchored on the base *tip* (not the merge-base), the
+        # s.a-vs-{s.a,s.b} delta would surface s.b as removed/required and the
+        # branch would spuriously fail. Merge-base anchoring sees no grant
+        # change on the feature branch at all.
+        assert report.has_grant_changes is False
+        assert report.is_valid is True
+
+    def test_unmodeled_grant_without_migration_fails(self, repo: Path):
+        """D9 end-to-end: an unmodeled object class degrades and fails sans migration."""
+        _init(repo)
+        _write(repo, "README.md", "# r")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+        base = _default_branch(repo)
+
+        _git(repo, "checkout", "-b", "feature")
+        _write(repo, "db/7_grant/71_grant.sql", "GRANT CONNECT ON DATABASE app TO reporter;\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "database grant, no migration")
+
+        checker = GrantAccompanimentChecker(repo_path=repo)
+        report = checker.check_accompaniment(base_ref=base, target_ref="feature")
+        assert report.is_valid is False
+        assert report.unverifiable_notes
+
+
+class TestSemanticAccompanimentStagedMode:
+    def test_staged_match_passes(self, repo: Path):
+        _init(repo)
+        _write(repo, "README.md", "# r")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+
+        _write(repo, "db/7_grant/71_grant.sql", "GRANT SELECT ON s.t TO reporter;\n")
+        _write(
+            repo,
+            "db/migrations/20260613130000_x.up.sql",
+            "GRANT SELECT ON s.t TO reporter;\n",
+        )
+        _git(repo, "add", "db/7_grant/71_grant.sql", "db/migrations/20260613130000_x.up.sql")
+
+        checker = GrantAccompanimentChecker(repo_path=repo)
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+        assert report.unmatched_grants == []
+
+    def test_staged_mismatch_fails(self, repo: Path):
+        _init(repo)
+        _write(repo, "README.md", "# r")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+
+        _write(repo, "db/7_grant/71_grant.sql", "GRANT SELECT ON s.t TO reporter;\n")
+        _write(
+            repo,
+            "db/migrations/20260613130000_x.up.sql",
+            "GRANT INSERT ON s.t TO reporter;\n",
+        )
+        _git(repo, "add", "db/7_grant/71_grant.sql", "db/migrations/20260613130000_x.up.sql")
+
+        checker = GrantAccompanimentChecker(repo_path=repo)
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert len(report.unmatched_grants) == 1

--- a/tests/unit/json_schemas/test_validate_grant_schema.py
+++ b/tests/unit/json_schemas/test_validate_grant_schema.py
@@ -1,0 +1,69 @@
+"""Validate ``migrate validate --require-grant-migration --format json`` output (issue #162).
+
+This schema is NOT part of the fraisier adapter contract (D13) — it is a
+standalone, completeness schema for the grant gate's JSON failure envelope.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.models.git import GrantAccompanimentReport
+
+SCHEMA_FILE = "migrate-validate-grant.schema.json"
+
+
+def _failing_report() -> GrantAccompanimentReport:
+    return GrantAccompanimentReport(
+        has_grant_changes=True,
+        has_migration_changes=True,
+        grant_files_changed=[Path("db/7_grant/71_grant.sql")],
+        migration_files_staged=[Path("db/migrations/20260613130000_x.py")],
+        unmatched_grants=[
+            {
+                "statement": "GRANT SELECT ON s.t TO reporter",
+                "action": "GRANT",
+                "objtype": "TABLE",
+                "target_kind": "OBJECT",
+                "schema": "s",
+                "object": "t",
+                "grantee": "reporter",
+                "privilege": "SELECT",
+                "changed_in": "db/7_grant/71_grant.sql",
+                "migrations_inspected": ["db/migrations/20260613130000_x.py"],
+            }
+        ],
+        unverifiable_notes=["db/7_grant/71_grant.sql: dynamic SQL (dynamic_sql)"],
+    )
+
+
+def test_schema_is_valid_draft_2020_12(schemas_dir):
+    schema = json.loads((schemas_dir / SCHEMA_FILE).read_text())
+    Draft202012Validator.check_schema(schema)
+
+
+def test_failed_grant_envelope_validates(schemas_dir):
+    with (
+        patch("confiture.cli.git_validation.validate_git_flags_in_repo"),
+        patch("confiture.cli.git_validation.GrantAccompanimentChecker") as mock_cls,
+    ):
+        mock_checker = MagicMock()
+        mock_checker.check_accompaniment.return_value = _failing_report()
+        mock_cls.return_value = mock_checker
+        result = CliRunner().invoke(
+            app,
+            ["migrate", "validate", "--require-grant-migration", "--staged", "--format", "json"],
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    schema = json.loads((schemas_dir / SCHEMA_FILE).read_text())
+    Draft202012Validator(schema).validate(payload)
+    assert payload["check"] == "grant_accompaniment"
+    assert payload["status"] == "failed"

--- a/tests/unit/linting/test_acl_coverage_rule.py
+++ b/tests/unit/linting/test_acl_coverage_rule.py
@@ -276,6 +276,52 @@ def test_handles_various_migration_filename_styles(tmp_path: Path, filename: str
 
 
 # ---------------------------------------------------------------------------
+# Python-migration coverage (issue #162 twin gap — same blind spot as the
+# grant-accompaniment gate)
+# ---------------------------------------------------------------------------
+
+
+def test_python_migration_create_with_grant_is_covered(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path,
+        "20260613130000_add_foo.py",
+        "from confiture import Migration\n"
+        "class M(Migration):\n"
+        "    def up(self):\n"
+        "        self.execute('CREATE TABLE foo (id int);')\n"
+        "        self.execute('GRANT SELECT, INSERT ON foo TO my_app;')\n",
+    )
+    rule = Acl001GrantCoverage(expectations=_make_expectations(), grant_dir=None)
+    assert rule.check(tmp_path) == []
+
+
+def test_python_migration_create_without_grant_is_flagged(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path,
+        "20260613130000_add_foo.py",
+        "from confiture import Migration\n"
+        "class M(Migration):\n"
+        "    def up(self):\n"
+        "        self.execute('CREATE TABLE foo (id int);')\n",
+    )
+    rule = Acl001GrantCoverage(expectations=_make_expectations(), grant_dir=None)
+    violations = rule.check(tmp_path)
+    assert len(violations) >= 1
+
+
+def test_python_init_and_private_modules_are_skipped(tmp_path: Path) -> None:
+    # __init__.py / _-prefixed modules are package machinery, not migrations.
+    _write_migration(tmp_path, "__init__.py", "")
+    _write_migration(
+        tmp_path,
+        "_helpers.py",
+        "x = 'CREATE TABLE ghost (id int);'\n",
+    )
+    rule = Acl001GrantCoverage(expectations=_make_expectations(), grant_dir=None)
+    assert rule.check(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
 # Owner-only directive — per-table scoping
 #
 # The directive must apply only to the immediately-following CREATE TABLE.

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -241,3 +241,96 @@ class TestGitRepository:
 
             with pytest.raises(GitError):
                 git_repo.get_file_at_ref(Path("test.sql"), "nonexistent_ref")
+
+
+def _run(repo_path: Path, *args: str) -> str:
+    import subprocess
+
+    result = subprocess.run(
+        ["git", *args], cwd=repo_path, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo_path: Path) -> None:
+    _run(repo_path, "init")
+    _run(repo_path, "config", "user.email", "test@test.com")
+    _run(repo_path, "config", "user.name", "Test User")
+    _run(repo_path, "config", "commit.gpgsign", "false")
+
+
+class TestGitPlumbingIssue162:
+    """Tests for the merge-base + staged-content plumbing (issue #162, Phase 3)."""
+
+    def test_get_staged_file_content_returns_staged_blob(self):
+        """Staged content is the index blob, not the (dirtier) working tree."""
+        with TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_repo(repo_path)
+            f = repo_path / "g.sql"
+            f.write_text("GRANT SELECT ON s.t TO r;\n")
+            _run(repo_path, "add", "g.sql")
+            # Working tree diverges from the index after staging.
+            f.write_text("GRANT SELECT ON s.t TO r;\nGRANT INSERT ON s.t TO r;\n")
+
+            git_repo = GitRepository(repo_path)
+            staged = git_repo.get_staged_file_content(Path("g.sql"))
+            assert staged == "GRANT SELECT ON s.t TO r;\n"
+
+    def test_get_staged_file_content_none_when_not_staged(self):
+        with TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_repo(repo_path)
+            (repo_path / "README.md").write_text("# Test")
+            _run(repo_path, "add", ".")
+            _run(repo_path, "commit", "-m", "init")
+
+            git_repo = GitRepository(repo_path)
+            assert git_repo.get_staged_file_content(Path("absent.sql")) is None
+
+    def test_get_merge_base_returns_common_ancestor(self):
+        """merge-base must be the fork point, not the tip of base."""
+        with TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_repo(repo_path)
+            (repo_path / "a.txt").write_text("1")
+            _run(repo_path, "add", ".")
+            _run(repo_path, "commit", "-m", "c1")
+            fork_point = _run(repo_path, "rev-parse", "HEAD")
+            _run(repo_path, "branch", "feature")
+
+            # Advance main (base) past the fork point.
+            (repo_path / "a.txt").write_text("2")
+            _run(repo_path, "commit", "-am", "c2-on-main")
+
+            # Commit on the feature branch.
+            _run(repo_path, "checkout", "feature")
+            (repo_path / "b.txt").write_text("1")
+            _run(repo_path, "add", ".")
+            _run(repo_path, "commit", "-m", "c3-on-feature")
+
+            git_repo = GitRepository(repo_path)
+            mb = git_repo.get_merge_base("master", "feature")
+            # Some git versions default the initial branch to "main".
+            if mb is None or mb == "master":
+                mb = git_repo.get_merge_base("main", "feature")
+            assert mb == fork_point
+
+    def test_get_merge_base_falls_back_on_unrelated_histories(self):
+        """Unrelated histories have no merge-base → fall back to base_ref."""
+        with TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            _init_repo(repo_path)
+            (repo_path / "a.txt").write_text("1")
+            _run(repo_path, "add", ".")
+            _run(repo_path, "commit", "-m", "c1")
+            # Orphan branch — a second root with no common ancestor.
+            _run(repo_path, "checkout", "--orphan", "orphan")
+            (repo_path / "c.txt").write_text("1")
+            _run(repo_path, "add", ".")
+            _run(repo_path, "commit", "-m", "orphan-root")
+
+            git_repo = GitRepository(repo_path)
+            base = git_repo.get_merge_base("master", "orphan")
+            base = base if base not in (None, "master") else git_repo.get_merge_base("main", "orphan")
+            assert base in ("master", "main")

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -332,5 +332,7 @@ class TestGitPlumbingIssue162:
 
             git_repo = GitRepository(repo_path)
             base = git_repo.get_merge_base("master", "orphan")
-            base = base if base not in (None, "master") else git_repo.get_merge_base("main", "orphan")
+            base = (
+                base if base not in (None, "master") else git_repo.get_merge_base("main", "orphan")
+            )
             assert base in ("master", "main")

--- a/tests/unit/test_grant_accompaniment.py
+++ b/tests/unit/test_grant_accompaniment.py
@@ -168,6 +168,39 @@ class TestGrantAccompanimentChecker:
         assert report.has_migration_changes is False
         assert report.is_valid is False
 
+    def test_grant_change_with_python_migration_is_valid(self):
+        """Issue #162: a Python migration counts as an accompanying migration."""
+        checker = self._make_checker()
+        checker.git_repo.get_staged_files.return_value = [
+            Path("db/7_grant/741_grant_reporter.sql"),
+            Path("db/migrations/20260613130000_add_reporter.py"),
+        ]
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+        assert report.has_migration_changes is True
+
+    def test_python_init_module_not_counted(self):
+        """__init__.py is package machinery, not a migration (issue #162)."""
+        checker = self._make_checker()
+        checker.git_repo.get_staged_files.return_value = [
+            Path("db/7_grant/741_grant_reporter.sql"),
+            Path("db/migrations/__init__.py"),
+        ]
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.has_migration_changes is False
+        assert report.is_valid is False
+
+    def test_private_python_module_not_counted(self):
+        """_-prefixed modules are helpers, not migrations (issue #162)."""
+        checker = self._make_checker()
+        checker.git_repo.get_staged_files.return_value = [
+            Path("db/7_grant/741_grant_reporter.sql"),
+            Path("db/migrations/_helpers.py"),
+        ]
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.has_migration_changes is False
+        assert report.is_valid is False
+
     def test_nested_grant_file_is_detected(self):
         checker = self._make_checker()
         checker.git_repo.get_staged_files.return_value = [

--- a/tests/unit/test_grant_accompaniment.py
+++ b/tests/unit/test_grant_accompaniment.py
@@ -29,13 +29,48 @@ class TestGrantAccompanimentReport:
         assert report.is_valid is True
 
     def test_grant_change_without_migration_is_invalid(self):
+        # Semantic engine: an unmatched (or unverifiable) grant with no
+        # migration is the failing case. A grant change carrying *nothing*
+        # representable + no migration is the no-op loosening (tested below).
+        report = GrantAccompanimentReport(
+            has_grant_changes=True,
+            has_migration_changes=False,
+            grant_files_changed=[Path("db/7_grant/741_grant_reporter.sql")],
+            migration_files_staged=[],
+            unmatched_grants=[{"statement": "GRANT SELECT ON s.t TO reporter"}],
+        )
+        assert report.is_valid is False
+
+    def test_unverifiable_grant_without_migration_is_invalid(self):
+        report = GrantAccompanimentReport(
+            has_grant_changes=True,
+            has_migration_changes=False,
+            grant_files_changed=[Path("db/7_grant/741_grant_reporter.sql")],
+            migration_files_staged=[],
+            unverifiable_notes=["dynamic SQL — could not statically verify"],
+        )
+        assert report.is_valid is False
+
+    def test_unverifiable_grant_with_migration_degrades_to_valid(self):
+        report = GrantAccompanimentReport(
+            has_grant_changes=True,
+            has_migration_changes=True,
+            grant_files_changed=[Path("db/7_grant/741_grant_reporter.sql")],
+            migration_files_staged=[Path("db/migrations/001_x.up.sql")],
+            unverifiable_notes=["dynamic SQL — could not statically verify"],
+        )
+        assert report.is_valid is True
+
+    def test_noop_grant_edit_without_migration_is_valid(self):
+        # Comment-only / reorder edit: nothing representable changed, nothing
+        # unverifiable. The semantic gate passes without a migration (loosening).
         report = GrantAccompanimentReport(
             has_grant_changes=True,
             has_migration_changes=False,
             grant_files_changed=[Path("db/7_grant/741_grant_reporter.sql")],
             migration_files_staged=[],
         )
-        assert report.is_valid is False
+        assert report.is_valid is True
 
     def test_only_migration_no_grant_is_valid(self):
         report = GrantAccompanimentReport(
@@ -70,8 +105,9 @@ class TestGrantAccompanimentReport:
             has_migration_changes=False,
             grant_files_changed=[Path("db/7_grant/741_grant_reporter.sql")],
             migration_files_staged=[],
+            unmatched_grants=[{"statement": "GRANT SELECT ON s.t TO reporter"}],
         )
-        assert "without" in report.summary()
+        assert "not carried" in report.summary()
 
     def test_to_dict_structure(self):
         report = GrantAccompanimentReport(
@@ -79,6 +115,8 @@ class TestGrantAccompanimentReport:
             has_migration_changes=False,
             grant_files_changed=[Path("db/7_grant/741_grant_reporter.sql")],
             migration_files_staged=[],
+            unmatched_grants=[{"statement": "GRANT SELECT ON s.t TO reporter"}],
+            unverifiable_notes=["a note"],
         )
         d = report.to_dict()
         assert "is_valid" in d
@@ -86,6 +124,8 @@ class TestGrantAccompanimentReport:
         assert "has_migration_changes" in d
         assert "grant_files_changed" in d
         assert "migration_files_staged" in d
+        assert "unmatched_grants" in d
+        assert "unverifiable_notes" in d
         assert d["is_valid"] is False
         assert d["grant_files_changed"] == ["db/7_grant/741_grant_reporter.sql"]
 
@@ -247,3 +287,242 @@ class TestGrantAccompanimentChecker:
         ]
         report = checker.check_accompaniment(staged_only=True)
         assert report.has_migration_changes is True
+
+
+class TestSemanticGrantMatching:
+    """Content-bearing tests for the semantic engine (issue #162, Phase 3).
+
+    Unlike the MagicMock-only tests above (which exercise the degradation
+    path), these stub the git content reads so the engine can actually parse
+    and compare GRANT/REVOKE statements.
+    """
+
+    GRANT = Path("db/7_grant/71_grant.sql")
+    MIG_SQL = Path("db/migrations/20260613130000_x.up.sql")
+    MIG_PY = Path("db/migrations/20260613130000_x.py")
+
+    def _checker(
+        self,
+        staged_files,
+        target_contents,
+        base_contents=None,
+    ):
+        checker = GrantAccompanimentChecker()
+        git = MagicMock()
+        git.get_staged_files.return_value = list(staged_files)
+        target = {p.as_posix(): c for p, c in target_contents.items()}
+        base = {p.as_posix(): c for p, c in (base_contents or {}).items()}
+        git.get_staged_file_content.side_effect = lambda p: target.get(p.as_posix())
+        # In staged mode the diff base is HEAD; serve base content from here.
+        git.get_file_at_ref.side_effect = lambda p, ref: base.get(p.as_posix())
+        git.get_merge_base.return_value = "HEAD"
+        checker.git_repo = git
+        return checker
+
+    def test_semantic_match_passes(self):
+        checker = self._checker(
+            [self.GRANT, self.MIG_SQL],
+            {
+                self.GRANT: "GRANT SELECT ON s.t TO reporter;",
+                self.MIG_SQL: "GRANT SELECT ON s.t TO reporter;",
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+        assert report.unmatched_grants == []
+
+    def test_semantic_mismatch_fails_and_names_grant(self):
+        checker = self._checker(
+            [self.GRANT, self.MIG_SQL],
+            {
+                self.GRANT: "GRANT SELECT ON s.t TO reporter;",
+                self.MIG_SQL: "GRANT SELECT ON other.tbl TO someone;",
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert len(report.unmatched_grants) == 1
+        stmt = report.unmatched_grants[0]
+        assert stmt["schema"] == "s"
+        assert stmt["object"] == "t"
+        assert stmt["grantee"] == "reporter"
+        assert "GRANT SELECT ON s.t TO reporter" in stmt["statement"]
+
+    def test_diff_aware_only_changed_grant_required(self):
+        """Editing one grant in a many-grant file requires only that grant."""
+        checker = self._checker(
+            [self.GRANT, self.MIG_SQL],
+            {
+                self.GRANT: "GRANT SELECT ON s.a TO r;\nGRANT SELECT ON s.b TO r;\nGRANT SELECT ON s.c TO r;",
+                self.MIG_SQL: "GRANT SELECT ON s.c TO r;",
+            },
+            base_contents={
+                self.GRANT: "GRANT SELECT ON s.a TO r;\nGRANT SELECT ON s.b TO r;",
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+        assert report.unmatched_grants == []
+
+    def test_grant_all_matches_explicit_privileges(self):
+        checker = self._checker(
+            [self.GRANT, self.MIG_SQL],
+            {
+                self.GRANT: "GRANT ALL ON s.t TO r;",
+                self.MIG_SQL: (
+                    "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER "
+                    "ON s.t TO r;"
+                ),
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+
+    def test_revoke_match(self):
+        checker = self._checker(
+            [self.GRANT, self.MIG_SQL],
+            {
+                self.GRANT: "REVOKE SELECT ON s.t FROM r;",
+                self.MIG_SQL: "REVOKE SELECT ON s.t FROM r;",
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+
+    def test_schema_wide_grant_match(self):
+        checker = self._checker(
+            [self.GRANT, self.MIG_SQL],
+            {
+                self.GRANT: "GRANT SELECT ON ALL TABLES IN SCHEMA s TO r;",
+                self.MIG_SQL: "GRANT SELECT ON ALL TABLES IN SCHEMA s TO r;",
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+
+    def test_noop_comment_edit_passes_without_migration(self):
+        checker = self._checker(
+            [self.GRANT],
+            {self.GRANT: "-- a new comment\nGRANT SELECT ON s.t TO r;"},
+            base_contents={self.GRANT: "GRANT SELECT ON s.t TO r;"},
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+        assert report.unmatched_grants == []
+        assert report.unverifiable_notes == []
+
+    def test_python_migration_carries_grant(self):
+        checker = self._checker(
+            [self.GRANT, self.MIG_PY],
+            {
+                self.GRANT: "GRANT SELECT ON s.t TO reporter;",
+                self.MIG_PY: (
+                    "from confiture import Migration\n"
+                    "class M(Migration):\n"
+                    "    def up(self):\n"
+                    "        self.execute('GRANT SELECT ON s.t TO reporter;')\n"
+                ),
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+        assert report.unmatched_grants == []
+
+    def test_python_migration_missing_grant_fails(self):
+        checker = self._checker(
+            [self.GRANT, self.MIG_PY],
+            {
+                self.GRANT: "GRANT SELECT ON s.t TO reporter;",
+                self.MIG_PY: (
+                    "from confiture import Migration\n"
+                    "class M(Migration):\n"
+                    "    def up(self):\n"
+                    "        self.execute('CREATE TABLE s.t (id int);')\n"
+                ),
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert len(report.unmatched_grants) == 1
+
+    # ---- D9 silent-pass set: degrade + note, fail without a migration ----
+
+    def test_unmodeled_database_grant_fails_without_migration(self):
+        checker = self._checker(
+            [self.GRANT],
+            {self.GRANT: "GRANT CONNECT ON DATABASE foo TO r;"},
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert any("DATABASE" in n or "unmodeled" in n for n in report.unverifiable_notes)
+
+    def test_unmodeled_database_grant_passes_with_migration(self):
+        checker = self._checker(
+            [self.GRANT, self.MIG_SQL],
+            {
+                self.GRANT: "GRANT CONNECT ON DATABASE foo TO r;",
+                self.MIG_SQL: "GRANT CONNECT ON DATABASE foo TO r;",
+            },
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is True
+        assert report.unverifiable_notes  # surfaced, even though it passes
+
+    def test_alter_default_privileges_degrades(self):
+        checker = self._checker(
+            [self.GRANT],
+            {self.GRANT: "ALTER DEFAULT PRIVILEGES IN SCHEMA s GRANT SELECT ON TABLES TO r;"},
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert any(
+            "alter_default_privileges" in n.lower() or "default" in n.lower()
+            for n in report.unverifiable_notes
+        )
+
+    def test_column_level_grant_degrades(self):
+        checker = self._checker(
+            [self.GRANT],
+            {self.GRANT: "GRANT SELECT (col1) ON s.t TO r;"},
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert any("column" in n.lower() for n in report.unverifiable_notes)
+
+    def test_dynamic_sql_grant_degrades(self):
+        checker = self._checker(
+            [self.GRANT],
+            {self.GRANT: "DO $$ BEGIN EXECUTE format('GRANT SELECT ON %I TO r', 't'); END $$;"},
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert any("dynamic" in n.lower() for n in report.unverifiable_notes)
+
+    def test_search_path_relative_grant_degrades(self):
+        checker = self._checker(
+            [self.GRANT],
+            {self.GRANT: "SET search_path = myschema;\nGRANT SELECT ON t TO r;"},
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert any("search_path" in n for n in report.unverifiable_notes)
+
+    def test_removed_grant_degrades_to_file_presence(self):
+        checker = self._checker(
+            [self.GRANT],
+            {self.GRANT: "-- emptied\n"},
+            base_contents={self.GRANT: "GRANT SELECT ON s.t TO r;"},
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert any("removed" in n.lower() for n in report.unverifiable_notes)
+
+    def test_grant_option_only_change_degrades(self):
+        checker = self._checker(
+            [self.GRANT],
+            {self.GRANT: "GRANT SELECT ON s.t TO r WITH GRANT OPTION;"},
+            base_contents={self.GRANT: "GRANT SELECT ON s.t TO r;"},
+        )
+        report = checker.check_accompaniment(staged_only=True)
+        assert report.is_valid is False
+        assert any("GRANT OPTION" in n for n in report.unverifiable_notes)

--- a/tests/unit/test_grant_statements_extractor.py
+++ b/tests/unit/test_grant_statements_extractor.py
@@ -1,0 +1,355 @@
+"""Unit tests for the richer ``extract_grant_statements`` API (issue #162).
+
+The semantic grant-accompaniment engine (issue #162) needs more than the
+table-only ``extract_grants`` shape: it must recognize GRANT **and** REVOKE
+across table / schema-wide / sequence / function objects, and — crucially —
+must NEVER silently drop a privilege change it can't represent. Anything
+parse-clean-but-unmodeled lands in ``GrantExtraction.unrepresentable`` (D9),
+so the gate degrades to file-presence rather than passing a grant that never
+reaches production.
+
+Both backends (pglast primary, regex fallback) are exercised. pglast is the
+ground truth; the regex fallback is intentionally weaker for non-table
+objects and leans on the unrepresentable channel rather than guessing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.migration_grant_extractor import (
+    _ALL_FUNCTION_PRIVILEGES,
+    _ALL_SCHEMA_PRIVILEGES,
+    _ALL_SEQUENCE_PRIVILEGES,
+    _ALL_TABLE_PRIVILEGES,
+    GrantStatement,
+    MigrationGrantExtractor,
+)
+
+
+def _keys(stmts: list[GrantStatement]) -> set[tuple]:
+    """Reduce statements to their comparable match keys (privilege-level)."""
+    return {
+        (s.action, s.objtype, s.target_kind, s.schema, s.object, s.grantee, s.privilege)
+        for s in stmts
+    }
+
+
+def _regex(monkeypatch: pytest.MonkeyPatch) -> MigrationGrantExtractor:
+    monkeypatch.setattr("confiture.core.migration_grant_extractor._HAS_PGLAST", False)
+    return MigrationGrantExtractor()
+
+
+# ---------------------------------------------------------------------------
+# GRANT / REVOKE on tables — both backends, full parity
+# ---------------------------------------------------------------------------
+
+
+def test_grant_table_pglast() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements("GRANT SELECT ON s.t TO r;")
+    assert _keys(result.statements) == {("GRANT", "TABLE", "OBJECT", "s", "t", "r", "SELECT")}
+    assert result.unrepresentable == []
+
+
+def test_grant_table_regex(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _regex(monkeypatch).extract_grant_statements("GRANT SELECT ON s.t TO r;")
+    assert _keys(result.statements) == {("GRANT", "TABLE", "OBJECT", "s", "t", "r", "SELECT")}
+    assert result.unrepresentable == []
+
+
+def test_revoke_table_pglast() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements("REVOKE SELECT ON foo FROM r;")
+    assert _keys(result.statements) == {
+        ("REVOKE", "TABLE", "OBJECT", "public", "foo", "r", "SELECT")
+    }
+
+
+def test_revoke_table_regex(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _regex(monkeypatch).extract_grant_statements("REVOKE SELECT ON foo FROM r;")
+    assert _keys(result.statements) == {
+        ("REVOKE", "TABLE", "OBJECT", "public", "foo", "r", "SELECT")
+    }
+
+
+def test_multi_privilege_multi_grantee_fanout() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT SELECT, INSERT ON s.t TO r1, r2;"
+    )
+    assert _keys(result.statements) == {
+        ("GRANT", "TABLE", "OBJECT", "s", "t", "r1", "SELECT"),
+        ("GRANT", "TABLE", "OBJECT", "s", "t", "r1", "INSERT"),
+        ("GRANT", "TABLE", "OBJECT", "s", "t", "r2", "SELECT"),
+        ("GRANT", "TABLE", "OBJECT", "s", "t", "r2", "INSERT"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# ALL expansion per object type
+# ---------------------------------------------------------------------------
+
+
+def test_grant_all_table_expands() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements("GRANT ALL ON s.t TO r;")
+    assert {s.privilege for s in result.statements} == set(_ALL_TABLE_PRIVILEGES)
+
+
+def test_grant_all_sequence_expands() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements("GRANT ALL ON SEQUENCE s.seq TO r;")
+    assert {s.privilege for s in result.statements} == set(_ALL_SEQUENCE_PRIVILEGES)
+    assert all(s.objtype == "SEQUENCE" for s in result.statements)
+
+
+def test_grant_all_function_expands() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT ALL ON FUNCTION s.fn(int) TO r;"
+    )
+    assert {s.privilege for s in result.statements} == set(_ALL_FUNCTION_PRIVILEGES)
+
+
+def test_grant_all_schema_expands() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements("GRANT ALL ON SCHEMA s TO r;")
+    assert {s.privilege for s in result.statements} == set(_ALL_SCHEMA_PRIVILEGES)
+    assert all(
+        s.objtype == "SCHEMA" and s.object is None and s.schema == "s" for s in result.statements
+    )
+
+
+def test_grant_all_explicit_list_equivalence() -> None:
+    """GRANT ALL must yield the same key set as the explicit privilege list."""
+    all_form = MigrationGrantExtractor().extract_grant_statements("GRANT ALL ON s.t TO r;")
+    explicit = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON s.t TO r;"
+    )
+    assert _keys(all_form.statements) == _keys(explicit.statements)
+
+
+# ---------------------------------------------------------------------------
+# Sequence / function / schema objects (pglast)
+# ---------------------------------------------------------------------------
+
+
+def test_sequence_grant_pglast() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT USAGE ON SEQUENCE s.seq TO r;"
+    )
+    assert _keys(result.statements) == {("GRANT", "SEQUENCE", "OBJECT", "s", "seq", "r", "USAGE")}
+
+
+def test_function_grant_includes_signature() -> None:
+    """Overloads must be distinguishable: the arg signature is part of the key."""
+    a = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT EXECUTE ON FUNCTION s.fn(int) TO r;"
+    )
+    b = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT EXECUTE ON FUNCTION s.fn(text) TO r;"
+    )
+    assert _keys(a.statements) != _keys(b.statements)
+    # int and integer normalize identically (pglast canonicalizes to int4).
+    c = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT EXECUTE ON FUNCTION s.fn(integer) TO r;"
+    )
+    assert _keys(a.statements) == _keys(c.statements)
+
+
+def test_function_args_unspecified_is_unrepresentable() -> None:
+    """`GRANT EXECUTE ON FUNCTION s.fn` (no parens) can't pin an overload."""
+    result = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT EXECUTE ON FUNCTION s.fn TO r;"
+    )
+    assert result.statements == []
+    assert any(u.reason == "unmodeled_objtype" for u in result.unrepresentable) or any(
+        "overload" in u.detail.lower() or "signature" in u.detail.lower()
+        for u in result.unrepresentable
+    )
+
+
+def test_schema_grant_pglast() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements("GRANT USAGE ON SCHEMA s TO r;")
+    assert _keys(result.statements) == {("GRANT", "SCHEMA", "OBJECT", "s", None, "r", "USAGE")}
+
+
+# ---------------------------------------------------------------------------
+# Schema-wide (ALL ... IN SCHEMA)
+# ---------------------------------------------------------------------------
+
+
+def test_all_tables_in_schema_pglast() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT SELECT ON ALL TABLES IN SCHEMA s TO r;"
+    )
+    assert _keys(result.statements) == {
+        ("GRANT", "TABLE", "ALL_IN_SCHEMA", "s", None, "r", "SELECT")
+    }
+
+
+def test_all_sequences_in_schema_pglast() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT USAGE ON ALL SEQUENCES IN SCHEMA s TO r;"
+    )
+    assert _keys(result.statements) == {
+        ("GRANT", "SEQUENCE", "ALL_IN_SCHEMA", "s", None, "r", "USAGE")
+    }
+
+
+def test_all_in_schema_does_not_match_individual_object() -> None:
+    """A schema-wide grant is a distinct key from an individual-object grant."""
+    wide = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT SELECT ON ALL TABLES IN SCHEMA s TO r;"
+    )
+    one = MigrationGrantExtractor().extract_grant_statements("GRANT SELECT ON s.t TO r;")
+    assert _keys(wide.statements).isdisjoint(_keys(one.statements))
+
+
+# ---------------------------------------------------------------------------
+# D12 — grantee case folding is consistent across backends
+# ---------------------------------------------------------------------------
+
+
+def test_grantee_case_folding_unquoted_pglast() -> None:
+    upper = MigrationGrantExtractor().extract_grant_statements("GRANT SELECT ON s.t TO Reporter;")
+    lower = MigrationGrantExtractor().extract_grant_statements("GRANT SELECT ON s.t TO reporter;")
+    assert _keys(upper.statements) == _keys(lower.statements)
+    assert next(iter(upper.statements)).grantee == "reporter"
+
+
+def test_grantee_case_folding_unquoted_regex(monkeypatch: pytest.MonkeyPatch) -> None:
+    ext = _regex(monkeypatch)
+    upper = ext.extract_grant_statements("GRANT SELECT ON s.t TO Reporter;")
+    lower = ext.extract_grant_statements("GRANT SELECT ON s.t TO reporter;")
+    assert _keys(upper.statements) == _keys(lower.statements)
+    assert next(iter(upper.statements)).grantee == "reporter"
+
+
+def test_grantee_quoted_preserves_case() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(
+        'GRANT SELECT ON s.t TO "Reporter";'
+    )
+    assert next(iter(result.statements)).grantee == "Reporter"
+
+
+def test_grantee_public_literal_both_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    pglast_result = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT SELECT ON s.t TO public;"
+    )
+    regex_result = _regex(monkeypatch).extract_grant_statements("GRANT SELECT ON s.t TO PUBLIC;")
+    assert next(iter(pglast_result.statements)).grantee == "PUBLIC"
+    assert next(iter(regex_result.statements)).grantee == "PUBLIC"
+
+
+# ---------------------------------------------------------------------------
+# grant_option is exposed but EXCLUDED from the match key
+# ---------------------------------------------------------------------------
+
+
+def test_grant_option_excluded_from_match_key() -> None:
+    plain = MigrationGrantExtractor().extract_grant_statements("GRANT SELECT ON s.t TO r;")
+    with_opt = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT SELECT ON s.t TO r WITH GRANT OPTION;"
+    )
+    # Equal as keys (grant_option is compare=False) ...
+    assert set(plain.statements) == set(with_opt.statements)
+    # ... but the flag is still readable for Phase 3's "differs only by" check.
+    assert next(iter(plain.statements)).grant_option is False
+    assert next(iter(with_opt.statements)).grant_option is True
+
+
+# ---------------------------------------------------------------------------
+# D9 — the unrepresentable channel (the load-bearing safety property)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "GRANT CONNECT ON DATABASE foo TO r;",
+        "GRANT USAGE ON LANGUAGE plpgsql TO r;",
+        "GRANT USAGE ON TYPE s.mytype TO r;",
+        "GRANT USAGE ON FOREIGN DATA WRAPPER fdw TO r;",
+        "GRANT ALL ON TABLESPACE ts TO r;",
+    ],
+)
+def test_unmodeled_objtype_is_unrepresentable_pglast(sql: str) -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(sql)
+    assert result.statements == []
+    assert any(u.reason == "unmodeled_objtype" for u in result.unrepresentable)
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "GRANT CONNECT ON DATABASE foo TO r;",
+        "GRANT USAGE ON LANGUAGE plpgsql TO r;",
+        "GRANT USAGE ON FOREIGN DATA WRAPPER fdw TO r;",
+    ],
+)
+def test_unmodeled_objtype_is_unrepresentable_regex(
+    sql: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _regex(monkeypatch).extract_grant_statements(sql)
+    assert result.statements == []
+    assert any(u.reason == "unmodeled_objtype" for u in result.unrepresentable)
+
+
+def test_alter_default_privileges_is_unrepresentable_pglast() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA s GRANT SELECT ON TABLES TO r;"
+    )
+    assert result.statements == []
+    assert any(u.reason == "alter_default_privileges" for u in result.unrepresentable)
+
+
+def test_alter_default_privileges_is_unrepresentable_regex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = _regex(monkeypatch).extract_grant_statements(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA s GRANT SELECT ON TABLES TO r;"
+    )
+    assert result.statements == []
+    assert any(u.reason == "alter_default_privileges" for u in result.unrepresentable)
+
+
+def test_column_level_privileges_is_unrepresentable_pglast() -> None:
+    result = MigrationGrantExtractor().extract_grant_statements(
+        "GRANT SELECT (col1, col2) ON s.t TO r;"
+    )
+    assert result.statements == []
+    assert any(u.reason == "column_privileges" for u in result.unrepresentable)
+
+
+def test_column_level_privileges_is_unrepresentable_regex(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _regex(monkeypatch).extract_grant_statements("GRANT SELECT (col1, col2) ON s.t TO r;")
+    assert result.statements == []
+    assert any(u.reason == "column_privileges" for u in result.unrepresentable)
+
+
+def test_dynamic_sql_is_unrepresentable() -> None:
+    sql = "DO $$ BEGIN EXECUTE format('GRANT SELECT ON %I TO r', 't'); END $$;"
+    result = MigrationGrantExtractor().extract_grant_statements(sql)
+    assert result.statements == []
+    assert any(u.reason == "dynamic_sql" for u in result.unrepresentable)
+
+
+def test_unmodeled_does_not_swallow_a_neighbouring_table_grant() -> None:
+    """A modeled grant alongside an unmodeled one must still be extracted."""
+    sql = "GRANT CONNECT ON DATABASE foo TO r;\nGRANT SELECT ON s.t TO r;"
+    result = MigrationGrantExtractor().extract_grant_statements(sql)
+    assert _keys(result.statements) == {("GRANT", "TABLE", "OBJECT", "s", "t", "r", "SELECT")}
+    assert any(u.reason == "unmodeled_objtype" for u in result.unrepresentable)
+
+
+# ---------------------------------------------------------------------------
+# Legacy extract_grants must stay byte-compatible (D6)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_grants_still_table_only_and_grant_only() -> None:
+    ext = MigrationGrantExtractor()
+    # REVOKE absent from legacy shape.
+    assert ext.extract_grants("REVOKE SELECT ON foo FROM r;") == []
+    # Sequence/schema/function absent from legacy shape.
+    assert ext.extract_grants("GRANT USAGE ON SEQUENCE s.seq TO r;") == []
+    assert ext.extract_grants("GRANT USAGE ON SCHEMA s TO r;") == []
+    # Table grant still works, unchanged shape.
+    assert ext.extract_grants("GRANT SELECT ON s.t TO r;") == [
+        ("s", "t", "r", frozenset({"SELECT"}))
+    ]

--- a/tests/unit/test_issue_162_grant_semantic_cli.py
+++ b/tests/unit/test_issue_162_grant_semantic_cli.py
@@ -1,0 +1,130 @@
+"""CLI tests for the semantic grant gate's actionable output (issue #162).
+
+The failure message must name the specific unmatched grant (object,
+privilege, grantee) and the migration(s) inspected — not the old generic
+".up.sql was not staged" text — and must surface degradation notes.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.models.git import GrantAccompanimentReport
+
+
+@contextmanager
+def _run_with(report: GrantAccompanimentReport, *cli_args: str):
+    """Invoke `migrate validate` with the checker stubbed to return *report*."""
+    with (
+        patch("confiture.cli.git_validation.validate_git_flags_in_repo"),
+        patch("confiture.cli.git_validation.GrantAccompanimentChecker") as mock_cls,
+    ):
+        mock_checker = MagicMock()
+        mock_checker.check_accompaniment.return_value = report
+        mock_cls.return_value = mock_checker
+        yield CliRunner().invoke(
+            app, ["migrate", "validate", "--require-grant-migration", "--staged", *cli_args]
+        )
+
+
+class TestSemanticGrantCli:
+    def test_unmatched_grant_is_named_in_failure(self):
+        report = GrantAccompanimentReport(
+            has_grant_changes=True,
+            has_migration_changes=True,
+            grant_files_changed=[Path("db/7_grant/71_grant.sql")],
+            migration_files_staged=[Path("db/migrations/20260613130000_x.py")],
+            unmatched_grants=[
+                {
+                    "statement": "GRANT SELECT ON some_schema.some_table TO some_role",
+                    "action": "GRANT",
+                    "objtype": "TABLE",
+                    "schema": "some_schema",
+                    "object": "some_table",
+                    "grantee": "some_role",
+                    "privilege": "SELECT",
+                    "changed_in": "db/7_grant/71_grant.sql",
+                    "migrations_inspected": ["db/migrations/20260613130000_x.py"],
+                }
+            ],
+        )
+        with _run_with(report) as result:
+            assert result.exit_code == 1
+            assert "GRANT SELECT ON some_schema.some_table TO some_role" in result.output
+            assert "db/7_grant/71_grant.sql" in result.output
+            assert "20260613130000_x.py" in result.output
+
+    def test_degradation_notes_surfaced(self):
+        report = GrantAccompanimentReport(
+            has_grant_changes=True,
+            has_migration_changes=True,
+            grant_files_changed=[Path("db/7_grant/71_grant.sql")],
+            migration_files_staged=[Path("db/migrations/20260613130000_x.up.sql")],
+            unverifiable_notes=[
+                "db/7_grant/71_grant.sql: EXECUTE format(...) / dynamic SQL (dynamic_sql)"
+            ],
+        )
+        with _run_with(report) as result:
+            # Migration present + only notes → passes (degraded to file-presence).
+            assert result.exit_code == 0
+            assert "dynamic SQL" in result.output
+
+    def test_no_up_sql_only_wording_in_failure(self):
+        report = GrantAccompanimentReport(
+            has_grant_changes=True,
+            has_migration_changes=False,
+            grant_files_changed=[Path("db/7_grant/71_grant.sql")],
+            migration_files_staged=[],
+            unmatched_grants=[
+                {
+                    "statement": "GRANT SELECT ON s.t TO r",
+                    "action": "GRANT",
+                    "objtype": "TABLE",
+                    "schema": "s",
+                    "object": "t",
+                    "grantee": "r",
+                    "privilege": "SELECT",
+                    "changed_in": "db/7_grant/71_grant.sql",
+                    "migrations_inspected": [],
+                }
+            ],
+        )
+        with _run_with(report) as result:
+            assert result.exit_code == 1
+            # The old message claimed only ".up.sql" migrations satisfy the gate.
+            assert "(.up.sql)" not in result.output
+
+    def test_json_envelope_carries_new_keys(self):
+        report = GrantAccompanimentReport(
+            has_grant_changes=True,
+            has_migration_changes=False,
+            grant_files_changed=[Path("db/7_grant/71_grant.sql")],
+            migration_files_staged=[],
+            unmatched_grants=[
+                {
+                    "statement": "GRANT SELECT ON s.t TO r",
+                    "action": "GRANT",
+                    "objtype": "TABLE",
+                    "schema": "s",
+                    "object": "t",
+                    "grantee": "r",
+                    "privilege": "SELECT",
+                    "changed_in": "db/7_grant/71_grant.sql",
+                    "migrations_inspected": [],
+                }
+            ],
+            unverifiable_notes=["a note"],
+        )
+        with _run_with(report, "--format", "json") as result:
+            assert result.exit_code == 1
+            payload = json.loads(result.output)
+            assert payload["status"] == "failed"
+            assert payload["check"] == "grant_accompaniment"
+            assert payload["unmatched_grants"][0]["grantee"] == "r"
+            assert payload["unverifiable_notes"] == ["a note"]


### PR DESCRIPTION
Closes #162.

## Summary

`migrate validate --require-grant-migration` was **file-presence only**: "a grant file changed AND *some* migration is in the changeset." It passed by coincidence and — the literal #162 report — false-positived on every grant change in **Python-migration** projects (it only recognized `.up.sql`).

This makes the gate **semantic**: it verifies that each *changed* `GRANT`/`REVOKE` in the grant directory is actually **carried by an accompanying migration** (SQL **or** Python), and recognizes `.py` migrations everywhere `.up.sql` was recognized.

⚠️ **BREAKING (tightening)** — shipped as **0.30.0**. Bundles what was scoped as 0.29.0 (the `.py` recognition fix) with the semantic engine. Also a **loosening**: a no-op grant edit (comment/whitespace/reorder) now passes without a migration.

## What's in it

- **`.py` migration recognition** — `db/migrations/*.py` counts as an accompanying migration (predicate parity with the canonical loader; `_`-prefixed / `__init__.py` excluded). The literal #162 fix.
- **Semantic matching** — `MigrationGrantExtractor.extract_grant_statements()` → `GrantStatement` keys, covering **GRANT + REVOKE** across **table / schema-wide (`… IN SCHEMA`) / sequence / function** objects, on both backends (pglast primary, regex fallback). `GRANT ALL` and the explicit privilege list compare equal. Legacy `extract_grants()` is **untouched** (the `--check-acls` lint is unaffected).
- **Diff-aware, merge-base-anchored** — only *added/changed* grants are required; the required set diffs against `git merge-base base target` (D10), consistent with three-dot changed-file semantics.
- **Honest degradation, never silent-pass (D7/D9)** — grants that can't be statically represented (dynamic SQL, `ON DATABASE/LANGUAGE/TYPE/DOMAIN/FDW/TABLESPACE`, `ALTER DEFAULT PRIVILEGES`, column-level privileges, `WITH GRANT OPTION`-only deltas, non-public `SET search_path` (D12), removed grants (D8)) fall back to the file-presence check and are surfaced as **notes**.
- **Actionable output** — failure names each unmatched grant (object, privilege, grantee), where it changed, and the migrations inspected; JSON envelope gains `unmatched_grants` + `unverifiable_notes`; new (non-adapter-contract, **D13**) schema `migrate-validate-grant.schema.json`. `grant_dir` is now plumbed from config.
- **ACL lint twin-fix** — `--check-acls` (`Acl001GrantCoverage`) also scans `.py` migrations now (same blind spot).

## Git plumbing

`GitRepository.get_merge_base()` + `get_staged_file_content()`; `get_file_at_ref()` now treats "exists on disk, but not in `<ref>`" as absent-at-ref (`None`) rather than an error. Content reads are `str`-guarded so a missing/None blob degrades instead of crashing.

## Tests / gates

- Full suite **8574 pass / 79 skip**; `ruff check` + `ruff format --check` + `ty check` all clean.
- New: extractor API tests, content-bearing semantic unit tests, a **real-repo integration test** (D10 merge-base + D11 `.py`-at-ref), git-plumbing unit tests, JSON-schema validation, ACL `.py` tests, semantic-CLI tests.
- Adapter contract unaffected (D13 — the grant schema is **not** wired into `tests/contract/`).

See `CHANGELOG.md` `[0.30.0]` for the full tightening **and** loosening notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)