### PR TITLE
fix(restore): defer matview REFRESH past ANALYZE (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`confiture restore` defers materialized-view refreshes until after `ANALYZE`
+  (#172).** A logical dump carries no planner statistics, so a freshly loaded
+  database starts with empty `pg_statistic`. Previously the matview `REFRESH`
+  bundled into the archive ran during the restore with those empty stats, and a
+  stats-sensitive matview (self-joins + window functions over a resolved view)
+  could replan into a catastrophic nested loop — a ~5-second refresh becoming
+  tens of minutes to hours, blowing deploy timeouts and wedging the restore.
+  `DatabaseRestorer` now lists the archive TOC (`pg_restore -l`), holds every
+  `MATERIALIZED VIEW DATA` item out of **all** restore phases (they land in the
+  data *or* post-data section depending on the pg_dump version, so a whole-restore
+  `-L` filter is the version-robust exclusion), runs a database-wide `ANALYZE`,
+  then refreshes the matviews serially on real statistics. Backups without
+  materialized views take the classic three-phase path with byte-for-byte
+  unchanged `pg_restore` invocations. `RestoreResult` gains `matviews_deferred`,
+  `matviews_refreshed`, and `analyze_ran`.
+
+### Added
+
+- **`confiture restore --no-refresh-matviews`.** Restores materialized views
+  `WITH NO DATA` (excluded from every phase, no `ANALYZE`/refresh), leaving them
+  for the caller to refresh on their own schedule. See the new
+  [restore guide](docs/guides/restore.md).
+
+### Changed
+
+- **`confiture restore` default behavior change** (pre-1.0): a backup containing
+  materialized views now restores through the deferred `ANALYZE` + refresh path
+  by default instead of refreshing inline. Use `--no-refresh-matviews` for the
+  fast, leave-them-empty behavior. Restores of matview-free backups are
+  unaffected. `ANALYZE` runs via `psql`, so PostgreSQL client tools must be on
+  `PATH` (they already are for `pg_restore`).
+
 ## [0.34.0] - 2026-06-25
 
 Completes the 0.33.0 #168 fix at the model layer so every Python-API consumer —

--- a/docs/guides/restore.md
+++ b/docs/guides/restore.md
@@ -1,0 +1,95 @@
+# Restoring a backup with `confiture restore`
+
+`confiture restore` restores a PostgreSQL `pg_dump` archive using a **three-phase
+`pg_restore`** that avoids the foreign-key race conditions a naive parallel
+restore hits, and defers materialized-view refreshes until after `ANALYZE` so
+they never replan on empty statistics.
+
+It requires a **custom-format (`-Fc`)** or **directory-format (`-Fd`)** archive —
+the `--section` machinery it relies on does not work on plain-text SQL dumps.
+
+```bash
+pg_dump -Fc mydb > backup.pgdump
+
+confiture restore backup.pgdump --database staging --jobs 4
+```
+
+## The phases
+
+| Phase | Parallel | What runs |
+|-------|----------|-----------|
+| `pre-data`  | no  | Schema DDL, types, sequences, matview *definitions* (`WITH NO DATA`) |
+| `data`      | `--jobs` | Table rows (no FK constraints exist yet, so parallel is safe) |
+| `post-data` | no  | Indexes, primary keys, FK constraints |
+
+When the archive contains **materialized views**, two more serial steps run:
+
+| Phase | What runs |
+|-------|-----------|
+| `analyze` | A database-wide `ANALYZE`, so the just-loaded tables have planner statistics |
+| `refresh-matviews` | `REFRESH MATERIALIZED VIEW` for every deferred matview — now on real stats |
+
+### Why matviews are deferred
+
+A logical dump never carries planner statistics (`pg_statistic` is not dumped), so
+a freshly loaded database starts with **empty stats**. A stats-sensitive matview
+(self-joins, window functions, date-segmented views) that refreshes against empty
+stats can replan into a catastrophic nested loop — turning a ~5-second refresh
+into **tens of minutes to hours**, which then blows past deploy timeouts and can
+wedge the whole restore.
+
+`pg_restore` on its own cannot fix this: it never runs `ANALYZE`, and the matview
+`REFRESH` is bundled into the archive's data/post-data phases. `confiture restore`
+solves it by holding the matview refreshes out of **every** restore phase, running
+`ANALYZE`, and only then refreshing — so each refresh sees real statistics.
+
+This is the default. Backups **without** materialized views take the classic
+three-phase path unchanged.
+
+## Deferring the refresh to your own schedule
+
+If you would rather restore fast and refresh the matviews later (for example, to
+bring an environment online quickly and warm the matviews out of band):
+
+```bash
+confiture restore backup.pgdump --database staging --no-refresh-matviews
+```
+
+The matviews are restored **`WITH NO DATA`** (unpopulated). Refresh them yourself
+once statistics exist:
+
+```sql
+ANALYZE;
+REFRESH MATERIALIZED VIEW mv_one;
+REFRESH MATERIALIZED VIEW mv_two;
+```
+
+Querying an unpopulated matview raises
+`materialized view "…" has not been populated` until you refresh it.
+
+## Options
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--database`, `-d` | *(required)* | Target database name |
+| `--jobs`, `-j` | `4` | Parallel workers for the data phase |
+| `--refresh-matviews` / `--no-refresh-matviews` | refresh | Refresh matviews after `ANALYZE`, or leave them empty |
+| `--no-owner` / `--owner` | owner | Skip object ownership restoration |
+| `--no-acl` / `--acl` | acl | Skip access-privilege restoration |
+| `--exit-on-error` / `--no-exit-on-error` | exit-on-error | Abort on the first error |
+| `--min-tables` | `0` | Post-restore: fail unless at least N tables exist |
+| `--superuser` | *(none)* | Run `pg_restore`/`psql` via `sudo -u <user>` |
+
+## Backup-side alternative
+
+If you maintain the backups yourself, you can also keep a stats-sensitive matview
+out of the archive entirely and refresh it after restore:
+
+```bash
+pg_dump -Fc --exclude-table-data=public.mv_maintenance_price mydb > backup.pgdump
+```
+
+The matview then restores `WITH NO DATA` regardless of the restore flags; run
+`ANALYZE` and `REFRESH MATERIALIZED VIEW` afterwards. `confiture restore`'s default
+deferral makes this unnecessary, but it is a useful belt-and-braces option when a
+single matview dominates restore time.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -294,7 +294,7 @@ cached CI provisioning:
 | `--dump-format custom\|directory` | `custom` = `-Fc` (default), `directory` = `-Fd` (parallel dump). |
 | `--seed-profile <name>` | Apply only the named seed profile (see `seed.profiles`) during `--sequential` seed application and `--dump`. |
 
-The artifact is restorable by [`confiture restore`](#confiture-restore). See the
+The artifact is restorable by [`confiture restore`](../guides/restore.md). See the
 [Parallel CI provisioning guide](../guides/parallel-ci-provisioning.md).
 
 ---

--- a/python/confiture/cli/commands/admin.py
+++ b/python/confiture/cli/commands/admin.py
@@ -474,12 +474,27 @@ def restore(
         "--superuser",
         help="Run pg_restore via sudo as this OS user",
     ),
+    refresh_matviews: bool = typer.Option(
+        True,
+        "--refresh-matviews/--no-refresh-matviews",
+        help=(
+            "Refresh materialized views after a database-wide ANALYZE (default). "
+            "--no-refresh-matviews leaves them WITH NO DATA for you to refresh later."
+        ),
+    ),
 ) -> None:
     """Restore a PostgreSQL backup using three-phase pg_restore.
 
     Prevents FK constraint race conditions during parallel restore by running
     pre-data and post-data phases serially, parallelising only the data phase
     (where no FK constraints exist yet).
+
+    When the backup contains materialized views, their REFRESH is deferred out of
+    the parallel data phase: base tables load first, then a database-wide ANALYZE
+    runs, then the matviews are refreshed serially — so every refresh replans on
+    real statistics instead of the empty stats of a freshly loaded database (which
+    can turn a fast refresh into a multi-hour nested loop). Use
+    --no-refresh-matviews to leave them empty and refresh on your own schedule.
 
     Requires custom format (-Fc) or directory format (-Fd) dumps. To create one:
 
@@ -492,6 +507,8 @@ def restore(
       confiture restore prod.pgdump --database staging --jobs 8 --min-tables 300
 
       confiture restore /backups/dump --database staging --superuser postgres
+
+      confiture restore prod.pgdump --database staging --no-refresh-matviews
     """
     from confiture.core.restorer import DatabaseRestorer, RestoreOptions
     from confiture.exceptions import RestoreError
@@ -518,6 +535,7 @@ def restore(
         superuser=superuser,
         min_tables=min_tables,
         min_tables_schema=min_tables_schema,
+        no_refresh_matviews=not refresh_matviews,
     )
 
     console.print(
@@ -540,6 +558,16 @@ def restore(
 
     if result.success:
         console.print(f"[green]✓ Restore complete[/green] ({len(result.phases_completed)} phases)")
+        if result.matviews_deferred:
+            if result.matviews_refreshed:
+                console.print(
+                    f"  Materialized views: {result.matviews_refreshed} refreshed after ANALYZE"
+                )
+            else:
+                console.print(
+                    f"  Materialized views: {result.matviews_deferred} left WITH NO DATA "
+                    "(not refreshed) — refresh them after ANALYZE on your own schedule"
+                )
         if result.table_count is not None:
             console.print(f"  Tables verified: {result.table_count} (≥ {min_tables} required)")
     else:

--- a/python/confiture/core/restorer.py
+++ b/python/confiture/core/restorer.py
@@ -9,9 +9,12 @@ Requires custom format (-Fc) or directory format (-Fd) dumps.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import logging
+import re
 import subprocess
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -23,6 +26,49 @@ from confiture.exceptions import RestoreError
 _log = logging.getLogger(__name__)
 
 _PGDUMP_MAGIC = b"PGDMP"
+
+# A `pg_restore -l` entry line: "<dumpId>; <catalogId> <oid> <desc> <schema> <name> <owner>".
+# We only need the leading dump id and the description that follows the oid.
+_TOC_LINE_RE = re.compile(r"^(?P<dump_id>\d+);\s+\d+\s+\d+\s+(?P<rest>.+)$")
+
+# pg_restore object descriptions that contain spaces, longest first so that
+# "MATERIALIZED VIEW DATA" is matched before the "MATERIALIZED VIEW" definition.
+_MULTIWORD_DESCS = (
+    "MATERIALIZED VIEW DATA",
+    "MATERIALIZED VIEW",
+    "TABLE DATA",
+    "FK CONSTRAINT",
+    "SEQUENCE OWNED BY",
+    "SEQUENCE SET",
+    "DEFAULT ACL",
+    "PUBLICATION TABLE",
+    "ROW SECURITY",
+)
+
+_MATVIEW_DATA_DESC = "MATERIALIZED VIEW DATA"
+
+
+@dataclass(frozen=True)
+class TocEntry:
+    """A single entry from a ``pg_restore -l`` table-of-contents listing.
+
+    Attributes:
+        dump_id: The numeric dump id at the start of the line. This is the token
+            ``pg_restore -L`` uses to select an entry.
+        description: The object description, e.g. ``"TABLE DATA"`` or
+            ``"MATERIALIZED VIEW DATA"``.
+        raw_line: The original ``-l`` line, preserved verbatim so it can be
+            written back into a ``-L`` use-list unchanged.
+    """
+
+    dump_id: int
+    description: str
+    raw_line: str
+
+    @property
+    def is_matview_data(self) -> bool:
+        """True if this entry is a ``REFRESH MATERIALIZED VIEW`` (matview data)."""
+        return self.description == _MATVIEW_DATA_DESC
 
 
 @dataclass
@@ -75,6 +121,18 @@ class RestoreOptions:
     Note: even with ``parallel_restore=True``, ``exit_on_error=False`` is set
     on :class:`RestoreOptions`; the original options object is **not** mutated.
     """
+    no_refresh_matviews: bool = False
+    """When ``True``, materialized-view refreshes are excluded from the restore
+    entirely: their data is filtered out of every restore phase and the deferred
+    ANALYZE + refresh step is skipped, leaving every matview ``WITH NO DATA`` for
+    the caller to refresh on their own schedule.
+
+    When ``False`` (default), a backup containing materialized views is restored
+    with the refresh **deferred**: base tables load first, then a database-wide
+    ``ANALYZE`` runs, then the matviews are refreshed serially — so every refresh
+    replans on real statistics instead of the empty ``pg_statistic`` of a freshly
+    loaded database.
+    """
 
 
 @dataclass
@@ -91,6 +149,14 @@ class RestoreResult:
         diagnostics: Actionable hints emitted when known error patterns are
             detected.  Currently populated after the post-data phase when
             ``"out of shared memory"`` is found in errors or warnings.
+        matviews_deferred: Number of materialized-view refreshes held out of the
+            restore phases and deferred past ANALYZE. None when the backup
+            contains no matviews (the phase structure is unchanged in that case).
+        matviews_refreshed: Number of deferred matviews actually refreshed after
+            ANALYZE. 0 when ``no_refresh_matviews`` left them empty; None when no
+            matviews were present.
+        analyze_ran: True if the post-load ANALYZE step ran (only when matviews
+            were deferred and refresh was not suppressed).
     """
 
     success: bool
@@ -99,6 +165,9 @@ class RestoreResult:
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     diagnostics: list[str] = field(default_factory=list)
+    matviews_deferred: int | None = None
+    matviews_refreshed: int | None = None
+    analyze_ran: bool = False
 
 
 class DatabaseRestorer:
@@ -133,12 +202,24 @@ class DatabaseRestorer:
         options: RestoreOptions,
         on_stderr_line: Callable[[str], None] | None = None,
     ) -> RestoreResult:
-        """Run the three-phase restore.
+        """Run the three-phase restore, deferring matview refreshes past ANALYZE.
 
         Phases:
             1. pre-data (serial) — DDL, sequences, types
             2. data (parallel)   — table rows; no FK constraints exist yet
             3. post-data (serial) — indexes, FK constraints
+
+        When the archive contains materialized-view data, the ``REFRESH`` is
+        deferred out of the parallel data phase (which otherwise refreshes on the
+        empty statistics of a freshly loaded database, risking catastrophic query
+        plans) and run after two extra serial steps:
+
+            4. analyze (serial)  — database-wide ANALYZE so stats exist
+            5. refresh-matviews (serial) — REFRESH MATERIALIZED VIEW on real stats
+
+        Backups without matviews take the classic three-phase path unchanged.
+        ``options.no_refresh_matviews`` keeps matviews out of the data phase and
+        skips steps 4–5, leaving them ``WITH NO DATA``.
 
         Args:
             options: Restore configuration.
@@ -164,33 +245,83 @@ class DatabaseRestorer:
             )
             options = dataclasses.replace(options, exit_on_error=False)
 
+        non_matview, matview_data = self._partition_entries(self._list_toc(options))
+        defer = bool(matview_data)
+
         all_warnings: list[str] = []
         phases_done: list[str] = []
         post_data_result: RestoreResult | None = None
+        analyze_ran = False
+        matviews_refreshed = 0
 
-        for section, parallel in [
-            ("pre-data", False),
-            ("data", True),
-            ("post-data", False),
-        ]:
-            result = self._run_section(section, options, parallel, on_stderr_line)
-            all_warnings.extend(result.warnings)
-            if section == "post-data":
-                post_data_result = result
-            if not result.success:
-                diagnostics = (
-                    self._diagnose_post_data_errors(result.errors + result.warnings)
-                    if section == "post-data"
-                    else []
+        with contextlib.ExitStack() as stack:
+            tables_list, matviews_list = self._prepare_use_lists(stack, non_matview, matview_data)
+
+            # Steps 1-3: classic pre-data → data → post-data. When deferring,
+            # ``tables_list`` excludes the matview-data (REFRESH) items from every
+            # phase — pg_dump files them under data or post-data depending on its
+            # version, so a whole-restore ``-L`` filter is the version-robust way
+            # to keep the refresh out until stats exist. ``tables_list`` is None on
+            # the no-matview fast path, leaving the argv byte-for-byte unchanged.
+            for section, parallel in [
+                ("pre-data", False),
+                ("data", True),
+                ("post-data", False),
+            ]:
+                result = self._run_section(
+                    section, options, parallel, on_stderr_line, use_list=tables_list
                 )
-                return RestoreResult(
-                    success=False,
-                    phases_completed=phases_done,
-                    errors=result.errors,
-                    warnings=all_warnings,
-                    diagnostics=diagnostics,
+                all_warnings.extend(result.warnings)
+                if section == "post-data":
+                    post_data_result = result
+                if not result.success:
+                    diagnostics = (
+                        self._diagnose_post_data_errors(result.errors + result.warnings)
+                        if section == "post-data"
+                        else []
+                    )
+                    return RestoreResult(
+                        success=False,
+                        phases_completed=phases_done,
+                        errors=result.errors,
+                        warnings=all_warnings,
+                        diagnostics=diagnostics,
+                        matviews_deferred=len(matview_data) if defer else None,
+                    )
+                phases_done.extend(result.phases_completed)
+
+            # Steps 4-5: ANALYZE, then refresh the deferred matviews on real stats.
+            # The refresh runs with no ``--section`` so it restores exactly the
+            # matview-data items regardless of which section pg_dump assigned them.
+            if defer and not options.no_refresh_matviews:
+                analyze = self._run_analyze(options, on_stderr_line)
+                all_warnings.extend(analyze.warnings)
+                if not analyze.success:
+                    return RestoreResult(
+                        success=False,
+                        phases_completed=phases_done,
+                        errors=analyze.errors,
+                        warnings=all_warnings,
+                        matviews_deferred=len(matview_data),
+                    )
+                analyze_ran = True
+                phases_done.extend(analyze.phases_completed)
+
+                refresh = self._run_section(
+                    None, options, False, on_stderr_line, use_list=matviews_list
                 )
-            phases_done.extend(result.phases_completed)
+                all_warnings.extend(refresh.warnings)
+                if not refresh.success:
+                    return RestoreResult(
+                        success=False,
+                        phases_completed=phases_done,
+                        errors=refresh.errors,
+                        warnings=all_warnings,
+                        matviews_deferred=len(matview_data),
+                        analyze_ran=analyze_ran,
+                    )
+                phases_done.append("refresh-matviews")
+                matviews_refreshed = len(matview_data)
 
         # Collect diagnostics from post-data phase (success or not)
         post_data_lines = (
@@ -199,6 +330,9 @@ class DatabaseRestorer:
             else []
         )
         diagnostics = self._diagnose_post_data_errors(post_data_lines)
+
+        deferred_count = len(matview_data) if defer else None
+        refreshed_count = matviews_refreshed if defer else None
 
         # Optional post-restore table count check
         if options.min_tables > 0:
@@ -210,6 +344,9 @@ class DatabaseRestorer:
                 errors=check.errors,
                 warnings=all_warnings,
                 diagnostics=diagnostics,
+                matviews_deferred=deferred_count,
+                matviews_refreshed=refreshed_count,
+                analyze_ran=analyze_ran,
             )
 
         return RestoreResult(
@@ -217,6 +354,9 @@ class DatabaseRestorer:
             phases_completed=phases_done,
             warnings=all_warnings,
             diagnostics=diagnostics,
+            matviews_deferred=deferred_count,
+            matviews_refreshed=refreshed_count,
+            analyze_ran=analyze_ran,
         )
 
     # ------------------------------------------------------------------
@@ -272,13 +412,119 @@ class DatabaseRestorer:
             "confiture restore requires custom format (-Fc) or directory format (-Fd)."
         )
 
-    def _build_command(self, section: str, options: RestoreOptions, parallel: bool) -> list[str]:
+    def _list_toc(self, options: RestoreOptions) -> list[TocEntry]:
+        """List the archive's table of contents via ``pg_restore -l``.
+
+        ``pg_restore -l`` reads the archive only (no database connection), so it
+        needs neither host/port nor a target database — but it honours the same
+        ``sudo -u superuser`` prefix in case the archive is only readable by that
+        user.
+
+        Args:
+            options: Restore configuration (for the backup path and superuser).
+
+        Returns:
+            Parsed TOC entries, or ``[]`` if the archive lists no elements.
+
+        Raises:
+            RestoreError: If pg_restore is not found or the listing fails.
+        """
+        cmd: list[str] = []
+        if options.superuser:
+            cmd += ["sudo", "-u", options.superuser]
+        cmd += ["pg_restore", "-l", str(options.backup_path)]
+
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        except FileNotFoundError as e:
+            raise RestoreError(
+                "pg_restore not found. Ensure PostgreSQL client tools are installed and on PATH."
+            ) from e
+
+        if proc.returncode != 0:
+            raise RestoreError(
+                f"pg_restore -l failed for {options.backup_path}: {proc.stderr.strip()}"
+            )
+        return self._parse_toc_lines(proc.stdout.splitlines())
+
+    def _prepare_use_lists(
+        self,
+        stack: contextlib.ExitStack,
+        non_matview: list[TocEntry],
+        matview_data: list[TocEntry],
+    ) -> tuple[Path | None, Path | None]:
+        """Materialize the ``-L`` use-lists for a deferred-matview restore.
+
+        Returns ``(None, None)`` when there is no matview data (the classic
+        three-phase path, argv unchanged). Otherwise writes ``tables.list`` (data
+        phase, matview refreshes excluded) and ``matviews.list`` (refresh phase)
+        into a temporary directory registered on ``stack`` for cleanup.
+
+        Args:
+            stack: ExitStack owning the temp directory's lifetime.
+            non_matview: Every non-matview-data TOC entry.
+            matview_data: The matview-data (REFRESH) TOC entries.
+
+        Returns:
+            ``(tables_list, matviews_list)`` paths, or ``(None, None)``.
+        """
+        if not matview_data:
+            return None, None
+        base = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="confiture-restore-")))
+        tables_list = base / "tables.list"
+        matviews_list = base / "matviews.list"
+        self._write_use_list(non_matview, tables_list)
+        self._write_use_list(matview_data, matviews_list)
+        return tables_list, matviews_list
+
+    @staticmethod
+    def _partition_entries(
+        entries: list[TocEntry],
+    ) -> tuple[list[TocEntry], list[TocEntry]]:
+        """Split TOC entries into (everything-else, matview-data).
+
+        The first list drives the parallel data phase (table data, minus matview
+        refreshes); the second drives the deferred serial refresh phase.
+
+        Args:
+            entries: Parsed TOC entries.
+
+        Returns:
+            A ``(non_matview, matview_data)`` tuple.
+        """
+        matview_data = [e for e in entries if e.is_matview_data]
+        non_matview = [e for e in entries if not e.is_matview_data]
+        return non_matview, matview_data
+
+    @staticmethod
+    def _write_use_list(entries: list[TocEntry], path: Path) -> None:
+        """Write a ``pg_restore -L`` use-list of the given entries' raw lines.
+
+        Args:
+            entries: Entries to include (their verbatim ``-l`` lines are written).
+            path: Destination file path.
+        """
+        path.write_text("\n".join(e.raw_line for e in entries) + "\n")
+
+    def _build_command(
+        self,
+        section: str | None,
+        options: RestoreOptions,
+        parallel: bool,
+        use_list: Path | None = None,
+    ) -> list[str]:
         """Construct the pg_restore argument list for a single section.
 
         Args:
-            section: One of ``"pre-data"``, ``"data"``, or ``"post-data"``.
+            section: One of ``"pre-data"``, ``"data"``, or ``"post-data"``, or
+                ``None`` to omit ``--section`` entirely (used for the deferred
+                matview refresh, whose TOC items may be data or post-data
+                depending on the pg_dump version — a ``-L`` list plus no section
+                filter restores exactly the listed items in either case).
             options: Restore configuration.
             parallel: Whether to enable parallel workers for this phase.
+            use_list: Optional ``pg_restore -L`` use-list restricting the restore
+                to the listed archive elements (used to defer matview refreshes).
 
         Returns:
             Full argv list (including optional ``sudo -u`` prefix).
@@ -294,8 +540,9 @@ class DatabaseRestorer:
             str(options.port),
             "-d",
             options.target_db,
-            f"--section={section}",
         ]
+        if section is not None:
+            cmd.append(f"--section={section}")
         if options.username:
             cmd += ["-U", options.username]
         if options.exit_on_error:
@@ -306,8 +553,94 @@ class DatabaseRestorer:
             cmd.append("--no-acl")
         if parallel and options.jobs > 1:
             cmd += ["-j", str(options.jobs)]
+        if use_list is not None:
+            cmd += ["-L", str(use_list)]
         cmd.append(str(options.backup_path))
         return cmd
+
+    def _build_analyze_command(self, options: RestoreOptions) -> list[str]:
+        """Construct the ``psql`` argument list for the post-load ANALYZE.
+
+        ANALYZE is run through ``psql`` (not psycopg) so it reuses the exact
+        ``sudo -u superuser`` and connection flags as pg_restore — a whole-DB
+        ANALYZE by a role that does not own the tables silently skips them, which
+        would leave the deferred matview refresh running on empty statistics.
+
+        Args:
+            options: Restore configuration.
+
+        Returns:
+            Full argv list (including optional ``sudo -u`` prefix).
+        """
+        cmd: list[str] = []
+        if options.superuser:
+            cmd += ["sudo", "-u", options.superuser]
+        cmd += [
+            "psql",
+            "-h",
+            options.host,
+            "-p",
+            str(options.port),
+            "-d",
+            options.target_db,
+        ]
+        if options.username:
+            cmd += ["-U", options.username]
+        cmd += ["-v", "ON_ERROR_STOP=1", "-c", "ANALYZE"]
+        return cmd
+
+    def _run_analyze(
+        self,
+        options: RestoreOptions,
+        on_stderr_line: Callable[[str], None] | None = None,
+    ) -> RestoreResult:
+        """Run a database-wide ANALYZE so deferred matview refreshes see stats.
+
+        Args:
+            options: Restore configuration.
+            on_stderr_line: Optional callback for every psql stderr line.
+
+        Returns:
+            :class:`RestoreResult` with ``phases_completed=["analyze"]`` on
+            success, or ``success=False`` with the captured error lines.
+
+        Raises:
+            RestoreError: If psql is not found or the process is interrupted.
+        """
+        cmd = self._build_analyze_command(options)
+        errors: list[str] = []
+
+        try:
+            with subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            ) as proc:
+                try:
+                    assert proc.stderr is not None
+                    for raw in proc.stderr:
+                        line = raw.rstrip()
+                        if on_stderr_line:
+                            on_stderr_line(line)
+                        if "ERROR:" in line or "psql: error" in line:
+                            errors.append(line)
+                    returncode = proc.wait()
+                except KeyboardInterrupt:
+                    proc.kill()
+                    raise RestoreError("ANALYZE phase interrupted by user") from None
+        except FileNotFoundError as e:
+            raise RestoreError(
+                "psql not found. Ensure PostgreSQL client tools are installed and on PATH."
+            ) from e
+
+        if returncode != 0:
+            return RestoreResult(
+                success=False,
+                phases_completed=[],
+                errors=errors or [f"psql ANALYZE exited with code {returncode}"],
+            )
+        return RestoreResult(success=True, phases_completed=["analyze"])
 
     @staticmethod
     def _diagnose_post_data_errors(lines: list[str]) -> list[str]:
@@ -330,6 +663,44 @@ class DatabaseRestorer:
         return hints
 
     @staticmethod
+    def _parse_toc_lines(lines: list[str]) -> list[TocEntry]:
+        """Parse ``pg_restore -l`` output into structured TOC entries.
+
+        Comment lines (starting with ``;``) and blank lines are skipped. Each
+        remaining line is parsed for its dump id and object description; the
+        original line is preserved for round-tripping into a ``-L`` use-list.
+
+        Args:
+            lines: Lines from ``pg_restore -l`` (already split, newline-stripped
+                or not — trailing whitespace is ignored).
+
+        Returns:
+            One :class:`TocEntry` per archive element, in listing order.
+        """
+        entries: list[TocEntry] = []
+        for raw in lines:
+            line = raw.rstrip("\n")
+            stripped = line.strip()
+            if not stripped or stripped.startswith(";"):
+                continue
+            match = _TOC_LINE_RE.match(stripped)
+            if match is None:
+                continue
+            rest = match.group("rest")
+            description = next(
+                (desc for desc in _MULTIWORD_DESCS if rest.startswith(desc + " ")),
+                rest.split(" ", 1)[0],
+            )
+            entries.append(
+                TocEntry(
+                    dump_id=int(match.group("dump_id")),
+                    description=description,
+                    raw_line=stripped,
+                )
+            )
+        return entries
+
+    @staticmethod
     def _classify_stderr_line(line: str) -> str:
         """Classify a pg_restore stderr line.
 
@@ -347,10 +718,11 @@ class DatabaseRestorer:
 
     def _run_section(
         self,
-        section: str,
+        section: str | None,
         options: RestoreOptions,
         parallel: bool,
         on_stderr_line: Callable[[str], None] | None = None,
+        use_list: Path | None = None,
     ) -> RestoreResult:
         """Run pg_restore for a single section with streaming stderr.
 
@@ -361,19 +733,23 @@ class DatabaseRestorer:
         - Ctrl+C cleanly kills the subprocess
 
         Args:
-            section: pg_restore ``--section`` value.
+            section: pg_restore ``--section`` value, or ``None`` to omit it (the
+                deferred matview refresh drives the section via its ``-L`` list).
             options: Restore configuration.
             parallel: Enable ``-j`` workers.
             on_stderr_line: Optional callback for every stderr line.
+            use_list: Optional ``pg_restore -L`` use-list restricting the restore
+                to the listed archive elements.
 
         Returns:
-            :class:`RestoreResult` for this section.
+            :class:`RestoreResult` for this section (``phases_completed`` carries
+            the section name, or is empty when ``section`` is ``None``).
 
         Raises:
             RestoreError: If pg_restore is not found or the process is
                 interrupted.
         """
-        cmd = self._build_command(section, options, parallel)
+        cmd = self._build_command(section, options, parallel, use_list=use_list)
         errors: list[str] = []
         warnings: list[str] = []
 
@@ -398,7 +774,8 @@ class DatabaseRestorer:
                     returncode = proc.wait()
                 except KeyboardInterrupt:
                     proc.kill()
-                    raise RestoreError(f"pg_restore {section} phase interrupted by user") from None
+                    phase = section or "matview-refresh"
+                    raise RestoreError(f"pg_restore {phase} phase interrupted by user") from None
         except FileNotFoundError as e:
             raise RestoreError(
                 "pg_restore not found. Ensure PostgreSQL client tools are installed and on PATH."
@@ -414,7 +791,10 @@ class DatabaseRestorer:
         # Lenient mode (exit_on_error=False, no hard errors, non-zero exit): treat as success
 
         return RestoreResult(
-            success=True, phases_completed=[section], errors=errors, warnings=warnings
+            success=True,
+            phases_completed=[section] if section is not None else [],
+            errors=errors,
+            warnings=warnings,
         )
 
     def _validate_table_count(self, options: RestoreOptions) -> RestoreResult:

--- a/tests/e2e/test_restore_cli.py
+++ b/tests/e2e/test_restore_cli.py
@@ -178,3 +178,85 @@ class TestRestoreCLI:
             runner.invoke(app, ["restore", str(backup), "--database", "db"])
         assert captured["opts"].no_owner is False
         assert captured["opts"].no_acl is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #172: matview refresh deferral flag + reporting
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreMatviewCLI:
+    def test_no_refresh_matviews_flag_in_help(self):
+        import re
+
+        result = runner.invoke(app, ["restore", "--help"])
+        assert result.exit_code == 0
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "--no-refresh-matviews" in clean
+
+    def test_refresh_matviews_defaults_to_enabled(self, tmp_path):
+        backup = tmp_path / "dump.pgdump"
+        backup.touch()
+        captured: dict = {}
+
+        def capture(opts, on_stderr_line=None):
+            captured["opts"] = opts
+            return RestoreResult(success=True, phases_completed=["pre-data", "data", "post-data"])
+
+        with patch("confiture.core.restorer.DatabaseRestorer.restore", side_effect=capture):
+            runner.invoke(app, ["restore", str(backup), "--database", "db"])
+        assert captured["opts"].no_refresh_matviews is False
+
+    def test_no_refresh_matviews_forwarded(self, tmp_path):
+        backup = tmp_path / "dump.pgdump"
+        backup.touch()
+        captured: dict = {}
+
+        def capture(opts, on_stderr_line=None):
+            captured["opts"] = opts
+            return RestoreResult(success=True, phases_completed=["pre-data", "data", "post-data"])
+
+        with patch("confiture.core.restorer.DatabaseRestorer.restore", side_effect=capture):
+            runner.invoke(
+                app, ["restore", str(backup), "--database", "db", "--no-refresh-matviews"]
+            )
+        assert captured["opts"].no_refresh_matviews is True
+
+    def test_refreshed_count_reported(self, tmp_path):
+        backup = tmp_path / "dump.pgdump"
+        backup.touch()
+        with patch(
+            "confiture.core.restorer.DatabaseRestorer.restore",
+            return_value=RestoreResult(
+                success=True,
+                phases_completed=["pre-data", "data", "post-data", "analyze", "refresh-matviews"],
+                matviews_deferred=3,
+                matviews_refreshed=3,
+                analyze_ran=True,
+            ),
+        ):
+            result = runner.invoke(app, ["restore", str(backup), "--database", "db"])
+        assert result.exit_code == 0
+        assert "3" in result.output
+        assert "refresh" in result.output.lower()
+
+    def test_deferred_but_not_refreshed_reported(self, tmp_path):
+        backup = tmp_path / "dump.pgdump"
+        backup.touch()
+        with patch(
+            "confiture.core.restorer.DatabaseRestorer.restore",
+            return_value=RestoreResult(
+                success=True,
+                phases_completed=["pre-data", "data", "post-data"],
+                matviews_deferred=2,
+                matviews_refreshed=0,
+                analyze_ran=False,
+            ),
+        ):
+            result = runner.invoke(
+                app, ["restore", str(backup), "--database", "db", "--no-refresh-matviews"]
+            )
+        assert result.exit_code == 0
+        out = result.output.lower()
+        assert "2" in result.output
+        assert "no data" in out or "not refreshed" in out or "skipped" in out

--- a/tests/integration/test_restore_matview_deferral.py
+++ b/tests/integration/test_restore_matview_deferral.py
@@ -1,0 +1,153 @@
+"""Integration: `confiture restore` defers matview refresh past ANALYZE (issue #172).
+
+Builds a schema containing a *populated* materialized view into a pg_dump -Fc
+artifact, then restores it into a fresh database and asserts:
+
+- default: the matview is refreshed (populated) after a database-wide ANALYZE, and
+  the result reports the deferral + refresh;
+- ``no_refresh_matviews``: the matview is restored WITH NO DATA (not populated),
+  leaving it for the caller to refresh on their own schedule.
+
+Requires a reachable local PostgreSQL (CONFITURE_TEST_DB_URL or localhost).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import psycopg.sql
+import pytest
+
+from confiture.core.restorer import DatabaseRestorer, RestoreOptions
+from confiture.core.schema_artifact import SchemaArtifactDumper, build_schema_artifact
+
+pytestmark = pytest.mark.integration
+
+# A table with rows plus a materialized view over it. Created WITH DATA (the
+# default), so pg_dump emits a MATERIALIZED VIEW DATA (REFRESH) entry.
+_MATVIEW_SCHEMA_SQL = """
+CREATE TABLE measurement (id int PRIMARY KEY, bucket int, amount numeric);
+INSERT INTO measurement
+    SELECT g, g % 5, (g * 1.5)::numeric FROM generate_series(1, 200) AS g;
+CREATE MATERIALIZED VIEW mv_bucket_totals AS
+    SELECT bucket, count(*) AS n, sum(amount) AS total
+    FROM measurement
+    GROUP BY bucket;
+"""
+
+
+def _server_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+def _maintenance_url(server_url: str) -> str:
+    from confiture.core.temp_database import _maintenance_url
+
+    return _maintenance_url(server_url)
+
+
+@pytest.fixture
+def server_url() -> str:
+    url = _server_url()
+    try:
+        with psycopg.connect(_maintenance_url(url), autocommit=True):
+            pass
+    except psycopg.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
+    return url
+
+
+@pytest.fixture
+def fresh_target(server_url: str) -> Iterator[str]:
+    target = "confiture_matview_deferral"
+    maint = _maintenance_url(server_url)
+    target_id = psycopg.sql.Identifier(target)
+    with psycopg.connect(maint, autocommit=True) as conn:
+        conn.execute(psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(target_id))
+        conn.execute(psycopg.sql.SQL("CREATE DATABASE {}").format(target_id))
+    try:
+        yield target
+    finally:
+        with psycopg.connect(maint, autocommit=True) as conn:
+            conn.execute(
+                psycopg.sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(target_id)
+            )
+
+
+def _matview_is_populated(server_url: str, target_db: str, matview: str) -> bool:
+    target_url = server_url.rsplit("/", 1)[0] + f"/{target_db}"
+    with psycopg.connect(target_url, autocommit=True) as conn:
+        row = conn.execute(
+            "SELECT ispopulated FROM pg_matviews WHERE matviewname = %s",
+            (matview,),
+        ).fetchone()
+    assert row is not None, f"matview {matview!r} was not restored at all"
+    return bool(row[0])
+
+
+def _build_matview_artifact(server_url: str, tmp_path: Path) -> Path:
+    artifact = tmp_path / "matview_schema.full.deadbeefcafe.pgdump"
+    result = build_schema_artifact(
+        server_url=server_url,
+        schema_sql=_MATVIEW_SCHEMA_SQL,
+        output_path=artifact,
+        schema_hash="deadbeefcafe0001",
+        dump_format="custom",
+        dumper=SchemaArtifactDumper(jobs=2),
+    )
+    assert result.skipped is False
+    assert artifact.exists()
+    return artifact
+
+
+def _restore_options(artifact: Path, target: str, **kwargs) -> RestoreOptions:
+    return RestoreOptions(
+        backup_path=artifact,
+        target_db=target,
+        host="localhost",
+        port=5432,
+        jobs=2,
+        parallel_restore=True,
+        no_owner=True,
+        no_acl=True,
+        **kwargs,
+    )
+
+
+def test_default_restore_refreshes_matview_after_analyze(
+    server_url: str, fresh_target: str, tmp_path: Path
+) -> None:
+    artifact = _build_matview_artifact(server_url, tmp_path)
+
+    result = DatabaseRestorer().restore(_restore_options(artifact, fresh_target))
+
+    assert result.success, result.errors
+    # The matview refresh was deferred out of the data phase and run after ANALYZE.
+    assert result.matviews_deferred == 1
+    assert result.matviews_refreshed == 1
+    assert result.analyze_ran is True
+    assert "analyze" in result.phases_completed
+    assert "refresh-matviews" in result.phases_completed
+    # And it is actually populated in the restored database.
+    assert _matview_is_populated(server_url, fresh_target, "mv_bucket_totals") is True
+
+
+def test_no_refresh_matviews_leaves_matview_unpopulated(
+    server_url: str, fresh_target: str, tmp_path: Path
+) -> None:
+    artifact = _build_matview_artifact(server_url, tmp_path)
+
+    result = DatabaseRestorer().restore(
+        _restore_options(artifact, fresh_target, no_refresh_matviews=True)
+    )
+
+    assert result.success, result.errors
+    assert result.matviews_deferred == 1
+    assert result.matviews_refreshed == 0
+    assert result.analyze_ran is False
+    assert "refresh-matviews" not in result.phases_completed
+    # The matview exists but was restored WITH NO DATA.
+    assert _matview_is_populated(server_url, fresh_target, "mv_bucket_totals") is False

--- a/tests/unit/test_restorer.py
+++ b/tests/unit/test_restorer.py
@@ -11,7 +11,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from confiture.core.restorer import DatabaseRestorer, RestoreOptions, RestoreResult
+from confiture.core.restorer import (
+    DatabaseRestorer,
+    RestoreOptions,
+    RestoreResult,
+    TocEntry,
+)
 from confiture.exceptions import RestoreError
 
 # ---------------------------------------------------------------------------
@@ -303,11 +308,12 @@ class TestRestoreOrchestration:
         def fake_validate(path):
             pass
 
-        def fake_run(section, opts, parallel, on_stderr_line=None):
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             calls.append((section, parallel))
             return RestoreResult(success=True, phases_completed=[section])
 
         restorer._validate_dump_format = fake_validate  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
         restorer._run_section = fake_run  # type: ignore[method-assign]
         result = restorer.restore(self._opts())
         assert calls == [("pre-data", False), ("data", True), ("post-data", False)]
@@ -321,7 +327,7 @@ class TestRestoreOrchestration:
         def fake_validate(path):
             raise RestoreError("bad format")
 
-        def fake_run(section, opts, parallel, on_stderr_line=None):
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             run_called.append(section)
             return RestoreResult(success=True, phases_completed=[section])
 
@@ -336,8 +342,9 @@ class TestRestoreOrchestration:
         calls: list[str] = []
 
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
 
-        def fake_run(section, opts, parallel, on_stderr_line=None):
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             calls.append(section)
             if section == "pre-data":
                 return RestoreResult(success=False, phases_completed=[], errors=["DDL error"])
@@ -352,8 +359,9 @@ class TestRestoreOrchestration:
         restorer = DatabaseRestorer()
         calls: list[str] = []
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
 
-        def fake_run(section, opts, parallel, on_stderr_line=None):
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             calls.append(section)
             if section == "data":
                 return RestoreResult(success=False, phases_completed=[], errors=["data error"])
@@ -367,8 +375,9 @@ class TestRestoreOrchestration:
     def test_warnings_accumulated_across_phases(self):
         restorer = DatabaseRestorer()
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
 
-        def fake_run(section, opts, parallel, on_stderr_line=None):
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             return RestoreResult(
                 success=True, phases_completed=[section], warnings=[f"warn from {section}"]
             )
@@ -381,8 +390,11 @@ class TestRestoreOrchestration:
         restorer = DatabaseRestorer()
         validate_table_called = []
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
         restorer._run_section = (  # type: ignore[method-assign]
-            lambda s, o, p, on_stderr_line=None: RestoreResult(success=True, phases_completed=[s])
+            lambda s, o, p, on_stderr_line=None, use_list=None: RestoreResult(
+                success=True, phases_completed=[s]
+            )
         )
 
         def fake_validate_table(opts):
@@ -397,8 +409,11 @@ class TestRestoreOrchestration:
         restorer = DatabaseRestorer()
         validate_table_called = []
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
         restorer._run_section = (  # type: ignore[method-assign]
-            lambda s, o, p, on_stderr_line=None: RestoreResult(success=True, phases_completed=[s])
+            lambda s, o, p, on_stderr_line=None, use_list=None: RestoreResult(
+                success=True, phases_completed=[s]
+            )
         )
 
         def fake_validate_table(opts):
@@ -536,8 +551,9 @@ class TestDiagnosePostDataErrors:
         """End-to-end: out-of-shared-memory error in post-data → hint in RestoreResult."""
         restorer = DatabaseRestorer()
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
 
-        def fake_run(section, opts, parallel, on_stderr_line=None):
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             if section == "post-data":
                 return RestoreResult(
                     success=False,
@@ -556,8 +572,9 @@ class TestDiagnosePostDataErrors:
         """out-of-shared-memory in a warning on a lenient restore → hint in RestoreResult."""
         restorer = DatabaseRestorer()
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
 
-        def fake_run(section, opts, parallel, on_stderr_line=None):
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             if section == "post-data":
                 return RestoreResult(
                     success=True,
@@ -575,8 +592,11 @@ class TestDiagnosePostDataErrors:
     def test_restore_result_no_diagnostics_on_clean_restore(self):
         restorer = DatabaseRestorer()
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
         restorer._run_section = (  # type: ignore[method-assign]
-            lambda s, o, p, on_stderr_line=None: RestoreResult(success=True, phases_completed=[s])
+            lambda s, o, p, on_stderr_line=None, use_list=None: RestoreResult(
+                success=True, phases_completed=[s]
+            )
         )
         result = restorer.restore(RestoreOptions(backup_path=Path("d.pgdump"), target_db="db"))
         assert result.diagnostics == []
@@ -596,8 +616,11 @@ class TestParallelRestoreFlag:
     def _make_restorer(self):
         restorer = DatabaseRestorer()
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
         restorer._run_section = (  # type: ignore[method-assign]
-            lambda s, o, p, on_stderr_line=None: RestoreResult(success=True, phases_completed=[s])
+            lambda s, o, p, on_stderr_line=None, use_list=None: RestoreResult(
+                success=True, phases_completed=[s]
+            )
         )
         return restorer
 
@@ -607,8 +630,9 @@ class TestParallelRestoreFlag:
 
         restorer = DatabaseRestorer()
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
 
-        def capture_run(section, opts, parallel, on_stderr_line=None):
+        def capture_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             seen_options.append(opts)
             return RestoreResult(success=True, phases_completed=[section])
 
@@ -622,8 +646,9 @@ class TestParallelRestoreFlag:
 
         restorer = DatabaseRestorer()
         restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: []  # type: ignore[method-assign]  # fast path: no matviews
 
-        def capture_run(section, opts, parallel, on_stderr_line=None):
+        def capture_run(section, opts, parallel, on_stderr_line=None, use_list=None):
             seen_options.append(opts)
             return RestoreResult(success=True, phases_completed=[section])
 
@@ -655,3 +680,405 @@ class TestParallelRestoreFlag:
         with caplog.at_level(logging.WARNING, logger="confiture.core.restorer"):
             restorer.restore(self._opts(parallel_restore=True, exit_on_error=False))
         assert not any("parallel_restore" in msg for msg in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# Issue #172, Phase 1: TOC parsing
+# ---------------------------------------------------------------------------
+
+# A representative `pg_restore -l` listing: header comments, a table + its data,
+# a matview definition (pre-data) + its DATA entry (the REFRESH), an index and an
+# FK constraint (post-data). Owners/tablespaces vary in real output.
+_SAMPLE_TOC = """;
+; Archive created at 2026-07-07 09:00:00 UTC
+;     dbname: prod
+;     TOC Entries: 8
+;     Compression: -1
+;     Dump Version: 1.14-0
+;     Format: CUSTOM
+;
+;
+; Selected TOC Entries:
+;
+215; 1259 16405 TABLE public tb_order postgres
+3001; 0 16405 TABLE DATA public tb_order postgres
+216; 1259 16410 MATERIALIZED VIEW public mv_maintenance_price postgres
+3002; 0 16410 MATERIALIZED VIEW DATA public mv_maintenance_price postgres
+217; 1259 16420 MATERIALIZED VIEW public mv_count_all postgres
+3003; 0 16420 MATERIALIZED VIEW DATA public mv_count_all postgres
+2801; 1259 16430 INDEX public tb_order_pkey postgres
+2900; 2606 16435 FK CONSTRAINT public tb_order tb_order_customer_fkey postgres
+"""
+
+
+class TestParseTocLines:
+    def _parse(self):
+        return DatabaseRestorer._parse_toc_lines(_SAMPLE_TOC.splitlines())
+
+    def test_skips_comment_and_blank_lines(self):
+        entries = self._parse()
+        # 8 real entries; every comment (`;`) and blank line dropped.
+        assert len(entries) == 8
+        assert all(isinstance(e, TocEntry) for e in entries)
+
+    def test_extracts_dump_id(self):
+        entries = self._parse()
+        assert [e.dump_id for e in entries] == [215, 3001, 216, 3002, 217, 3003, 2801, 2900]
+
+    def test_preserves_raw_line_for_use_list_round_trip(self):
+        entries = self._parse()
+        matview_data = [e for e in entries if e.is_matview_data]
+        assert "3002; 0 16410 MATERIALIZED VIEW DATA public mv_maintenance_price postgres" in [
+            e.raw_line for e in matview_data
+        ]
+
+    def test_matview_data_detected(self):
+        entries = self._parse()
+        mv_data = [e for e in entries if e.is_matview_data]
+        assert len(mv_data) == 2
+        assert {e.dump_id for e in mv_data} == {3002, 3003}
+
+    def test_matview_definition_is_not_matview_data(self):
+        """CREATE MATERIALIZED VIEW (pre-data) must not be mistaken for its DATA entry."""
+        entries = self._parse()
+        definitions = [e for e in entries if e.dump_id in (216, 217)]
+        assert len(definitions) == 2
+        assert all(not e.is_matview_data for e in definitions)
+        assert all(e.description == "MATERIALIZED VIEW" for e in definitions)
+
+    def test_table_data_classified(self):
+        entries = self._parse()
+        table_data = [e for e in entries if e.description == "TABLE DATA"]
+        assert [e.dump_id for e in table_data] == [3001]
+        assert all(not e.is_matview_data for e in table_data)
+
+    def test_matview_data_description(self):
+        entries = self._parse()
+        mv_data = [e for e in entries if e.is_matview_data]
+        assert all(e.description == "MATERIALIZED VIEW DATA" for e in mv_data)
+
+    def test_empty_input_returns_empty(self):
+        assert DatabaseRestorer._parse_toc_lines([]) == []
+
+    def test_comment_only_input_returns_empty(self):
+        lines = [";", "; header", ";     dbname: x", ""]
+        assert DatabaseRestorer._parse_toc_lines(lines) == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #172, Phase 2: use-list partitioning + _build_command -L
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionEntries:
+    def _entries(self):
+        return DatabaseRestorer._parse_toc_lines(_SAMPLE_TOC.splitlines())
+
+    def test_partition_splits_matview_data_from_the_rest(self):
+        non_matview, matview_data = DatabaseRestorer._partition_entries(self._entries())
+        assert {e.dump_id for e in matview_data} == {3002, 3003}
+        # Everything else (table, table-data, matview definitions, index, FK) stays.
+        assert {e.dump_id for e in non_matview} == {215, 3001, 216, 217, 2801, 2900}
+
+    def test_partition_no_matviews_returns_empty_matview_list(self):
+        no_mv = [
+            "215; 1259 16405 TABLE public tb_order postgres",
+            "3001; 0 16405 TABLE DATA public tb_order postgres",
+        ]
+        entries = DatabaseRestorer._parse_toc_lines(no_mv)
+        non_matview, matview_data = DatabaseRestorer._partition_entries(entries)
+        assert matview_data == []
+        assert len(non_matview) == 2
+
+    def test_write_use_list_preserves_raw_lines(self, tmp_path):
+        _, matview_data = DatabaseRestorer._partition_entries(self._entries())
+        path = tmp_path / "matviews.list"
+        DatabaseRestorer._write_use_list(matview_data, path)
+        written = path.read_text().splitlines()
+        assert (
+            "3002; 0 16410 MATERIALIZED VIEW DATA public mv_maintenance_price postgres" in written
+        )
+        assert "3003; 0 16420 MATERIALIZED VIEW DATA public mv_count_all postgres" in written
+        assert len(written) == 2
+
+
+class TestBuildCommandUseList:
+    def _opts(self, **kwargs) -> RestoreOptions:
+        defaults = {"backup_path": Path("dump.pgdump"), "target_db": "mydb"}
+        defaults.update(kwargs)
+        return RestoreOptions(**defaults)
+
+    def test_use_list_adds_dash_L_with_path(self, tmp_path):
+        use_list = tmp_path / "tables.list"
+        cmd = DatabaseRestorer()._build_command(
+            "data", self._opts(), parallel=True, use_list=use_list
+        )
+        assert "-L" in cmd
+        assert str(use_list) in cmd
+        # -L must reference the list, immediately following the flag.
+        assert cmd[cmd.index("-L") + 1] == str(use_list)
+
+    def test_no_use_list_omits_dash_L(self):
+        cmd = DatabaseRestorer()._build_command("data", self._opts(), parallel=True)
+        assert "-L" not in cmd
+
+    def test_backup_path_still_last_with_use_list(self, tmp_path):
+        use_list = tmp_path / "tables.list"
+        cmd = DatabaseRestorer()._build_command(
+            "data", self._opts(), parallel=True, use_list=use_list
+        )
+        assert cmd[-1] == "dump.pgdump"
+
+    def test_section_none_omits_section_flag(self, tmp_path):
+        """The deferred refresh runs with -L but no --section (version-robust)."""
+        use_list = tmp_path / "matviews.list"
+        cmd = DatabaseRestorer()._build_command(
+            None, self._opts(), parallel=False, use_list=use_list
+        )
+        assert not any(a.startswith("--section") for a in cmd)
+        assert "-L" in cmd
+        assert cmd[-1] == "dump.pgdump"
+
+
+# ---------------------------------------------------------------------------
+# Issue #172, Phase 3: ANALYZE phase
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAnalyzeCommand:
+    def _opts(self, **kwargs) -> RestoreOptions:
+        defaults = {"backup_path": Path("dump.pgdump"), "target_db": "mydb"}
+        defaults.update(kwargs)
+        return RestoreOptions(**defaults)
+
+    def test_runs_psql_analyze_on_target_db(self):
+        cmd = DatabaseRestorer()._build_analyze_command(self._opts())
+        assert "psql" in cmd
+        assert "-d" in cmd
+        assert "mydb" in cmd
+        assert "ANALYZE" in cmd
+        assert "-h" in cmd
+        assert "/var/run/postgresql" in cmd
+        assert "-p" in cmd
+        assert "5432" in cmd
+
+    def test_stops_on_error(self):
+        cmd = DatabaseRestorer()._build_analyze_command(self._opts())
+        assert "ON_ERROR_STOP=1" in cmd
+
+    def test_username_added_when_set(self):
+        cmd = DatabaseRestorer()._build_analyze_command(self._opts(username="appuser"))
+        assert "-U" in cmd
+        assert "appuser" in cmd
+
+    def test_no_username_when_none(self):
+        cmd = DatabaseRestorer()._build_analyze_command(self._opts(username=None))
+        assert "-U" not in cmd
+
+    def test_superuser_prepends_sudo(self):
+        cmd = DatabaseRestorer()._build_analyze_command(self._opts(superuser="postgres"))
+        assert cmd[:3] == ["sudo", "-u", "postgres"]
+
+
+class TestRunAnalyze:
+    def _opts(self, **kwargs) -> RestoreOptions:
+        defaults = {"backup_path": Path("d.pgdump"), "target_db": "db"}
+        defaults.update(kwargs)
+        return RestoreOptions(**defaults)
+
+    def test_success_returns_analyze_phase(self):
+        mock_proc = _make_proc(["ANALYZE\n"], 0)
+        with patch("subprocess.Popen", return_value=mock_proc):
+            result = DatabaseRestorer()._run_analyze(self._opts())
+        assert result.success is True
+        assert result.phases_completed == ["analyze"]
+
+    def test_nonzero_exit_with_error_line_returns_failure(self):
+        mock_proc = _make_proc(["ERROR:  permission denied for table tb_order\n"], 1)
+        with patch("subprocess.Popen", return_value=mock_proc):
+            result = DatabaseRestorer()._run_analyze(self._opts())
+        assert result.success is False
+        assert any("permission denied" in e for e in result.errors)
+
+    def test_nonzero_exit_without_error_line_still_fails(self):
+        mock_proc = _make_proc(["some noise\n"], 2)
+        with patch("subprocess.Popen", return_value=mock_proc):
+            result = DatabaseRestorer()._run_analyze(self._opts())
+        assert result.success is False
+        assert result.errors  # a synthetic exit-code error is recorded
+
+    def test_psql_not_found_raises_restore_error(self):
+        with patch("subprocess.Popen", side_effect=FileNotFoundError("psql")):
+            with pytest.raises(RestoreError, match="psql not found"):
+                DatabaseRestorer()._run_analyze(self._opts())
+
+    def test_keyboard_interrupt_kills_process(self):
+        mock_proc = MagicMock()
+        mock_proc.stderr = iter([])
+        mock_proc.wait.side_effect = KeyboardInterrupt
+        mock_proc.__enter__ = lambda s: s
+        mock_proc.__exit__ = MagicMock(return_value=False)
+        with patch("subprocess.Popen", return_value=mock_proc):
+            with pytest.raises(RestoreError, match="interrupted"):
+                DatabaseRestorer()._run_analyze(self._opts())
+        mock_proc.kill.assert_called_once()
+
+    def test_on_stderr_line_callback_called(self):
+        mock_proc = _make_proc(["ANALYZE\n"], 0)
+        lines: list[str] = []
+        with patch("subprocess.Popen", return_value=mock_proc):
+            DatabaseRestorer()._run_analyze(self._opts(), on_stderr_line=lines.append)
+        assert lines == ["ANALYZE"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #172, Phase 4: deferred-matview orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredMatviewOrchestration:
+    """restore() with a backup that contains materialized-view data."""
+
+    def _opts(self, **kwargs) -> RestoreOptions:
+        defaults = {"backup_path": Path("d.pgdump"), "target_db": "db"}
+        defaults.update(kwargs)
+        return RestoreOptions(**defaults)
+
+    def _restorer_with_matviews(self, calls: list, *, refresh_ok=True, analyze_ok=True):
+        """A restorer whose TOC has 2 matview-data entries; phase runs are recorded."""
+        restorer = DatabaseRestorer()
+        entries = DatabaseRestorer._parse_toc_lines(_SAMPLE_TOC.splitlines())
+        restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: entries  # type: ignore[method-assign]
+
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
+            calls.append(("section", section, parallel, use_list.name if use_list else None))
+            ok = refresh_ok or use_list is None or use_list.name != "matviews.list"
+            return RestoreResult(
+                success=ok,
+                phases_completed=[section] if ok else [],
+                errors=[] if ok else ["refresh boom"],
+            )
+
+        def fake_analyze(opts, on_stderr_line=None):
+            calls.append(("analyze",))
+            return RestoreResult(
+                success=analyze_ok,
+                phases_completed=["analyze"] if analyze_ok else [],
+                errors=[] if analyze_ok else ["analyze boom"],
+            )
+
+        restorer._run_section = fake_run  # type: ignore[method-assign]
+        restorer._run_analyze = fake_analyze  # type: ignore[method-assign]
+        return restorer
+
+    def test_defers_matview_refresh_past_analyze(self):
+        calls: list = []
+        restorer = self._restorer_with_matviews(calls)
+        result = restorer.restore(self._opts())
+
+        assert result.success is True
+        # Every phase excludes matview data (tables.list); the refresh runs
+        # serially after ANALYZE with no --section (section=None).
+        assert calls == [
+            ("section", "pre-data", False, "tables.list"),
+            ("section", "data", True, "tables.list"),
+            ("section", "post-data", False, "tables.list"),
+            ("analyze",),
+            ("section", None, False, "matviews.list"),
+        ]
+
+    def test_reports_deferred_and_refreshed_counts(self):
+        calls: list = []
+        restorer = self._restorer_with_matviews(calls)
+        result = restorer.restore(self._opts())
+        assert result.matviews_deferred == 2
+        assert result.matviews_refreshed == 2
+        assert result.analyze_ran is True
+        assert "analyze" in result.phases_completed
+        assert "refresh-matviews" in result.phases_completed
+
+    def test_no_refresh_matviews_skips_analyze_and_refresh(self):
+        calls: list = []
+        restorer = self._restorer_with_matviews(calls)
+        result = restorer.restore(self._opts(no_refresh_matviews=True))
+
+        assert result.success is True
+        # Matview data filtered out of every phase, but no analyze / no refresh.
+        assert calls == [
+            ("section", "pre-data", False, "tables.list"),
+            ("section", "data", True, "tables.list"),
+            ("section", "post-data", False, "tables.list"),
+        ]
+        assert result.matviews_deferred == 2
+        assert result.matviews_refreshed == 0
+        assert result.analyze_ran is False
+
+    def test_analyze_failure_aborts_before_refresh(self):
+        calls: list = []
+        restorer = self._restorer_with_matviews(calls, analyze_ok=False)
+        result = restorer.restore(self._opts())
+
+        assert result.success is False
+        assert any("analyze boom" in e for e in result.errors)
+        # The matview refresh never runs after a failed ANALYZE.
+        assert ("section", None, False, "matviews.list") not in calls
+        assert result.matviews_deferred == 2
+
+    def test_refresh_failure_surfaces_as_failure(self):
+        calls: list = []
+        restorer = self._restorer_with_matviews(calls, refresh_ok=False)
+        result = restorer.restore(self._opts())
+
+        assert result.success is False
+        assert any("refresh boom" in e for e in result.errors)
+        assert result.analyze_ran is True
+
+    def test_no_matview_toc_takes_classic_path(self):
+        """A TOC without matview data → no use-list, no analyze phase."""
+        calls: list = []
+        restorer = DatabaseRestorer()
+        no_mv = DatabaseRestorer._parse_toc_lines(
+            [
+                "215; 1259 16405 TABLE public tb_order postgres",
+                "3001; 0 16405 TABLE DATA public tb_order postgres",
+            ]
+        )
+        restorer._validate_dump_format = lambda p: None  # type: ignore[method-assign]
+        restorer._list_toc = lambda o: no_mv  # type: ignore[method-assign]
+
+        def fake_run(section, opts, parallel, on_stderr_line=None, use_list=None):
+            calls.append((section, parallel, use_list))
+            return RestoreResult(success=True, phases_completed=[section])
+
+        restorer._run_section = fake_run  # type: ignore[method-assign]
+        result = restorer.restore(self._opts())
+
+        assert calls == [
+            ("pre-data", False, None),
+            ("data", True, None),  # no -L use-list: byte-for-byte the classic path
+            ("post-data", False, None),
+        ]
+        assert result.matviews_deferred is None
+        assert result.matviews_refreshed is None
+        assert result.analyze_ran is False
+
+    def test_use_lists_written_with_correct_partition(self):
+        """_prepare_use_lists writes tables.list (no matview) + matviews.list (only matview)."""
+        entries = DatabaseRestorer._parse_toc_lines(_SAMPLE_TOC.splitlines())
+        non_matview, matview_data = DatabaseRestorer._partition_entries(entries)
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            tables_list, matviews_list = DatabaseRestorer()._prepare_use_lists(
+                stack, non_matview, matview_data
+            )
+            assert tables_list is not None and matviews_list is not None
+            tables_txt = tables_list.read_text()
+            matviews_txt = matviews_list.read_text()
+
+        # matview REFRESH entries only in matviews.list; base table data only in tables.list.
+        assert "MATERIALIZED VIEW DATA" not in tables_txt
+        assert "TABLE DATA public tb_order" in tables_txt
+        assert "MATERIALIZED VIEW DATA public mv_maintenance_price" in matviews_txt
+        assert "TABLE DATA" not in matviews_txt


### PR DESCRIPTION
## Summary

Fixes #172. `confiture restore` refreshed materialized views on the **empty planner statistics** of a freshly loaded database (a logical dump carries no `pg_statistic`), so a stats-sensitive matview could replan into a catastrophic nested loop — a ~5s refresh becoming tens of minutes to hours, blowing deploy timeouts and wedging restore-based deploys (e.g. staging = restore-from-prod).

## What changed

`DatabaseRestorer`:
- Lists the archive TOC (`pg_restore -l` → `_parse_toc_lines`/`TocEntry`).
- Holds every `MATERIALIZED VIEW DATA` item out of **all** restore phases via a `-L` use-list.
- Runs a database-wide `ANALYZE` (via `psql`, so it reuses the exact `sudo`/connection auth as `pg_restore` — a non-owner whole-DB ANALYZE silently skips tables).
- Refreshes the matviews serially with `-L matviews.list` and **no `--section`**, now on real stats.
- Backups **without** matviews take the classic three-phase path with byte-for-byte unchanged `pg_restore` argv.

New surface: `confiture restore --refresh-matviews/--no-refresh-matviews` (default refresh); `RestoreResult.{matviews_deferred,matviews_refreshed,analyze_ran}`; new [restore guide](docs/guides/restore.md).

## Key finding

Empirically (pg_dump 18 / server 17) the matview REFRESH is a **post-data** TOC item, not the parallel data phase the issue described — and the section assignment is version-dependent. So the fix excludes matview data from *every* phase and refreshes with no `--section`, which is robust either way. Caught by a real-DB integration test.

## Behavior change (pre-1.0)

Matview-bearing backups now default to the deferred `ANALYZE` + refresh path. `--no-refresh-matviews` restores them `WITH NO DATA` for the caller to refresh later. Matview-free restores are unaffected. `ANALYZE` runs via `psql`, so PostgreSQL client tools must be on `PATH` (already required for `pg_restore`). Flagged in CHANGELOG.

## Verification

- ✅ 8566 pass (unit + e2e + integration + contract); ruff + ty clean
- ✅ 2 real-DB integration tests (`tests/integration/test_restore_matview_deferral.py`)
- ✅ Manual CLI e2e both paths: default → 5 phases / matview populated; `--no-refresh-matviews` → 3 phases / `ispopulated=f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)