### PR TITLE
chore(release): 0.31.0 — preflight cumulative-success guard (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-06-19
+
+### Added
+
+- **`test_preflight_against_later_pending_sees_earlier_pending`** — regression guard proving that `MigratorSession.run_against()` applies pending migrations **cumulatively**: a later pending migration sees an object created by an earlier pending one. Two inter-dependent migrations (`V1 CREATE TABLE widgets`, `V2 CREATE VIEW v_widgets … FROM widgets`) both report `success=True`, and the outer rollback leaves no trace. This is the missing counterpart to the existing `test_preflight_against_continues_past_failure` (which proves *failure isolation*) — the absence of a *cumulative success* test is what let fraiseql/fraisier#250 be filed against already-correct behaviour. The engine itself is unchanged; this release only closes the coverage gap.
+
 ## [0.30.0] - 2026-06-13
 
 Makes `migrate validate --require-grant-migration` **semantic** (issue #162):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.30.0"
+version = "0.31.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/integration/test_preflight_against.py
+++ b/tests/integration/test_preflight_against.py
@@ -78,6 +78,22 @@ def bad_migrations_dir(tmp_path):
 
 
 @pytest.fixture()
+def interdependent_migrations_dir(tmp_path):
+    """Two inter-dependent migrations: 002 creates a view over 001's table."""
+    (tmp_path / "20260401000001_create_widgets.up.sql").write_text(
+        "CREATE TABLE public.widgets (id BIGINT PRIMARY KEY);"
+    )
+    (tmp_path / "20260401000001_create_widgets.down.sql").write_text("DROP TABLE public.widgets;")
+    (tmp_path / "20260401000002_add_widgets_view.up.sql").write_text(
+        "CREATE OR REPLACE VIEW public.v_widgets AS SELECT id FROM public.widgets;"
+    )
+    (tmp_path / "20260401000002_add_widgets_view.down.sql").write_text(
+        "DROP VIEW public.v_widgets;"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
 def non_transactional_migrations_dir(tmp_path):
     """Two migrations: 001 transactional (CREATE TABLE), 002 non-transactional (Python, CONCURRENTLY)."""
     (tmp_path / "20260401000001_create_foo.up.sql").write_text(
@@ -159,6 +175,39 @@ def test_preflight_against_continues_past_failure(preflight_db, bad_migrations_d
     assert result.migrations[1].error is not None
 
     # Even the passing migrations are rolled back.
+    assert _count_public_tables(preflight_db) == 0
+
+
+@pytest.mark.integration
+def test_preflight_against_later_pending_sees_earlier_pending(
+    preflight_db, interdependent_migrations_dir
+):
+    """A later pending migration sees an earlier pending migration's object.
+
+    Regression guard for issue #250: ``run_against`` applies pending migrations
+    cumulatively (success → ``RELEASE SAVEPOINT`` keeps the DDL within the outer
+    envelope), so ``V2``'s view over ``V1``'s table resolves and both succeed.
+    The complement to ``test_preflight_against_continues_past_failure`` (which
+    proves failure isolation); this one proves cumulative success.
+    """
+    pending = sorted(interdependent_migrations_dir.glob("*.up.sql"))
+
+    session = MigratorSession(
+        config=None,
+        migrations_dir=interdependent_migrations_dir,
+        database_url_override=preflight_db,
+    )
+    with session:
+        result = session.run_against(pending, against_url=preflight_db)
+
+    assert result.all_passed is True
+    assert len(result.migrations) == 2
+    assert result.migrations[0].success is True  # create_widgets
+    assert result.migrations[1].success is True  # add_widgets_view — sees widgets
+    assert all(m.error is None for m in result.migrations)
+    assert result.db_consumed is False
+
+    # Outer rollback left no trace: neither the table nor the view remains.
     assert _count_public_tables(preflight_db) == 0
 
 


### PR DESCRIPTION
## Why

fraiseql/fraisier#250 reports that `migrate preflight --against` gives false positives for inter-dependent pending migrations — hypothesising that each pending migration is evaluated against the *pristine* restored schema inside its own rolled-back savepoint.

That hypothesis is contradicted by the source. `MigratorSession.run_against()` applies pending migrations **cumulatively**: each runs in a per-version savepoint `RELEASE`d on success (kept) and only `ROLLBACK`ed at the very end via the outer `preflight_run` envelope. A later pending migration therefore *does* see an earlier pending one's objects. Verified empirically green on 0.9.4 / 0.18.0 / 0.30.0.

The suite had `test_preflight_against_continues_past_failure` (failure isolation) but **no test that a later pending migration sees an earlier pending one** (cumulative success). That missing test is exactly what let #250 be filed against already-correct behaviour.

## What

- Adds `test_preflight_against_later_pending_sees_earlier_pending`: two inter-dependent migrations (`CREATE TABLE widgets`, then `CREATE VIEW … FROM widgets`) both succeed; outer rollback leaves no trace.
- **No engine change** — coverage only.
- Version bump 0.30.0 → 0.31.0 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)