### PR TITLE
fix: align from_config + SQL-file preflight with `migrate up` (#168, #169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Two consistency fixes found while migrating fraisier to confiture 0.32: the
+public Python API now accepts the same minimal config the CLI does (#168), and
+SQL-file migrations that contain non-transactional statements no longer
+false-positive in preflight (#169). Both align a stricter/divergent path back to
+`migrate up`; no breaking changes.
+
+### Fixed
+
+- **`Migrator.from_config()` accepts a minimal `database_url`-only config (#168).**
+  The documented Python entry point validated through `Environment`, which
+  hard-requires the build-only fields `name`/`include_dirs` — so a config the
+  CLI's `migrate up --config` accepts was rejected by `from_config`. The
+  migrate path never reads those fields (`MigratorSession` uses only
+  `database_url` and `migration.tracking_table`), so `from_config` now defaults
+  them when absent, matching the CLI's lenient loader. A genuinely invalid
+  config (e.g. missing `database_url`) still fails with `CONFIG_002`.
+
+- **SQL-file migrations auto-detect non-transactional statements (#169).** A
+  pure `.up.sql` migration cannot declare `transactional = False`, so one
+  containing `CREATE INDEX CONCURRENTLY` (or `VACUUM`, `REINDEX … CONCURRENTLY`,
+  `ALTER TYPE … ADD VALUE`, …) inherited `transactional = True` and was run
+  inside a SAVEPOINT — failing under both `migrate up` ("cannot run inside a
+  transaction block") and `preflight --against` (an error-severity
+  `PFLIGHT_REPLAY_FAILED`, exit 7, beside the `PFLIGHT_NON_TRANSACTIONAL`
+  warning the static analyzer already emits). `FileSQLMigration` now reflects
+  its `.up.sql` content via the same `MigrationAnalyzer` the static preflight
+  check uses, so such a migration runs in autocommit under `migrate up` and is
+  skipped under `preflight --against` — exactly like a Python migration with
+  `transactional = False`. This restores the 0.9.x preflight-skip semantics
+  while keeping the informative warning. See
+  [transaction-contract.md](docs/reference/transaction-contract.md) §5.
+
 ## [0.32.0] - 2026-06-25
 
 Bounds per-worker clone concurrency adaptively so large templates on an

--- a/docs/reference/transaction-contract.md
+++ b/docs/reference/transaction-contract.md
@@ -126,7 +126,8 @@ END $$;
 
 (Note: `CREATE INDEX CONCURRENTLY` itself cannot run inside any
 transaction; the example is illustrative of the `EXCEPTION` block
-pattern.  Real `CONCURRENTLY` work needs `transactional = False`.)
+pattern.  Real `CONCURRENTLY` work needs `transactional = False` — or, in a
+`.up.sql` file, is auto-detected; see point 5.)
 
 **Implication for authors:** `EXCEPTION WHEN` handlers, including the
 `IF EXISTS` / `IF NOT EXISTS` idioms inside `DO` blocks, are safe under
@@ -162,6 +163,28 @@ class CreateIndexConcurrently(Migration):
         self.execute("CREATE INDEX CONCURRENTLY idx_users_email ON users(email)")
 ```
 
+### SQL-file migrations auto-detect (issue #169)
+
+A pure `.up.sql` migration has no Python class to carry
+`transactional = False`.  Confiture therefore inspects the `.up.sql`
+content (the same `MigrationAnalyzer` the static `preflight` check uses)
+and treats the migration as non-transactional automatically when it
+contains a statement PostgreSQL forbids inside a transaction —
+`CREATE INDEX CONCURRENTLY`, `DROP INDEX CONCURRENTLY`,
+`REINDEX … CONCURRENTLY`, `VACUUM`, `CLUSTER`, `ALTER TYPE … ADD VALUE`,
+`CREATE/DROP DATABASE`.  No declaration is needed (and none is possible):
+
+```sql
+-- 20260528121500_create_index_concurrently.up.sql
+CREATE INDEX CONCURRENTLY idx_users_email ON users (email);
+```
+
+Such a SQL file behaves exactly like a Python migration with
+`transactional = False`: `migrate up` runs it in autocommit, and the
+verification modes below skip it.  (Detection failure degrades to
+transactional — the historical default — so the real error, if any,
+surfaces when the migration executes.)
+
 Non-transactional migrations:
 
 - Are skipped under `--dry-run-execute` (no savepoint envelope can
@@ -187,8 +210,8 @@ migration body.
 |---------------|-----|
 | Group inserts/updates under a sub-rollback | `with self.connection.transaction(): …` |
 | Run `IF EXISTS`-style conditional DDL | `DO $$ … EXCEPTION WHEN … END $$` |
-| Run `CREATE INDEX CONCURRENTLY` | `transactional = False` |
-| Run `VACUUM` / `REINDEX CONCURRENTLY` | `transactional = False` |
+| Run `CREATE INDEX CONCURRENTLY` | `transactional = False` (Python) — auto-detected in a `.up.sql` file |
+| Run `VACUUM` / `REINDEX CONCURRENTLY` | `transactional = False` (Python) — auto-detected in a `.up.sql` file |
 | Test the migration without persisting | `migrate up --dry-run-execute` |
 | Test against a parallel database | `migrate preflight --against <db>` |
 

--- a/python/confiture/core/_migrator/factory.py
+++ b/python/confiture/core/_migrator/factory.py
@@ -50,6 +50,17 @@ def from_config(
             )
         with open(config_path) as f:
             raw: dict[str, Any] = yaml.safe_load(f)
+        # Issue #168: the migrate-only Python entry point must accept the same
+        # minimal ``database_url``-only config the CLI's ``migrate up`` accepts.
+        # The CLI loads a raw dict (``connection.load_config``) and never
+        # validates the build-only fields ``name``/``include_dirs``; those are
+        # never read on the migrate path either (``MigratorSession`` uses only
+        # ``database_url`` and ``migration.tracking_table``).  Default them when
+        # absent so ``from_config`` isn't stricter than the CLI.  A truly
+        # invalid config (e.g. missing ``database_url``) still fails validation.
+        if isinstance(raw, dict):
+            raw.setdefault("name", config_path.stem)
+            raw.setdefault("include_dirs", [])
         try:
             env = Environment.model_validate(raw)
         except Exception as e:

--- a/python/confiture/models/sql_file_migration.py
+++ b/python/confiture/models/sql_file_migration.py
@@ -43,6 +43,30 @@ from confiture.models.migration import Migration
 logger = logging.getLogger(__name__)
 
 
+def _detect_transactional(up_file: Path) -> bool:
+    """Return ``False`` when a SQL migration must run outside a transaction.
+
+    A pure ``.up.sql`` migration has no Python class to carry
+    ``transactional = False``, yet statements such as ``CREATE INDEX
+    CONCURRENTLY``, ``VACUUM``, ``REINDEX … CONCURRENTLY`` and ``ALTER TYPE …
+    ADD VALUE`` are rejected by PostgreSQL inside any transaction block.  This
+    mirrors the static ``preflight`` check (``MigrationAnalyzer`` on the up
+    file) so such a migration runs in autocommit under ``migrate up`` and is
+    skipped under ``preflight --against`` — exactly like a Python migration
+    that declares ``transactional = False`` (issue #169).
+
+    Any read or analysis failure degrades to ``True`` (transactional), the
+    historical default; the real error surfaces when the migration executes.
+    """
+    from confiture.core.migration_analyzer import MigrationAnalyzer
+
+    try:
+        sql = up_file.read_text(encoding="utf-8")
+        return not MigrationAnalyzer().analyze(sql)
+    except Exception:  # noqa: BLE001 — never let detection break migration loading
+        return True
+
+
 class FileSQLMigration(Migration):
     """Migration loaded from .up.sql/.down.sql file pair.
 
@@ -93,6 +117,10 @@ class FileSQLMigration(Migration):
                 "name": parts[1] if len(parts) > 1 else base_name,
                 "up_file": up_file,
                 "down_file": down_file,
+                # Issue #169 — auto-detect non-transactional SQL so the
+                # migration runs in autocommit instead of failing inside a
+                # SAVEPOINT.
+                "transactional": _detect_transactional(up_file),
             },
         )
 
@@ -236,6 +264,11 @@ class FileSQLMigration(Migration):
                 "down_file": down_file,
                 "up_preconditions": up_preconditions,
                 "down_preconditions": down_preconditions,
+                # Issue #169 — a SQL file containing CREATE INDEX CONCURRENTLY,
+                # VACUUM, etc. cannot run inside a transaction; detect that here
+                # (same analyzer as the static preflight check) so `migrate up`
+                # applies it in autocommit and `preflight --against` skips it.
+                "transactional": _detect_transactional(up_file),
                 "__init__": init_method,
                 "up": up_method,
                 "down": down_method,

--- a/tests/integration/test_preflight_against.py
+++ b/tests/integration/test_preflight_against.py
@@ -118,6 +118,27 @@ def non_transactional_migrations_dir(tmp_path):
     return tmp_path
 
 
+@pytest.fixture()
+def sql_non_transactional_migrations_dir(tmp_path):
+    """Issue #169 — a pure SQL-file migration with CREATE INDEX CONCURRENTLY.
+
+    001 creates a table (transactional); 002 is a ``.up.sql`` file whose only
+    statement is non-transactional.  Such a file cannot declare
+    ``transactional = False`` — confiture must auto-detect it.
+    """
+    (tmp_path / "20260401000001_create_foo.up.sql").write_text(
+        "CREATE TABLE foo (id SERIAL PRIMARY KEY, val TEXT);"
+    )
+    (tmp_path / "20260401000001_create_foo.down.sql").write_text("DROP TABLE foo;")
+    (tmp_path / "20260401000002_add_idx.up.sql").write_text(
+        "CREATE INDEX CONCURRENTLY idx_foo_val ON foo (val);"
+    )
+    (tmp_path / "20260401000002_add_idx.down.sql").write_text(
+        "DROP INDEX CONCURRENTLY IF EXISTS idx_foo_val;"
+    )
+    return tmp_path
+
+
 def _count_public_tables(db_url: str) -> int:
     conn = psycopg.connect(db_url)
     try:
@@ -237,6 +258,39 @@ def test_preflight_non_transactional_skipped_by_default(
     assert result.db_consumed is False
 
     # 001 DDL was also rolled back.
+    assert _count_public_tables(preflight_db) == 0
+
+
+@pytest.mark.integration
+def test_preflight_sql_file_concurrently_skipped_by_default(
+    preflight_db, sql_non_transactional_migrations_dir
+):
+    """Issue #169 — a SQL-file CREATE INDEX CONCURRENTLY migration is skipped,
+    not reported as a failed replay.
+
+    Before the fix it inherited ``transactional = True`` and failed to replay
+    inside a SAVEPOINT ("cannot run inside a transaction block"), surfacing an
+    error-severity ``PFLIGHT_REPLAY_FAILED`` and exit 7.
+    """
+    pending = sorted(sql_non_transactional_migrations_dir.glob("*.up.sql"))
+
+    session = MigratorSession(
+        config=None,
+        migrations_dir=sql_non_transactional_migrations_dir,
+        database_url_override=preflight_db,
+    )
+    with session:
+        result = session.run_against(pending, against_url=preflight_db)
+
+    assert len(result.migrations) == 2
+    assert result.migrations[0].success is True  # create_foo (transactional)
+    assert result.migrations[1].skipped is True  # CONCURRENTLY auto-detected
+    assert result.migrations[1].error is None  # not a replay failure
+    assert result.all_passed is True  # skipped is neutral → no exit 7
+    assert result.failures == []
+    assert result.db_consumed is False
+
+    # Outer rollback left no trace.
     assert _count_public_tables(preflight_db) == 0
 
 

--- a/tests/unit/test_issue_169_sql_non_transactional.py
+++ b/tests/unit/test_issue_169_sql_non_transactional.py
@@ -1,0 +1,75 @@
+"""Issue #169 — SQL-file migrations auto-detect non-transactional statements.
+
+A pure ``.up.sql`` migration cannot declare ``transactional = False`` (there is
+no Python class to set the attribute on).  Before this fix such a migration —
+e.g. ``CREATE INDEX CONCURRENTLY`` — inherited ``transactional = True`` and so:
+
+- ``migrate up`` ran it inside a SAVEPOINT and PostgreSQL rejected it
+  ("cannot run inside a transaction block");
+- ``preflight --against`` replayed it inside a SAVEPOINT, failed, and reported
+  an error-severity ``PFLIGHT_REPLAY_FAILED`` (exit 7) — a false positive next
+  to the ``PFLIGHT_NON_TRANSACTIONAL`` warning the static analyzer already
+  emits for the same migration.
+
+``FileSQLMigration`` now reflects its ``.up.sql`` content via the same
+``MigrationAnalyzer`` the static preflight check uses, so a non-transactional
+SQL file runs in autocommit (``migrate up``) and is skipped (``preflight``),
+exactly like a Python migration with ``transactional = False``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from confiture.models.sql_file_migration import FileSQLMigration
+
+
+def _make(tmp_path, up_sql: str, down_sql: str = "SELECT 1;"):
+    up_file = tmp_path / "20260101000000_example.up.sql"
+    down_file = tmp_path / "20260101000000_example.down.sql"
+    up_file.write_text(up_sql)
+    down_file.write_text(down_sql)
+    return FileSQLMigration.from_files(up_file, down_file)
+
+
+class TestFromFilesTransactionalDetection:
+    def test_create_index_concurrently_is_non_transactional(self, tmp_path):
+        cls = _make(tmp_path, "CREATE INDEX CONCURRENTLY idx_x ON some_table (col);")
+        assert cls.transactional is False
+
+    def test_plain_ddl_stays_transactional(self, tmp_path):
+        cls = _make(tmp_path, "CREATE TABLE foo (id INT);")
+        assert cls.transactional is True
+
+    def test_vacuum_is_non_transactional(self, tmp_path):
+        cls = _make(tmp_path, "VACUUM some_table;")
+        assert cls.transactional is False
+
+    def test_alter_type_add_value_is_non_transactional(self, tmp_path):
+        cls = _make(tmp_path, "ALTER TYPE my_enum ADD VALUE 'extra';")
+        assert cls.transactional is False
+
+    @pytest.mark.parametrize("attr", ["transactional"])
+    def test_attribute_is_class_level(self, tmp_path, attr):
+        """The flag is set on the class, so apply/run_against can read it
+        without instantiating against a live connection first."""
+        cls = _make(tmp_path, "CREATE INDEX CONCURRENTLY idx_x ON t (c);")
+        assert getattr(cls, attr) is False
+        migration = cls(connection=MagicMock())
+        assert getattr(migration, attr) is False
+
+
+class TestDirectConstructorDetection:
+    """The direct ``FileSQLMigration(conn, up, down)`` path (not used by the
+    loader, but public) must agree with ``from_files``."""
+
+    def test_direct_init_detects_non_transactional(self, tmp_path):
+        up_file = tmp_path / "20260101000000_example.up.sql"
+        down_file = tmp_path / "20260101000000_example.down.sql"
+        up_file.write_text("CREATE INDEX CONCURRENTLY idx_x ON t (c);")
+        down_file.write_text("DROP INDEX CONCURRENTLY IF EXISTS idx_x;")
+
+        migration = FileSQLMigration(MagicMock(), up_file, down_file)
+        assert migration.transactional is False

--- a/tests/unit/test_migrator_from_config.py
+++ b/tests/unit/test_migrator_from_config.py
@@ -126,6 +126,43 @@ class TestMigratorFromConfig:
                 assert isinstance(m, MigratorSession)
             mock_conn.close.assert_called_once()
 
+    def test_from_config_accepts_database_url_only_config(self, tmp_path):
+        """Issue #168: the migrate-only Python API must accept the same minimal
+        ``database_url``-only config the CLI's ``migrate up`` accepts.
+
+        The build-only fields ``name``/``include_dirs`` are never read on the
+        migrate path (``MigratorSession`` uses only ``database_url`` and
+        ``migration.tracking_table``), so ``from_config`` must not require them.
+        """
+        config_file = tmp_path / "min.yaml"
+        config_file.write_text("database_url: postgresql://localhost/db\n")
+        mock_conn = MagicMock()
+        with patch("confiture.core.migrator.create_connection", return_value=mock_conn):
+            session = Migrator.from_config(config_file)
+            assert isinstance(session, MigratorSession)
+            # The session is usable: defaults didn't leak into the migrate path.
+            with session as m:
+                assert callable(m.up)
+
+    def test_from_config_database_url_only_uses_default_tracking_table(self, tmp_path):
+        """A minimal config still resolves the default tracking table."""
+        config_file = tmp_path / "min.yaml"
+        config_file.write_text("database_url: postgresql://localhost/db\n")
+        mock_conn = MagicMock()
+        with patch("confiture.core.migrator.create_connection", return_value=mock_conn):
+            with Migrator.from_config(config_file) as m:
+                assert m._migrator.migration_table == "tb_confiture"
+
+    def test_from_config_still_rejects_missing_database_url(self, tmp_path):
+        """A config without database_url is genuinely invalid and must fail."""
+        from confiture.exceptions import ConfigurationError
+
+        config_file = tmp_path / "empty.yaml"
+        config_file.write_text("name: test\n")
+        with pytest.raises(ConfigurationError) as exc_info:
+            Migrator.from_config(config_file)
+        assert exc_info.value.error_code == "CONFIG_002"
+
     def test_from_config_nonexistent_file_raises(self):
         from confiture.exceptions import ConfigurationError
 


### PR DESCRIPTION
Two consistency fixes found while migrating fraisier to confiture 0.32 — each realigns a stricter/divergent path back to what `migrate up` does. No breaking changes.

## #168 — `Migrator.from_config()` rejected a minimal `database_url`-only config the CLI accepts
The documented Python entry point validated through `Environment`, which hard-requires the **build-only** fields `name`/`include_dirs`. The CLI's `migrate up --config` instead uses the lenient raw-dict loader (`connection.load_config`) and never needs them — and the migrate path never reads them (`MigratorSession` uses only `database_url` + `migration.tracking_table`).

**Fix:** `factory.from_config` defaults `name`/`include_dirs` when absent, matching the CLI. A genuinely invalid config (e.g. missing `database_url`) still fails `CONFIG_002`.

## #169 — preflight false-positives on non-transactional SQL-file migrations
A pure `.up.sql` migration cannot declare `transactional = False`, so one containing `CREATE INDEX CONCURRENTLY` (or `VACUUM`, `REINDEX … CONCURRENTLY`, `ALTER TYPE … ADD VALUE`, …) inherited `transactional = True` and ran inside a SAVEPOINT — failing under **both** `migrate up` ("cannot run inside a transaction block") **and** `preflight --against` (error-severity `PFLIGHT_REPLAY_FAILED`, exit 7, beside the `PFLIGHT_NON_TRANSACTIONAL` warning the static analyzer already emits).

> Note: the issue's premise that "`migrate up` runs it fine" was empirically false for SQL files — verified against local PostgreSQL, `migrate up` failed on the same file. The real gap was that SQL-file migrations had no way to be non-transactional. Hence the auto-detect fix (rather than a preflight-only downgrade, which would have let preflight green-light a deploy that `migrate up` then breaks).

**Fix:** `FileSQLMigration` now reflects its `.up.sql` content via the same `MigrationAnalyzer` the static preflight check uses, so the migration runs in autocommit under `migrate up` and is **skipped** under `preflight --against` — exactly like a Python migration with `transactional = False`. Restores the 0.9.x preflight-skip semantics while keeping the informative warning.

## Verification
- Full suite: **8639 passed, 79 skipped**; `ruff` + `ty` clean.
- New tests: 6 unit (#169 detection) + 3 unit (#168) + 1 integration (SQL `CONCURRENTLY` skipped, DB untouched).
- Reproduced both bugs and confirmed the fixes end-to-end against local PostgreSQL.
- Docs: `transaction-contract.md` §5 documents SQL-file auto-detection; `CHANGELOG.md` `[Unreleased]`.

Closes #168
Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)