### PR TITLE
Drift-guard epic: function/view/replay body-drift + release 0.36.0 (#174–#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FunctionBodyDriftReport.to_dict()` (both `include_bodies=`-gated) now back the
   serialization, replacing the previously inlined `body_drift` dict.
 
+- **Internal: `ExpectedSchemaDB` scratch-database foundation
+  (`core/expected_db.py`).** A context manager that builds the *expected* schema
+  into a throwaway database — either from source DDL (`from_source`) or by
+  replaying migrations (`from_base_plus_migrations`) — and yields a live
+  connection, so upcoming drift checks (view drift #174, replay drift #179,
+  require-migration bodies #178) can normalise the expected side through
+  PostgreSQL's own deparser (`pg_get_viewdef`, `pg_proc.prosrc`) instead of
+  text-normalising DDL. Wraps the existing `TempDatabase` lifecycle with
+  exception-safe cleanup (a failed build still drops the scratch DB). No CLI
+  surface yet.
+
 ### Fixed
+
+- **Scratch/temporary-database helpers now accept hostless socket DSNs
+  (`postgresql:///dbname`).** `TempDatabase`'s URL rewriting round-tripped the
+  connection string through `urllib.parse.urlunparse`, which drops the `//`
+  authority marker when the netloc is empty — turning `postgresql:///db` into the
+  malformed `postgresql:/db` and breaking every scratch-DB consumer
+  (`--live-snapshot`, `test-db` provisioning, and the new drift foundation) on a
+  Unix-socket DSN. The marker is now preserved; host-qualified URLs are
+  byte-for-byte unchanged.
 
 - **`confiture drift --schema` now parses the DDL that `confiture build` emits
   (#175).** The expected-schema parser used by `drift` yielded zero tables on any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-07-08
+
 ### Added
 
 - **`migrate validate --require-migration-bodies` fails a function/procedure body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`migrate validate --check-body-views` detects view and materialized-view
+  definition drift (#174).** The missing half of `--check-body`: it catches when a
+  live view's predicate or projection was changed directly in the database (an
+  out-of-band `CREATE OR REPLACE VIEW` on prod) without updating the DDL — the
+  class of bug behind the `printoptim_backend` ETL incident where a committed
+  `meter_at > max_volume_date` had silently become `meter_at > (max_volume_date +
+  1)` on production, dropping every other day's volume for months. Views aren't
+  stored verbatim (`pg_get_viewdef` returns pg's *deparsed* tree — schema-qualified,
+  `*`-expanded, reparenthesised), so a naive text compare of source DDL against
+  live would flag semantically-identical views as false positives. Instead the
+  expected views are built into a throwaway scratch database and read back through
+  the **same** `pg_get_viewdef(oid, true)` deparser as live — string equality then
+  means semantic equality, so only genuine logic changes register. Covers regular
+  (`relkind='v'`) and materialized (`'m'`) views, honours `--schemas`, exits 1 on
+  drift, and (with `--show-diff`) emits the expected/live definitions and a unified
+  diff. For a remote read-only live database over `--ssh`, pass `--scratch-url` to
+  point the scratch build at a writable local/CI server. New modules
+  `core/view_body_drift.py` and `core/live_view_catalog.py`.
+
 - **`migrate validate --check-body --show-diff` emits the expected body, the live
   body, and a unified diff per drifted function (#177).** Previously a body drift
   reported only two 12-char hashes (`source_hash`, `db_hash`), so every consumer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`migrate validate --check-signatures` no longer strips the `[]` array suffix
+  from function parameters (#176).** The signature parser dropped the array
+  suffix — the pglast (AST) path read `argType.names` but ignored
+  `argType.arrayBounds`, and the regex fallback kept `[]` but failed to alias the
+  base type through it (`int[]` vs the live `integer[]`). Because the live
+  (introspected) side keeps the canonical array type, an array-typed function was
+  falsely reported as a **stale overload** and its generated `remediation_sql`
+  was a destructive `DROP FUNCTION` for a function that exists in **both** the
+  database and the DDL. The same signature mismatch also prevented `--check-body`
+  from pairing the function, silently skipping its body diff. Array parameters
+  (`text[]`, `bigint[]`, `numeric(10,2)[]`, multidimensional `int[][]`, sized
+  `text[5]`) now round-trip correctly on both parser tiers and stay symmetric
+  with the live side. As a safety net, the drift detector never emits a
+  `DROP FUNCTION` for a "stale overload" whose base name and arity match a source
+  signature differing only by an array suffix.
+
 ## [0.35.0] - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`migrate validate --check-body-replay` reports out-of-band function hot-patches
+  via migration replay (#179).** The durable production drift signal. `--check-body`
+  builds its expected side from source DDL, so it is dominated by the
+  build-vs-migrate backlog — every body that shipped to rebuilt-from-DDL
+  environments but never got a migration reads as "drift", drowning out any *new*
+  hot-patch. `--check-body-replay` instead rebuilds the expected database by
+  replaying all migrations into a throwaway scratch DB (no source DDL, no
+  hot-patches) and diffs `pg_proc.prosrc` against live: `live − replayed` is
+  exactly the definitions that no migration produced — true out-of-band
+  `CREATE OR REPLACE` hot-patches. Both sides are real databases introspected
+  identically, so signature pairing is exact (this path never text-parses
+  signatures, sidestepping the #176 class entirely). A migration that fails at HEAD
+  surfaces as an error, not as false drift. Honours `--schemas` and
+  `--migrations-dir`; `--show-diff` shows the replayed vs live bodies; over `--ssh`
+  pass `--scratch-url` for the writable replay server. New module
+  `core/validation/replay_drift.py`. A scheduler (e.g. fraisier) can run this
+  post-deploy and on a timer as a standing drift guard.
+
 - **`migrate validate --check-body-views` detects view and materialized-view
   definition drift (#174).** The missing half of `--check-body`: it catches when a
   live view's predicate or projection was changed directly in the database (an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`migrate validate --check-body --show-diff` emits the expected body, the live
+  body, and a unified diff per drifted function (#177).** Previously a body drift
+  reported only two 12-char hashes (`source_hash`, `db_hash`), so every consumer
+  hand-wrote a `prosrc` differ to classify drift (the PrintOptim audit did this
+  for 120 functions). `FunctionBodyDrift` now also carries `expected_body`,
+  `live_body`, and a `unified_diff` computed with `difflib` over a new
+  line-oriented normalisation (`FunctionBodyNormalizer.normalize_for_diff`) — it
+  strips comments, lowercases, collapses indentation, and drops blank lines, so
+  the diff shows only genuine logic changes, not formatting churn. The new opt-in
+  `--show-diff` flag (requires `--check-body`) surfaces these in both the text
+  renderer (rich-highlighted `+/-` lines) and the JSON payload
+  (`body_drift.body_drifts[].expected_body` / `.live_body` / `.unified_diff`).
+  The default (`--check-body` without `--show-diff`) output is byte-for-byte
+  unchanged — hash-only — for terse CI logs. `FunctionBodyDrift.to_dict()` and
+  `FunctionBodyDriftReport.to_dict()` (both `include_bodies=`-gated) now back the
+  serialization, replacing the previously inlined `body_drift` dict.
+
 ### Fixed
 
 - **`confiture drift --schema` now parses the DDL that `confiture build` emits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`migrate validate --require-migration-bodies` fails a function/procedure body
+  change that has no accompanying migration (#178).** `--require-migration` already
+  gates table/column DDL and function *signature* changes, but not function
+  *bodies* — so a body edit that ships to rebuilt-from-DDL environments (dev/test)
+  without a migration silently never reaches migrate-only environments
+  (staging/production). In the PrintOptim audit ~120 functions ran different bodies
+  in prod purely because body edits never got a migration. The new opt-in flag
+  extends the accompaniment check: it diffs function bodies between `--base-ref` and
+  HEAD (static, git-based, **no DB**) and requires each changed body to be carried
+  by a migration that re-defines the function (`CREATE OR REPLACE`, in a `.sql` *or*
+  `.py` migration). Comment/whitespace/case-only changes don't count; a parameter-
+  type change is left to the existing signature check. Because it's diff-scoped, it
+  flags only what changed in the changeset, not the standing backlog. It is **off by
+  default** — drain the backlog first with the companion report-only flag
+  **`--list-unmigrated-bodies`** (lists un-migrated body changes without failing,
+  exit 0), then turn enforcement on. The failure message names each function and
+  shows a unified diff. This is the static PR-time gate; its runtime counterpart —
+  verifying the migration actually *produces* the intended body against a live DB —
+  is `--check-body-replay` (#179). New module `core/function_body_checker.py`.
+
 - **`migrate validate --check-body-replay` reports out-of-band function hot-patches
   via migration replay (#179).** The durable production drift signal. `--check-body`
   builds its expected side from source DDL, so it is dominated by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`confiture drift --schema` now parses the DDL that `confiture build` emits
+  (#175).** The expected-schema parser used by `drift` yielded zero tables on any
+  schema whose statements were preceded by a comment — which includes
+  `confiture build`'s own default block-comment file separators and ordinary
+  `--` line comments (non-ASCII content such as an em-dash included). `sqlparse`
+  keeps a leading comment attached to the statement that follows it, and the
+  position-anchored `CREATE TABLE` match never saw past it, so every live table
+  was reported as spurious `extra_table` drift **with exit 0** — a silent false
+  positive on the documented `drift --schema db/generated/schema_local.sql`
+  workflow. Comments are now stripped before parsing. Additionally, a schema that
+  declares tables (contains a top-level `CREATE TABLE`) but parses to zero now
+  fails loudly with `SchemaError` (`SCHEMA_202`, exit 4) instead of degrading to
+  an empty expectation; `CREATE TABLE` text inside function bodies does not
+  trigger this guard.
 - **`migrate validate --check-signatures` no longer strips the `[]` array suffix
   from function parameters (#176).** The signature parser dropped the array
   suffix — the pglast (AST) path read `argType.names` but ignored

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.35.0
-**Last Updated**: 2026-07-07
+**Version**: 0.36.0
+**Last Updated**: 2026-07-08
 **Current Status**: Production-Ready
 
 > **Status**: Production-ready. Actively used in production since March 2026.
@@ -925,8 +925,8 @@ When stuck, ask:
 
 ---
 
-**Last Updated**: 2026-07-07
-**Version**: 0.35.0
+**Last Updated**: 2026-07-08
+**Version**: 0.36.0
 
 ---
 

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -317,6 +317,76 @@ Python migrations are intentionally **not** auto-rewritten — unparsing
 the AST would lose comments and formatting. Violations in `.py` files
 must be fixed by hand.
 
+## `--check-signatures` and `--check-body`
+
+These two flags compare the functions declared in your source DDL against the
+**live** database, catching functions that were changed out-of-band (an ad-hoc
+`CREATE OR REPLACE` on production) without the repo being updated. Both require
+`--config` (or `--env`) and connect to the database; pass `--schema` to compare
+against an explicit schema file, otherwise the schema is auto-built from your DDL.
+
+- **`--check-signatures`** compares function *signatures*, detecting stale
+  overloads left behind when a `CREATE OR REPLACE` changed a parameter type
+  (the old overload lingers under the previous signature).
+- **`--check-body`** (requires `--check-signatures`) additionally compares each
+  function *body* (`pg_proc.prosrc`) against the source. Bodies are compared
+  after normalisation — comments, whitespace, and keyword casing are ignored — so
+  only genuine logic changes register as drift. Opt-in because body comparison is
+  heavier than signature-only.
+
+Either flag exits `1` when drift is found, `0` when clean.
+
+### `--show-diff` — see *what* changed, not just *that* it changed
+
+By default a body drift reports only two 12-char hashes (`source_hash`,
+`db_hash`) — enough to know a function drifted, but not what to do about it.
+`--show-diff` (requires `--check-body`) surfaces, per drifted function, the
+**expected body**, the **live body**, and a **unified diff** of the two. The diff
+is computed over a line-oriented normalisation (comments stripped, indentation
+and blank-line churn collapsed), so it pinpoints the changed lines instead of
+drowning them in reformatting noise.
+
+```bash
+# Terse (default): hash-only, ideal for CI logs
+confiture migrate validate --check-signatures --check-body --config confiture.yaml
+
+# Triage: show the expected/live bodies and a unified diff per drift
+confiture migrate validate --check-signatures --check-body --show-diff \
+    --config confiture.yaml
+```
+
+Text output under `--show-diff` prints a rich-highlighted `+/-` diff beneath each
+drifted function. The JSON payload (`--format json`) gains the bodies and diff on
+each entry — but **only** when `--show-diff` is set; the default JSON shape stays
+hash-only for back-compatibility:
+
+```json
+{
+  "check": "function_signature_drift",
+  "body_drift": {
+    "has_drift": true,
+    "body_drifts": [
+      {
+        "schema": "public",
+        "name": "calc_total",
+        "signature_key": "public.calc_total(numeric)",
+        "source_hash": "f111676f0375",
+        "db_hash": "6dc531b06f14",
+        "expected_body": "BEGIN\n  RETURN amount * 1.20;\nEND;",
+        "live_body": "BEGIN\n  RETURN amount * 1.196;\nEND;",
+        "unified_diff": "--- public.calc_total(numeric) (expected)\n+++ public.calc_total(numeric) (live)\n@@ -1,3 +1,3 @@\n begin\n-return amount * 1.20;\n+return amount * 1.196;\n end;"
+      }
+    ],
+    "functions_checked": 1,
+    "detection_time_ms": 0.08
+  }
+}
+```
+
+To re-apply the source body over the live drift, use
+`confiture migrate fix-signatures --check-body --apply` (dry-run without
+`--apply`).
+
 ## `--require-grant-migration`
 
 Build environments apply grants straight from the grant sweep directory

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -387,6 +387,61 @@ To re-apply the source body over the live drift, use
 `confiture migrate fix-signatures --check-body --apply` (dry-run without
 `--apply`).
 
+## `--check-body-views`
+
+The view/materialized-view counterpart to `--check-body`. It catches a view whose
+predicate or projection was changed directly in the database — an out-of-band
+`CREATE OR REPLACE VIEW` on production — without the DDL being updated. (This is
+the class of bug behind a real ETL incident where a committed
+`meter_at > max_volume_date` had silently become `meter_at > (max_volume_date + 1)`
+on prod, dropping every other day's data for months.)
+
+Views are harder than functions: PostgreSQL doesn't store a view's text, so
+`pg_get_viewdef` returns a *deparsed* rendering (schema-qualified, `*`-expanded,
+reparenthesised). A naive text compare of your `CREATE VIEW` DDL against that would
+report **false positives** on views that are only formatted differently. Instead,
+`--check-body-views` builds the expected views into a throwaway **scratch
+database** and reads them back through the **same** `pg_get_viewdef` deparser as
+live — so string equality means semantic equality, and only genuine logic changes
+register.
+
+```bash
+# Terse: hash-only, exits 1 on drift
+confiture migrate validate --check-body-views --config confiture.yaml --schema db/generated/schema.sql
+
+# Triage: unified diff of the deparsed definitions per drifted view
+confiture migrate validate --check-body-views --show-diff \
+    --schemas public,catalog --config confiture.yaml --schema db/generated/schema.sql
+```
+
+- Covers **regular and materialized** views; honours `--schemas`.
+- `--show-diff` adds `expected_def`, `live_def`, and `unified_diff` to each drifted
+  view (text and JSON). Default output is hash-only.
+- **Remote read-only live (`--ssh`)**: the scratch database is built on a
+  *writable* server, which the read-only production replica is not. Pass
+  `--scratch-url postgresql://localhost/postgres` (or a CI server) so the expected
+  side builds locally while the live side is read over the tunnel.
+
+The JSON payload mirrors `--check-body`:
+
+```json
+{
+  "check": "view_body_drift",
+  "has_drift": true,
+  "body_drifts": [
+    {
+      "schema": "public",
+      "name": "v_etl_unused_meters",
+      "relkind": "v",
+      "source_hash": "e442d2211789",
+      "db_hash": "251751b4699c"
+    }
+  ],
+  "views_checked": 2,
+  "detection_time_ms": 0.18
+}
+```
+
 ## `--require-grant-migration`
 
 Build environments apply grants straight from the grant sweep directory

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -442,6 +442,51 @@ The JSON payload mirrors `--check-body`:
 }
 ```
 
+## `--check-body-replay` — the production drift guard
+
+`--check-body` and `--check-body-replay` both detect function/procedure body drift
+against live, but they build the **expected** side differently:
+
+| | Expected side | Best for |
+|---|---|---|
+| `--check-body` | source DDL (`build`) | a repo where DDL *is* the source of truth |
+| `--check-body-replay` | replay of all migrations | migrate-strategy prod: isolate a *new* hot-patch |
+
+On a migrate-strategy database (staging, production), `--check-body`'s
+source-DDL expectation is swamped by the **build-vs-migrate backlog**: every body
+that shipped to dev/test (rebuilt from DDL) but never got a migration reads as
+"drift", so a genuinely new out-of-band `CREATE OR REPLACE` on prod is lost in the
+noise.
+
+`--check-body-replay` gives the clean signal. It rebuilds the expected database by
+replaying **all migrations** into a throwaway scratch DB — no source DDL, no
+hot-patches — and diffs `pg_proc.prosrc` against live. The difference is exactly
+the definitions **no migration produced**: true out-of-band hot-patches.
+
+```bash
+# Isolate live hot-patches that no migration carries
+confiture migrate validate --check-body-replay --env production \
+    --schemas public,catalog
+
+# With the diff, over an SSH tunnel to a read-only replica
+confiture migrate validate --check-body-replay --show-diff \
+    --env production --ssh deploy@db.internal \
+    --scratch-url postgresql://localhost/postgres
+```
+
+- Both sides are real databases introspected identically, so signature pairing is
+  exact — this path never text-parses signatures.
+- A migration that **fails at HEAD** surfaces as an error (non-zero exit), *not*
+  as false drift.
+- Heaviest drift check (replays the whole migration history). Explicitly opt-in.
+- `--scratch-url` is **required** with `--ssh` (the replay needs a writable server;
+  the read-only replica is not one). JSON `check` is `replay_body_drift`; the
+  `body_drifts` shape matches `--check-body` (with `--show-diff` adding
+  `expected_body`/`live_body`/`unified_diff`).
+
+A deploy scheduler (e.g. fraisier) can run this post-deploy and on a timer as a
+standing production drift guard — the consuming repo keeps only config.
+
 ## `--require-grant-migration`
 
 Build environments apply grants straight from the grant sweep directory

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -487,6 +487,50 @@ confiture migrate validate --check-body-replay --show-diff \
 A deploy scheduler (e.g. fraisier) can run this post-deploy and on a timer as a
 standing production drift guard — the consuming repo keeps only config.
 
+## `--require-migration-bodies` — gate un-migrated body edits at PR time
+
+`--require-migration` ensures table/column DDL changes and function *signature*
+changes have a migration, but it does **not** check function/procedure *bodies*.
+So a body edit in the schema DDL that ships to rebuilt-from-DDL environments
+(dev/test) without a migration silently never reaches migrate-only environments
+(staging/production) — the root cause of a whole class of prod↔source drift (in
+one audit, ~120 functions ran different bodies in prod for exactly this reason).
+
+`--require-migration-bodies` closes the gap. It is **static and git-based (no
+DB)**: it diffs function bodies between `--base-ref` and HEAD and requires each
+changed body to be carried by a migration that re-defines the function (a
+`CREATE OR REPLACE`, in a `.sql` or `.py` migration). Comment/whitespace/case-only
+changes don't count; parameter-type changes are the existing signature check's
+job. Because it's diff-scoped, it flags only what changed in the changeset — not
+your standing backlog.
+
+This is the PR-time static gate. Its runtime counterpart, which verifies the
+migration actually *produces* the intended body against a live database, is
+[`--check-body-replay`](#--check-body-replay--the-production-drift-guard).
+
+### Drain-first workflow
+
+It is **off by default**: an existing repo carries a backlog of body edits that
+predate the check, and turning it on cold would fail the first PR that touches any
+of them. Adopt it in three steps:
+
+```bash
+# 1. Size the backlog (report-only, never fails — exit 0)
+confiture migrate validate --list-unmigrated-bodies --base-ref origin/main
+
+# 2. Drain it: add migrations that re-apply each listed function, or accept them
+#    into a baseline. Re-run step 1 until the list is empty.
+
+# 3. Enforce in CI (fails the build on a new un-migrated body change)
+confiture migrate validate --require-migration-bodies --base-ref origin/main
+```
+
+`--require-migration-bodies` implies `--require-migration` (it runs the full
+accompaniment check plus the body check). On violation it names each function,
+shows a unified diff of the change, and exits 1. JSON failures carry a
+`body_violations` array (`function_key`, `signature_key`, `unified_diff`); the
+report-only mode emits `{"check": "unmigrated_bodies", "count": N, ...}`.
+
 ## `--require-grant-migration`
 
 Build environments apply grants straight from the grant sweep directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.35.0"
+version = "0.36.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/drift.py
+++ b/python/confiture/cli/commands/drift.py
@@ -99,7 +99,7 @@ def drift(
       0 - No drift detected
       1 - Drift detected (critical, or warning when --fail-on-warning)
       3 - Database connection failed
-      4 - Schema file not found
+      4 - Schema file not found, or unparseable (declares tables but parsed zero)
       5 - Invalid configuration (missing --schema, bad --format, config errors)
 
     JSON SCHEMA:
@@ -210,6 +210,10 @@ def drift(
             SchemaError(str(e), error_code="SCHEMA_201"),
             json_mode=json_mode,
         )
+    except SchemaError as e:
+        # e.g. SCHEMA_202: the --schema file declares tables but parsed to zero
+        # (issue #175) — surface with its own code/exit, not as a config error.
+        fail(e, json_mode=json_mode)
     except Exception as e:
         fail(
             ConfigurationError(

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -340,14 +340,27 @@ def migrate_validate(
             "Honours --schemas and --ssh (with --scratch-url)."
         ),
     ),
+    check_body_replay: bool = typer.Option(
+        False,
+        "--check-body-replay",
+        help=(
+            "Detect out-of-band function/procedure hot-patches by REPLAY: rebuild the "
+            "expected database by replaying all migrations into a scratch DB, then diff "
+            "prosrc against live. Unlike --check-body (expected = source DDL, swamped by "
+            "the build-vs-migrate backlog), this reports only definitions no migration "
+            "produced — the clean production drift signal. Requires --config (or --env); "
+            "honours --schemas, --migrations-dir, --ssh (with --scratch-url). Heaviest "
+            "drift check (replays the full migration history)."
+        ),
+    ),
     scratch_url: str | None = typer.Option(
         None,
         "--scratch-url",
         help=(
             "Writable PostgreSQL server on which to build the expected scratch database "
-            "for --check-body-views (default: the live server from the config). Required "
-            "when using --ssh, since the scratch DB cannot be built on the remote "
-            "read-only live server."
+            "for --check-body-views / --check-body-replay (default: the live server from "
+            "the config). Required when using --ssh, since the scratch DB cannot be built "
+            "on the remote read-only live server."
         ),
     ),
     check_acls: bool = typer.Option(
@@ -709,9 +722,11 @@ def migrate_validate(
         if check_body and not check_signatures:
             raise ConfigurationError("--check-body requires --check-signatures")
 
-        # Guard: --show-diff requires --check-body or --check-body-views
-        if show_diff and not (check_body or check_body_views):
-            raise ConfigurationError("--show-diff requires --check-body or --check-body-views")
+        # Guard: --show-diff requires one of the body-drift checks
+        if show_diff and not (check_body or check_body_views or check_body_replay):
+            raise ConfigurationError(
+                "--show-diff requires --check-body, --check-body-views, or --check-body-replay"
+            )
 
         # Run ACL coverage check on migration files (static, no DB).
         if check_acls:
@@ -873,6 +888,32 @@ def migrate_validate(
             )
             if view_result.has_drift:
                 raise typer.Exit(1)  # success-signal: view drift found
+            return
+
+        # Run replay-based function-body drift check (clean hot-patch signal)
+        if check_body_replay:
+            from confiture.cli.formatters.validate_formatter import render_replay_drift
+            from confiture.core.validation.replay_drift import check_replay_drift
+
+            replay_result = check_replay_drift(
+                config_path=config,
+                migrations_dir=migrations_dir,
+                schemas=check_signature_schemas,
+                ssh_via=ssh_via,
+                scratch_url=scratch_url,
+            )
+            if not json_mode and replay_result.ssh_target:
+                console.print(
+                    f"[dim]  (connecting via SSH tunnel to {replay_result.ssh_target})[/dim]"
+                )
+            render_replay_drift(
+                replay_result.body_report,
+                json_mode=json_mode,
+                output_file=output_file,
+                show_diff=show_diff,
+            )
+            if replay_result.has_drift:
+                raise typer.Exit(1)  # success-signal: hot-patch drift found
             return
 
         if not migrations_dir.exists():

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -325,7 +325,29 @@ def migrate_validate(
             "With --check-body: also emit, per drifted function, the expected body, the "
             "live body, and a unified diff of the two (normalised) bodies. Requires "
             "--check-body. Opt-in because bodies can be large; the default output stays "
-            "hash-only for terse CI logs."
+            "hash-only for terse CI logs. Also applies to --check-body-views."
+        ),
+    ),
+    check_body_views: bool = typer.Option(
+        False,
+        "--check-body-views",
+        help=(
+            "Compare view and materialized-view definitions between the source schema "
+            "and the live database. The expected views are built into a scratch DB and "
+            "read back through the same pg_get_viewdef deparser as live, so only genuine "
+            "predicate/projection changes register (formatting, schema-qualification and "
+            "*-expansion differences do not). Requires --config (or --env) and --schema. "
+            "Honours --schemas and --ssh (with --scratch-url)."
+        ),
+    ),
+    scratch_url: str | None = typer.Option(
+        None,
+        "--scratch-url",
+        help=(
+            "Writable PostgreSQL server on which to build the expected scratch database "
+            "for --check-body-views (default: the live server from the config). Required "
+            "when using --ssh, since the scratch DB cannot be built on the remote "
+            "read-only live server."
         ),
     ),
     check_acls: bool = typer.Option(
@@ -687,9 +709,9 @@ def migrate_validate(
         if check_body and not check_signatures:
             raise ConfigurationError("--check-body requires --check-signatures")
 
-        # Guard: --show-diff requires --check-body
-        if show_diff and not check_body:
-            raise ConfigurationError("--show-diff requires --check-body")
+        # Guard: --show-diff requires --check-body or --check-body-views
+        if show_diff and not (check_body or check_body_views):
+            raise ConfigurationError("--show-diff requires --check-body or --check-body-views")
 
         # Run ACL coverage check on migration files (static, no DB).
         if check_acls:
@@ -822,6 +844,35 @@ def migrate_validate(
             )
             if sig_result.has_any_drift:
                 raise typer.Exit(1)  # success-signal: drift found
+            return
+
+        # Run live view / materialized-view body-drift check
+        if check_body_views:
+            from confiture.cli.formatters.validate_formatter import render_view_drift
+            from confiture.core.validation.view_drift import check_view_drift
+
+            view_result = check_view_drift(
+                config_path=config,
+                schema_file=schema_file,
+                schemas=check_signature_schemas,
+                ssh_via=ssh_via,
+                scratch_url=scratch_url,
+            )
+            if not json_mode:
+                if view_result.auto_built:
+                    console.print("[dim]  (schema auto-built from DDL files)[/dim]")
+                if view_result.ssh_target:
+                    console.print(
+                        f"[dim]  (connecting via SSH tunnel to {view_result.ssh_target})[/dim]"
+                    )
+            render_view_drift(
+                view_result.view_report,
+                json_mode=json_mode,
+                output_file=output_file,
+                show_diff=show_diff,
+            )
+            if view_result.has_drift:
+                raise typer.Exit(1)  # success-signal: view drift found
             return
 
         if not migrations_dir.exists():

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -246,6 +246,26 @@ def migrate_validate(
             "Companion to --check-signatures which detects stale overloads in a live DB."
         ),
     ),
+    require_migration_bodies: bool = typer.Option(
+        False,
+        "--require-migration-bodies",
+        help=(
+            "Additionally require a function/procedure BODY change (between --base-ref "
+            "and HEAD) to be carried by a migration that re-defines it (#178). Static, "
+            "no DB. Implies --require-migration. OFF by default — drain the standing "
+            "backlog first (see --list-unmigrated-bodies). The runtime counterpart is "
+            "--check-body-replay."
+        ),
+    ),
+    list_unmigrated_bodies: bool = typer.Option(
+        False,
+        "--list-unmigrated-bodies",
+        help=(
+            "Report-only: list function body changes (between --base-ref and HEAD) not "
+            "carried by a migration, WITHOUT failing (exit 0). Use to size and drain the "
+            "backlog before enabling --require-migration-bodies."
+        ),
+    ),
     base_ref: str = typer.Option(
         "origin/main",
         "--base-ref",
@@ -582,7 +602,28 @@ def migrate_validate(
         config = _resolve_config(config, env)
 
         # Handle git validation flags
-        if check_drift or require_migration or require_grant_migration or staged:
+        # Report-only backlog listing (#178) — never fails, exits 0.
+        if list_unmigrated_bodies:
+            from confiture.cli.git_validation import report_unmigrated_bodies
+
+            body_result = report_unmigrated_bodies(
+                env="local",
+                base_ref=since or base_ref,
+                target_ref="HEAD",
+                console=console,
+                format_output=format_output,
+            )
+            if json_mode:
+                _output_json({"check": "unmigrated_bodies", **body_result}, output_file, console)
+            return
+
+        if (
+            check_drift
+            or require_migration
+            or require_migration_bodies
+            or require_grant_migration
+            or staged
+        ):
             from confiture.cli.git_validation import (
                 validate_git_drift,
                 validate_git_flags_in_repo,
@@ -628,9 +669,9 @@ def migrate_validate(
                         )
                         raise typer.Exit(1)  # success-signal: drift found
 
-            # Run migration accompaniment check
+            # Run migration accompaniment check (--require-migration-bodies implies it)
             accompaniment_passed = True
-            if require_migration:
+            if require_migration or require_migration_bodies:
                 try:
                     acc_result = validate_migration_accompaniment(
                         env="local",
@@ -638,6 +679,7 @@ def migrate_validate(
                         target_ref=target_ref,
                         console=console,
                         format_output=format_output,
+                        check_bodies=require_migration_bodies,
                     )
                 except Exception as e:
                     raise GitError(f"Accompaniment check failed: {e}") from e
@@ -704,7 +746,7 @@ def migrate_validate(
                             c
                             for c, flag in [
                                 ("drift", check_drift),
-                                ("accompaniment", require_migration),
+                                ("accompaniment", require_migration or require_migration_bodies),
                                 ("grant_accompaniment", require_grant_migration),
                             ]
                             if flag

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -318,6 +318,16 @@ def migrate_validate(
             "signature-only comparison."
         ),
     ),
+    show_diff: bool = typer.Option(
+        False,
+        "--show-diff",
+        help=(
+            "With --check-body: also emit, per drifted function, the expected body, the "
+            "live body, and a unified diff of the two (normalised) bodies. Requires "
+            "--check-body. Opt-in because bodies can be large; the default output stays "
+            "hash-only for terse CI logs."
+        ),
+    ),
     check_acls: bool = typer.Option(
         False,
         "--check-acls",
@@ -677,6 +687,10 @@ def migrate_validate(
         if check_body and not check_signatures:
             raise ConfigurationError("--check-body requires --check-signatures")
 
+        # Guard: --show-diff requires --check-body
+        if show_diff and not check_body:
+            raise ConfigurationError("--show-diff requires --check-body")
+
         # Run ACL coverage check on migration files (static, no DB).
         if check_acls:
             from confiture.cli.formatters.validate_formatter import render_acl_coverage
@@ -804,6 +818,7 @@ def migrate_validate(
                 sig_result.body_report,
                 json_mode=json_mode,
                 output_file=output_file,
+                show_diff=show_diff,
             )
             if sig_result.has_any_drift:
                 raise typer.Exit(1)  # success-signal: drift found

--- a/python/confiture/cli/formatters/validate_formatter.py
+++ b/python/confiture/cli/formatters/validate_formatter.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from rich.markup import escape
+
 from confiture.cli.helpers import _output_json, console
 
 if TYPE_CHECKING:
@@ -177,7 +179,22 @@ def render_live_drift(report: Any, *, json_mode: bool, output_file: Path | None)
         display_drift_report(report, console)
 
 
-def _display_body_drift_report(report: Any) -> None:
+def _print_unified_diff(unified_diff: str) -> None:
+    """Print a unified diff with rich-highlighted +/- lines, indented."""
+    for line in unified_diff.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            color = "green"
+        elif line.startswith("-") and not line.startswith("---"):
+            color = "red"
+        elif line.startswith("@@"):
+            color = "cyan"
+        else:
+            color = "dim"
+        # Escape any Rich markup in the SQL so brackets aren't parsed as tags.
+        console.print(f"      [{color}]{escape(line)}[/{color}]")
+
+
+def _display_body_drift_report(report: Any, *, show_diff: bool = False) -> None:
     """Print a FunctionBodyDriftReport to the console in human-readable form."""
     if not report.has_drift:
         console.print(
@@ -195,6 +212,9 @@ def _display_body_drift_report(report: Any) -> None:
         console.print(f"\n  [bold]{drift.signature_key}[/bold]")
         console.print(f"    Source hash:   [cyan]{drift.source_hash}[/cyan]")
         console.print(f"    Database hash: [red]{drift.db_hash}[/red]")
+        if show_diff and drift.unified_diff:
+            console.print("    [dim]Unified diff (expected → live, normalised):[/dim]")
+            _print_unified_diff(drift.unified_diff)
         console.print(
             "    Hint: function body differs — run "
             "[bold]fix-signatures --apply[/bold] to re-apply from source"
@@ -207,8 +227,14 @@ def render_signature_drift(
     *,
     json_mode: bool,
     output_file: Path | None,
+    show_diff: bool = False,
 ) -> None:
-    """Render the ``--check-signatures`` (+ ``--check-body``) result."""
+    """Render the ``--check-signatures`` (+ ``--check-body``) result.
+
+    ``show_diff`` (from ``--show-diff``) surfaces each drifted function's bodies
+    and unified diff; when ``False`` the output stays hash-only for both JSON and
+    text — the historical, terse shape.
+    """
     from confiture.cli.formatters.common import display_signature_drift_report
 
     if json_mode:
@@ -217,23 +243,9 @@ def render_signature_drift(
             **drift_report.to_dict(),
         }
         if body_report is not None:
-            payload["body_drift"] = {
-                "has_drift": body_report.has_drift,
-                "body_drifts": [
-                    {
-                        "schema": d.schema,
-                        "name": d.name,
-                        "signature_key": d.signature_key,
-                        "source_hash": d.source_hash,
-                        "db_hash": d.db_hash,
-                    }
-                    for d in body_report.body_drifts
-                ],
-                "functions_checked": body_report.functions_checked,
-                "detection_time_ms": body_report.detection_time_ms,
-            }
+            payload["body_drift"] = body_report.to_dict(include_bodies=show_diff)
         _output_json(payload, output_file, console)
     else:
         display_signature_drift_report(drift_report, console)
         if body_report is not None:
-            _display_body_drift_report(body_report)
+            _display_body_drift_report(body_report, show_diff=show_diff)

--- a/python/confiture/cli/formatters/validate_formatter.py
+++ b/python/confiture/cli/formatters/validate_formatter.py
@@ -249,3 +249,51 @@ def render_signature_drift(
         display_signature_drift_report(drift_report, console)
         if body_report is not None:
             _display_body_drift_report(body_report, show_diff=show_diff)
+
+
+_RELKIND_LABEL = {"v": "view", "m": "materialized view"}
+
+
+def render_view_drift(
+    view_report: Any,
+    *,
+    json_mode: bool,
+    output_file: Path | None,
+    show_diff: bool = False,
+) -> None:
+    """Render the ``--check-body-views`` ViewBodyDriftReport.
+
+    ``show_diff`` (from ``--show-diff``) surfaces each drifted view's expected
+    and live definitions plus a unified diff; otherwise output stays hash-only.
+    """
+    if json_mode:
+        _output_json(
+            {"check": "view_body_drift", **view_report.to_dict(include_defs=show_diff)},
+            output_file,
+            console,
+        )
+        return
+
+    if not view_report.has_drift:
+        console.print(
+            f"[green]✓[/green] 0 view definition drift(s) detected "
+            f"({view_report.views_checked} checked, {view_report.detection_time_ms:.1f}ms)"
+        )
+        return
+
+    console.print(
+        f"[yellow]⚠[/yellow]  {len(view_report.body_drifts)} view definition "
+        f"drift(s) detected ({view_report.views_checked} checked)"
+    )
+    for drift in view_report.body_drifts:
+        label = _RELKIND_LABEL.get(drift.relkind, drift.relkind)
+        console.print(f"\n  [bold]{drift.schema}.{drift.name}[/bold] [dim]({label})[/dim]")
+        console.print(f"    Source hash:   [cyan]{drift.source_hash}[/cyan]")
+        console.print(f"    Database hash: [red]{drift.db_hash}[/red]")
+        if show_diff and drift.unified_diff:
+            console.print("    [dim]Unified diff (expected → live, deparsed):[/dim]")
+            _print_unified_diff(drift.unified_diff)
+        console.print(
+            "    Hint: view definition differs from source — re-apply the committed "
+            "DDL or capture the live change in a migration"
+        )

--- a/python/confiture/cli/formatters/validate_formatter.py
+++ b/python/confiture/cli/formatters/validate_formatter.py
@@ -251,6 +251,52 @@ def render_signature_drift(
             _display_body_drift_report(body_report, show_diff=show_diff)
 
 
+def render_replay_drift(
+    body_report: Any,
+    *,
+    json_mode: bool,
+    output_file: Path | None,
+    show_diff: bool = False,
+) -> None:
+    """Render the ``--check-body-replay`` FunctionBodyDriftReport.
+
+    Reuses the function-body report shape (Phase 3) but frames drifts as
+    out-of-band hot-patches — definitions live has but a clean migration replay
+    does not produce. ``show_diff`` surfaces the expected/live bodies + diff.
+    """
+    if json_mode:
+        _output_json(
+            {"check": "replay_body_drift", **body_report.to_dict(include_bodies=show_diff)},
+            output_file,
+            console,
+        )
+        return
+
+    if not body_report.has_drift:
+        console.print(
+            f"[green]✓[/green] 0 out-of-band hot-patch(es) detected "
+            f"({body_report.functions_checked} checked, {body_report.detection_time_ms:.1f}ms)"
+        )
+        return
+
+    console.print(
+        f"[yellow]⚠[/yellow]  {len(body_report.body_drifts)} out-of-band hot-patch(es) "
+        f"detected ({body_report.functions_checked} checked) — live differs from a clean "
+        f"migration replay"
+    )
+    for drift in body_report.body_drifts:
+        console.print(f"\n  [bold]{drift.signature_key}[/bold]")
+        console.print(f"    Replayed hash: [cyan]{drift.source_hash}[/cyan]")
+        console.print(f"    Database hash: [red]{drift.db_hash}[/red]")
+        if show_diff and drift.unified_diff:
+            console.print("    [dim]Unified diff (replayed → live, normalised):[/dim]")
+            _print_unified_diff(drift.unified_diff)
+        console.print(
+            "    Hint: no migration produced this body — capture the live change in a "
+            "migration, or re-apply the migration-produced definition"
+        )
+
+
 _RELKIND_LABEL = {"v": "view", "m": "materialized view"}
 
 

--- a/python/confiture/cli/git_validation.py
+++ b/python/confiture/cli/git_validation.py
@@ -93,6 +93,8 @@ def validate_migration_accompaniment(
     target_ref: str,
     console: Console,
     format_output: str = "text",
+    *,
+    check_bodies: bool = False,
 ) -> dict:
     """Validate that DDL changes have migration files.
 
@@ -102,6 +104,8 @@ def validate_migration_accompaniment(
         target_ref: Target git reference
         console: Rich console for output
         format_output: Output format (text or json)
+        check_bodies: Also require function *body* changes to be carried by a
+            migration (#178).
 
     Returns:
         Dictionary with validation results
@@ -114,7 +118,7 @@ def validate_migration_accompaniment(
         validate_git_flags_in_repo()
 
         checker = MigrationAccompanimentChecker(env)
-        report = checker.check_accompaniment(base_ref, target_ref)
+        report = checker.check_accompaniment(base_ref, target_ref, check_bodies=check_bodies)
 
         if format_output == "text":
             if report.migration_error:
@@ -125,7 +129,11 @@ def validate_migration_accompaniment(
                     "[yellow]   Schema may be too large for static analysis "
                     "— DDL accompaniment check was not run.[/yellow]"
                 )
-            elif not report.has_ddl_changes and not report.has_signature_violations:
+            elif (
+                not report.has_ddl_changes
+                and not report.has_signature_violations
+                and not report.has_body_violations
+            ):
                 console.print("[green]✅ No DDL changes detected[/green]")
             elif report.is_valid:
                 console.print("[green]✅ DDL changes accompanied by migrations[/green]")
@@ -148,6 +156,8 @@ def validate_migration_accompaniment(
                             f"     [yellow]Fix: add DROP FUNCTION {v.old_signature}; "
                             f"before CREATE OR REPLACE in a migration[/yellow]"
                         )
+                if report.body_violations:
+                    _render_body_violations(report.body_violations, console)
 
         return report.to_dict()
 
@@ -155,6 +165,53 @@ def validate_migration_accompaniment(
         if format_output == "text":
             console.print(f"[red]❌ Git validation error: {e}[/red]")
         raise
+
+
+def _render_body_violations(violations: list, console: Console) -> None:
+    """Print function body-change violations (#178) for human eyes."""
+    console.print("[red]❌ Function body changes detected without an accompanying migration[/red]")
+    for v in violations:
+        console.print(f"   • {v.signature_key}")
+        console.print(
+            f"     [yellow]Fix: add a migration with "
+            f"CREATE OR REPLACE FUNCTION {v.function_key}(...)[/yellow]"
+        )
+
+
+def report_unmigrated_bodies(
+    env: str,
+    base_ref: str,
+    target_ref: str,
+    console: Console,
+    format_output: str = "text",
+) -> dict:
+    """Report function body changes not carried by a migration — without failing.
+
+    The drain-first companion to ``--require-migration-bodies``: lists the body
+    changes between refs that lack a re-defining migration so a repo can size and
+    clear its backlog before turning enforcement on. Always non-failing.
+
+    Returns:
+        ``{"body_violations": [...], "count": N}``.
+    """
+    validate_git_flags_in_repo()
+
+    checker = MigrationAccompanimentChecker(env)
+    report = checker.check_accompaniment(base_ref, target_ref, check_bodies=True)
+    violations = report.body_violations
+
+    if format_output == "text":
+        if not violations:
+            console.print("[green]✅ No un-migrated function body changes[/green]")
+        else:
+            console.print(
+                f"[yellow]⚠ {len(violations)} function body change(s) not carried by a "
+                f"migration (report-only):[/yellow]"
+            )
+            for v in violations:
+                console.print(f"   • {v.signature_key}")
+
+    return {"body_violations": [v.to_dict() for v in violations], "count": len(violations)}
 
 
 def _render_grant_report(report, console: Console) -> None:

--- a/python/confiture/core/drift.py
+++ b/python/confiture/core/drift.py
@@ -6,14 +6,17 @@ to detect unauthorized changes or migration mishaps.
 
 import fnmatch
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 import psycopg
+import sqlparse
 
 from confiture.core.schema_analyzer import SchemaAnalyzer, SchemaInfo
+from confiture.exceptions import SchemaError
 
 if TYPE_CHECKING:
     from confiture.config.environment import (
@@ -439,62 +442,93 @@ class SchemaDriftDetector:
         report.expected_schema_source = f"file:{schema_file_path}"
         return report
 
+    # Dollar-quoted body: AS $tag$ ... $tag$ (group 1 closes the tag exactly).
+    # Stripped from the guard text so a dynamic `CREATE TABLE` inside a function
+    # body can't spuriously trip the zero-tables guard.
+    _DOLLAR_BODY_RE = re.compile(r"\$([^$]*)\$.*?\$\1\$", re.DOTALL)
+
     def _parse_schema_from_sql(self, sql: str) -> SchemaInfo:
         """Parse SQL DDL to extract schema information.
 
         This is a simplified parser that extracts table and column info
         from CREATE TABLE statements.
 
+        Comments are stripped up front: ``confiture build`` emits block-comment
+        file separators by default (and real schemas carry ``--`` line comments,
+        some non-ASCII), and ``sqlparse`` keeps a leading comment attached to the
+        statement that follows it — which the position-anchored ``CREATE TABLE``
+        match then never sees, yielding zero tables and 100 % false ``extra_table``
+        drift with exit 0 (issue #175).
+
         Args:
             sql: SQL DDL statements
 
         Returns:
             SchemaInfo extracted from SQL
+
+        Raises:
+            SchemaError: If the input clearly declares tables (contains a
+                top-level ``CREATE TABLE``) but none were parsed — a parser
+                failure surfaced loudly rather than as a silent empty expectation.
         """
-        import re
-
-        import sqlparse
-
         info = SchemaInfo()
 
-        # Parse CREATE TABLE statements
-        statements = sqlparse.parse(sql)
-        for stmt in statements:
+        # Strip comments before parsing so leading separators/comments can't hide
+        # the statement that follows them.  Dollar-quoted bodies are preserved.
+        stripped = sqlparse.format(sql, strip_comments=True)
+
+        for stmt in sqlparse.parse(stripped):
             stmt_str = str(stmt).strip()
             if not stmt_str:
                 continue
 
-            # Check for CREATE TABLE
-            match = re.match(
+            # Anchored match (not search): after comment stripping each statement
+            # starts with its keyword, so anchoring avoids matching a dynamic
+            # `CREATE TABLE` embedded inside a function body.
+            table_match = re.match(
                 r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:\")?(\w+)(?:\")?",
                 stmt_str,
                 re.IGNORECASE,
             )
-            if match:
-                table_name = match.group(1).lower()
+            if table_match:
+                table_name = table_match.group(1).lower()
                 columns = self._extract_columns_from_create(stmt_str)
                 info.tables[table_name] = columns
 
-            # Check for CREATE INDEX
-            match = re.match(
+            index_match = re.match(
                 r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?"
                 r"(?:IF\s+NOT\s+EXISTS\s+)?(?:\")?(\w+)(?:\")?\s+ON\s+(?:\")?(\w+)(?:\")?",
                 stmt_str,
                 re.IGNORECASE,
             )
-            if match:
-                index_name = match.group(1).lower()
-                table_name = match.group(2).lower()
+            if index_match:
+                index_name = index_match.group(1).lower()
+                table_name = index_match.group(2).lower()
                 if table_name not in info.indexes:
                     info.indexes[table_name] = []
                 info.indexes[table_name].append(index_name)
+
+        # Guard: input declares tables but we parsed none → parser failure, not an
+        # empty expectation.  Ignore CREATE TABLE occurrences inside function
+        # bodies so a helper that does dynamic DDL doesn't false-trigger it.
+        if not info.tables:
+            guard_text = self._DOLLAR_BODY_RE.sub("", stripped)
+            if re.search(r"\bCREATE\s+TABLE\b", guard_text, re.IGNORECASE):
+                raise SchemaError(
+                    "Parsed 0 tables from a schema that contains CREATE TABLE "
+                    "statement(s) — the expected-schema parser failed. Comparing "
+                    "against this would report every live table as spurious drift.",
+                    error_code="SCHEMA_202",
+                    resolution_hint=(
+                        "This is a confiture parser bug — please report the schema "
+                        "file. As a workaround, regenerate it or simplify the DDL."
+                    ),
+                )
 
         return info
 
     def _extract_columns_from_create(self, create_stmt: str) -> dict[str, dict]:
         """Extract column definitions from CREATE TABLE statement."""
-        import re
-
         columns: dict[str, dict] = {}
 
         # Find the column definitions between parentheses

--- a/python/confiture/core/expected_db.py
+++ b/python/confiture/core/expected_db.py
@@ -1,0 +1,212 @@
+"""Build an "expected" schema into a throwaway database for pg-normalised readback.
+
+The recurring need across the drift-guard features (view drift #174, replay drift
+#179, require-migration bodies #178) is: materialise the schema the repository
+*expects* into a scratch database, then read it back through PostgreSQL's own
+catalogs and deparser (``pg_get_viewdef``, ``pg_proc.prosrc``). Reading both the
+expected and the live side through the identical deparser makes string equality
+mean semantic equality — far more robust than text-normalising source DDL.
+
+This module packages that pattern once, as a context manager that yields a live
+connection to the scratch database, so each downstream feature runs its own
+readback query instead of re-implementing the scratch-DB lifecycle.
+
+Two build modes:
+
+* :meth:`ExpectedSchemaDB.from_source` — apply the expected DDL (built from the
+  ``db/schema`` files, or passed explicitly). This is the "build-from-DDL"
+  expectation used by view drift (#174).
+* :meth:`ExpectedSchemaDB.from_base_plus_migrations` — apply an optional base
+  schema, then replay every migration in ``migrations_dir`` via ``migrate up``.
+  This is the "migrate-strategy" expectation used by replay drift (#179) and
+  require-migration bodies (#178).
+
+The scratch database is always built on a **writable** maintenance server (given
+by ``server_url``) — usually local or CI, and *not necessarily* the production
+server whose live schema is being compared. The live (possibly remote,
+read-only) connection is the caller's concern and stays entirely separate.
+
+Usage::
+
+    with ExpectedSchemaDB(server_url, env="production").from_source() as conn:
+        viewdef = conn.execute(
+            "SELECT pg_get_viewdef('public.my_view'::regclass, true)"
+        ).fetchone()[0]
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import psycopg
+
+from confiture.core.temp_database import TempDatabase
+from confiture.exceptions import ConfigurationError, SchemaError
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from confiture.config.environment import Environment
+
+_MODE_SOURCE = "source"
+_MODE_MIGRATIONS = "migrations"
+
+
+class ExpectedSchemaDB:
+    """Context manager that builds the expected schema into a throwaway database.
+
+    Select a build mode with :meth:`from_source` or
+    :meth:`from_base_plus_migrations` (both return ``self`` for chaining), then
+    enter the context to receive a live :class:`psycopg.Connection` to the
+    scratch database. On exit the scratch database is dropped unconditionally
+    (delegated to :class:`~confiture.core.temp_database.TempDatabase`), even if
+    the build raised.
+
+    Args:
+        server_url: Writable PostgreSQL server URL. Its database component is
+            ignored — the scratch DB is created via the ``postgres`` maintenance
+            database (see :class:`TempDatabase`).
+        env: Environment name (or :class:`Environment`) used by
+            :class:`~confiture.core.builder.SchemaBuilder` when building the
+            expected DDL from ``db/schema`` files. Required for
+            :meth:`from_source` unless explicit ``schema_sql`` is supplied.
+        project_dir: Project root for :class:`SchemaBuilder` (defaults to cwd).
+        migrations_dir: Directory of migration files for the replay mode
+            (defaults to ``db/migrations``).
+        migration_table: Optional tracking-table override for the replay.
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        *,
+        env: str | Environment | None = None,
+        project_dir: Path | None = None,
+        migrations_dir: Path | None = None,
+        migration_table: str | None = None,
+    ) -> None:
+        self._server_url = server_url
+        self._env = env
+        self._project_dir = project_dir
+        self._migrations_dir = migrations_dir or Path("db") / "migrations"
+        self._migration_table = migration_table
+
+        self._mode: str | None = None
+        self._schema_sql: str | None = None
+        self._base_sql: str | None = None
+
+        self._stack: contextlib.ExitStack | None = None
+        self._td: TempDatabase | None = None
+        self._temp_url: str | None = None
+        self._conn: psycopg.Connection | None = None
+
+    # -- mode selection -------------------------------------------------- #
+
+    def from_source(self, *, schema_sql: str | None = None) -> ExpectedSchemaDB:
+        """Build the scratch DB from the expected DDL.
+
+        Args:
+            schema_sql: Explicit DDL to apply. When ``None``, the schema is built
+                from the configured ``env`` via :class:`SchemaBuilder`
+                (``schema_only=True``).
+        """
+        self._mode = _MODE_SOURCE
+        self._schema_sql = schema_sql
+        return self
+
+    def from_base_plus_migrations(self, *, base_sql: str | None = None) -> ExpectedSchemaDB:
+        """Build the scratch DB by replaying migrations.
+
+        Applies ``base_sql`` first (if given), then runs ``migrate up`` over
+        every migration in ``migrations_dir`` against the scratch DB. With
+        ``base_sql=None`` the scratch starts empty and the migrations build the
+        whole schema — the pure migrate-strategy expectation.
+
+        Args:
+            base_sql: Optional baseline DDL applied before the migration replay.
+        """
+        self._mode = _MODE_MIGRATIONS
+        self._base_sql = base_sql
+        return self
+
+    # -- context management ---------------------------------------------- #
+
+    def __enter__(self) -> psycopg.Connection:
+        if self._mode is None:
+            raise ConfigurationError(
+                "ExpectedSchemaDB: choose a build mode before entering the context.",
+                resolution_hint="Call .from_source() or .from_base_plus_migrations() first.",
+            )
+
+        self._stack = contextlib.ExitStack()
+        try:
+            # TempDatabase drops the scratch DB (WITH FORCE) when the stack closes.
+            self._td = TempDatabase(self._server_url)
+            self._temp_url = self._stack.enter_context(self._td)
+            self._build()
+            # Registered after TempDatabase → closed first on unwind (LIFO), so the
+            # connection is gone before the DROP DATABASE runs.
+            self._conn = self._stack.enter_context(psycopg.connect(self._temp_url, autocommit=True))
+        except BaseException:
+            # Any build/connect failure still tears down the scratch DB.
+            self._stack.close()
+            self._stack = None
+            self._td = None
+            raise
+        return self._conn
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self._stack is not None:
+            self._stack.close()
+            self._stack = None
+        self._td = None
+        self._conn = None
+        self._temp_url = None
+
+    # -- build strategies ------------------------------------------------ #
+
+    def _build(self) -> None:
+        assert self._td is not None and self._temp_url is not None  # set by __enter__
+        if self._mode == _MODE_SOURCE:
+            schema_sql = self._resolve_source_sql()
+            self._td.apply_schema(self._temp_url, schema_sql)
+        else:
+            if self._base_sql:
+                self._td.apply_schema(self._temp_url, self._base_sql)
+            self._replay_migrations()
+
+    def _resolve_source_sql(self) -> str:
+        if self._schema_sql is not None:
+            return self._schema_sql
+        if self._env is None:
+            raise ConfigurationError(
+                "ExpectedSchemaDB.from_source needs an env or explicit schema_sql.",
+                resolution_hint="Pass env= to the constructor or schema_sql= to from_source().",
+            )
+        from confiture.core.builder import SchemaBuilder
+
+        return SchemaBuilder(env=self._env, project_dir=self._project_dir).build(schema_only=True)
+
+    def _replay_migrations(self) -> None:
+        from confiture.core._migrator.session import MigratorSession
+
+        session = MigratorSession(
+            config=None,
+            migrations_dir=self._migrations_dir,
+            database_url_override=self._temp_url,
+            migration_table_override=self._migration_table,
+        )
+        with session:
+            result = session.up()
+        if not result.success:
+            raise SchemaError(
+                f"Migration replay into the scratch database failed: {result.errors}",
+                resolution_hint="Fix the failing migration, then retry the drift check.",
+            )

--- a/python/confiture/core/function_body_checker.py
+++ b/python/confiture/core/function_body_checker.py
@@ -1,0 +1,188 @@
+"""Check that function/procedure body changes include an accompanying migration.
+
+The signature sibling of this check (``FunctionSignatureChecker``) catches
+*parameter type* changes that need a ``DROP FUNCTION``. This one catches *body*
+changes: a function whose body was edited in the schema DDL (same signature)
+without a migration that re-applies it will run the old body in migrate-only
+environments (staging/production) — silent prod↔source drift.
+
+Like the signature checker, this is **git-based and static (no database)**: it
+compares bodies between ``base_ref`` and ``target_ref`` and requires the change
+to be carried by a migration that re-defines the function. The complementary
+*runtime* guarantee — that the migration actually produces the intended body — is
+provided by ``migrate validate --check-body-replay`` (#179).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import difflib
+from typing import TYPE_CHECKING
+
+from confiture.core.function_body_normalizer import FunctionBodyNormalizer
+from confiture.core.function_signature_parser import FunctionSignatureParser
+from confiture.exceptions import GitError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from confiture.core.function_signature_parser import FunctionSignature
+    from confiture.core.git import GitRepository
+
+
+@dataclasses.dataclass
+class FunctionBodyViolation:
+    """A function whose body changed with no accompanying migration.
+
+    Attributes:
+        function_key: ``"schema.name"`` (without params).
+        signature_key: Full signature, e.g. ``"public.calc(integer)"``.
+        migration_file: Always ``None`` (a carrying migration would clear the
+            violation); kept for shape-parity with ``FunctionSignatureViolation``.
+        message: Human-readable description.
+        unified_diff: Diff of the old vs new normalised body (for triage).
+    """
+
+    function_key: str
+    signature_key: str
+    migration_file: str | None
+    message: str
+    unified_diff: str
+
+    def to_dict(self) -> dict:
+        return {
+            "function_key": self.function_key,
+            "signature_key": self.signature_key,
+            "migration_file": self.migration_file,
+            "message": self.message,
+            "unified_diff": self.unified_diff,
+        }
+
+
+class FunctionBodyChecker:
+    """Check that function body changes are carried by a migration.
+
+    Args:
+        git_repo: GitRepository for reading file content at refs.
+        parser: FunctionSignatureParser (created if not provided).
+        normalizer: FunctionBodyNormalizer (created if not provided).
+    """
+
+    def __init__(
+        self,
+        git_repo: GitRepository,
+        parser: FunctionSignatureParser | None = None,
+        normalizer: FunctionBodyNormalizer | None = None,
+    ) -> None:
+        self._git = git_repo
+        self._parser = parser or FunctionSignatureParser()
+        self._normalizer = normalizer or FunctionBodyNormalizer()
+
+    def check(
+        self,
+        changed_sql_files: list[Path],
+        migration_file_paths: list[Path],
+        base_ref: str,
+        target_ref: str,
+    ) -> list[FunctionBodyViolation]:
+        """Return body-change violations for the changed SQL files.
+
+        Args:
+            changed_sql_files: SQL files that changed between refs.
+            migration_file_paths: New migration files in the changeset.
+            base_ref: Old git reference.
+            target_ref: New git reference.
+
+        Returns:
+            One violation per function whose body changed (same signature) with no
+            migration re-defining it. Empty if all body changes are carried.
+        """
+        carried = self._functions_redefined_by_migrations(migration_file_paths)
+        violations: list[FunctionBodyViolation] = []
+        for sql_file in changed_sql_files:
+            old = self._bodies_at_ref(sql_file, base_ref)
+            new = self._bodies_at_ref(sql_file, target_ref)
+            violations.extend(self._check_file(old, new, carried))
+        return violations
+
+    def _bodies_at_ref(
+        self, path: Path, ref: str
+    ) -> dict[str, tuple[FunctionSignature, str | None]]:
+        """Return ``{signature_key: (sig, body)}`` for functions in *path* at *ref*."""
+        try:
+            content = self._git.show_file_at_ref(path, ref)
+        except GitError:
+            return {}
+        if content is None:
+            return {}
+        return {
+            sig.signature_key(): (sig, body)
+            for sig, body in self._parser.parse_with_bodies(content)
+        }
+
+    def _check_file(
+        self,
+        old: dict[str, tuple[FunctionSignature, str | None]],
+        new: dict[str, tuple[FunctionSignature, str | None]],
+        carried: set[str],
+    ) -> list[FunctionBodyViolation]:
+        violations: list[FunctionBodyViolation] = []
+        for sigkey, (sig, new_body) in new.items():
+            if sigkey not in old:
+                continue  # new overload/function — not a body change
+            _old_sig, old_body = old[sigkey]
+            if old_body is None or new_body is None:
+                continue  # C/internal — no extractable body to compare
+            if self._normalizer.hash_body(old_body) == self._normalizer.hash_body(new_body):
+                continue  # body unchanged (modulo comments/whitespace/case)
+
+            fn_key = sig.function_key()
+            if fn_key in carried:
+                continue  # a migration re-defines this function
+
+            violations.append(
+                FunctionBodyViolation(
+                    function_key=fn_key,
+                    signature_key=sigkey,
+                    migration_file=None,
+                    message=(
+                        f"Function body change for {sigkey} detected between refs "
+                        f"but no migration re-defines it. Migrate-only environments "
+                        f"(staging/production) will keep running the old body. Add a "
+                        f"migration with CREATE OR REPLACE FUNCTION {fn_key}(...)."
+                    ),
+                    unified_diff=self._diff(sigkey, old_body, new_body),
+                )
+            )
+        return violations
+
+    def _diff(self, sigkey: str, old_body: str, new_body: str) -> str:
+        old_norm = self._normalizer.normalize_for_diff(old_body)
+        new_norm = self._normalizer.normalize_for_diff(new_body)
+        return "\n".join(
+            difflib.unified_diff(
+                old_norm.splitlines(),
+                new_norm.splitlines(),
+                fromfile=f"{sigkey} (committed)",
+                tofile=f"{sigkey} (working)",
+                lineterm="",
+            )
+        )
+
+    def _functions_redefined_by_migrations(self, migration_files: list[Path]) -> set[str]:
+        """Return the set of ``function_key`` re-defined by any migration file.
+
+        Reuses :meth:`FunctionSignatureParser.parse_with_bodies` so a
+        ``CREATE [OR REPLACE] FUNCTION`` in a ``.sql`` migration — or inside a
+        ``self.execute("…")`` string in a ``.py`` migration — is detected the same
+        way, with the same schema-qualification/quoting handling as the source.
+        """
+        carried: set[str] = set()
+        for mig_path in migration_files:
+            try:
+                content = mig_path.read_text()
+            except OSError:
+                continue
+            for sig, _body in self._parser.parse_with_bodies(content):
+                carried.add(sig.function_key())
+        return carried

--- a/python/confiture/core/function_body_drift.py
+++ b/python/confiture/core/function_body_drift.py
@@ -9,7 +9,9 @@ updating the corresponding source file.
 from __future__ import annotations
 
 import dataclasses
+import difflib
 import time
+from typing import Any
 
 from confiture.core.function_body_normalizer import FunctionBodyNormalizer
 
@@ -26,6 +28,12 @@ class FunctionBodyDrift:
         signature_key: Canonical key — ``"schema.name(type1,type2)"``.
         source_hash: 12-char hex of the normalised source body.
         db_hash: 12-char hex of the normalised live-DB body.
+        expected_body: Raw function body from the source SQL (verbatim).
+        live_body: Raw ``pg_proc.prosrc`` body from the live database (verbatim).
+        expected_normalized: Line-oriented normalised source body (diff basis).
+        live_normalized: Line-oriented normalised live body (diff basis).
+        unified_diff: ``difflib`` unified diff of the two normalised bodies —
+            empty when the bodies are not surfaced (e.g. constructed directly).
     """
 
     schema: str
@@ -33,6 +41,32 @@ class FunctionBodyDrift:
     signature_key: str
     source_hash: str
     db_hash: str
+    expected_body: str = ""
+    live_body: str = ""
+    expected_normalized: str = ""
+    live_normalized: str = ""
+    unified_diff: str = ""
+
+    def to_dict(self, *, include_bodies: bool = False) -> dict[str, Any]:
+        """Serialize this drift record.
+
+        Args:
+            include_bodies: When ``True``, add ``expected_body``, ``live_body``,
+                and ``unified_diff``. Defaults to ``False`` so the terse
+                hash-only shape (the historical CLI output) is preserved.
+        """
+        payload: dict[str, Any] = {
+            "schema": self.schema,
+            "name": self.name,
+            "signature_key": self.signature_key,
+            "source_hash": self.source_hash,
+            "db_hash": self.db_hash,
+        }
+        if include_bodies:
+            payload["expected_body"] = self.expected_body
+            payload["live_body"] = self.live_body
+            payload["unified_diff"] = self.unified_diff
+        return payload
 
 
 @dataclasses.dataclass
@@ -51,6 +85,20 @@ class FunctionBodyDriftReport:
     functions_checked: int
     has_drift: bool
     detection_time_ms: float
+
+    def to_dict(self, *, include_bodies: bool = False) -> dict[str, Any]:
+        """Serialize the report to the CLI's ``body_drift`` JSON shape.
+
+        Args:
+            include_bodies: Forwarded to each drift's :meth:`FunctionBodyDrift.to_dict`
+                so bodies/diff are emitted only when ``--show-diff`` is set.
+        """
+        return {
+            "has_drift": self.has_drift,
+            "body_drifts": [d.to_dict(include_bodies=include_bodies) for d in self.body_drifts],
+            "functions_checked": self.functions_checked,
+            "detection_time_ms": self.detection_time_ms,
+        }
 
 
 def _parse_schema_name(key: str) -> tuple[str, str]:
@@ -113,6 +161,17 @@ class FunctionBodyDriftDetector:
             live_hash = self._normalizer.hash_body(live)
             if src_hash != live_hash:
                 schema, name = _parse_schema_name(key)
+                exp_norm = self._normalizer.normalize_for_diff(src)
+                live_norm = self._normalizer.normalize_for_diff(live)
+                unified = "\n".join(
+                    difflib.unified_diff(
+                        exp_norm.splitlines(),
+                        live_norm.splitlines(),
+                        fromfile=f"{key} (expected)",
+                        tofile=f"{key} (live)",
+                        lineterm="",
+                    )
+                )
                 drifts.append(
                     FunctionBodyDrift(
                         schema=schema,
@@ -120,6 +179,11 @@ class FunctionBodyDriftDetector:
                         signature_key=key,
                         source_hash=src_hash,
                         db_hash=live_hash,
+                        expected_body=src,
+                        live_body=live,
+                        expected_normalized=exp_norm,
+                        live_normalized=live_norm,
+                        unified_diff=unified,
                     )
                 )
 

--- a/python/confiture/core/function_body_normalizer.py
+++ b/python/confiture/core/function_body_normalizer.py
@@ -53,6 +53,26 @@ class FunctionBodyNormalizer:
         collapsed = re.sub(r"\s+", " ", lowered).strip()
         return collapsed
 
+    def normalize_for_diff(self, body: str) -> str:
+        """Return a line-oriented normalised form of *body* for unified diffs.
+
+        Unlike :meth:`normalize` — which collapses everything to a single line
+        for hashing — this preserves newlines so :func:`difflib.unified_diff`
+        produces readable per-line output. Each surviving line is
+        comment-stripped, lowercased, has internal whitespace runs collapsed to
+        a single space, and is trimmed; blank lines are dropped. The result is
+        that pure-formatting churn (re-indentation, added blank lines, casing)
+        does not appear as diff noise — only genuine logic changes do.
+        """
+        stripped = self._TOKENIZER.sub(self._replace_token, body)
+        lowered = stripped.lower()
+        lines = []
+        for raw_line in lowered.splitlines():
+            collapsed = re.sub(r"\s+", " ", raw_line).strip()
+            if collapsed:
+                lines.append(collapsed)
+        return "\n".join(lines)
+
     def hash_body(self, body: str) -> str:
         """Return a 12-character hex digest of the normalised *body*.
 

--- a/python/confiture/core/function_signature_drift.py
+++ b/python/confiture/core/function_signature_drift.py
@@ -15,11 +15,41 @@ avoids false positives for built-ins, extensions, and unmanaged functions.
 from __future__ import annotations
 
 import dataclasses
+import re
 import time
 from collections import defaultdict
 from typing import Any
 
 from confiture.core.function_signature_parser import FunctionSignature
+
+# Trailing array suffix (one or more '[]', possibly sized) used to compare two
+# param types ignoring array-ness — see the defensive guard in ``compare``.
+_ARRAY_SUFFIX_RE = re.compile(r"(?:\s*\[\s*\d*\s*\])+\s*$")
+
+
+def _strip_array(param_type: str) -> str:
+    """Return ``param_type`` with any trailing array suffix removed."""
+    return _ARRAY_SUFFIX_RE.sub("", param_type).strip()
+
+
+def _array_only_difference(
+    stale_params: tuple[str, ...], source_param_sets: set[tuple[str, ...]]
+) -> bool:
+    """True when a source signature of equal arity matches ``stale_params`` after
+    stripping array suffixes from both sides.
+
+    Guards against a normalisation gap emitting a destructive ``DROP FUNCTION``
+    for a function that plainly exists in source, differing only by an array
+    suffix (issue #176).  Conservative by design: suppressing a genuine
+    scalar/array overload is non-destructive, whereas dropping a live function is
+    catastrophic.
+    """
+    stale_base = tuple(_strip_array(p) for p in stale_params)
+    return any(
+        len(source_params) == len(stale_params)
+        and tuple(_strip_array(p) for p in source_params) == stale_base
+        for source_params in source_param_sets
+    )
 
 
 @dataclasses.dataclass
@@ -149,6 +179,10 @@ class FunctionSignatureDriftDetector:
                 continue
             stale_param_sets = live_by_fn[fn_key] - source_param_sets
             for stale_params in sorted(stale_param_sets):
+                # Never emit a destructive DROP for a base-name + arity match that
+                # differs only by an array suffix (issue #176 safety net).
+                if _array_only_difference(stale_params, source_param_sets):
+                    continue
                 schema, name = fn_key.split(".", 1)
                 stale_overloads.append(
                     StaleOverload(

--- a/python/confiture/core/function_signature_parser.py
+++ b/python/confiture/core/function_signature_parser.py
@@ -156,6 +156,13 @@ class FunctionSignatureParser:
                         type_str = ".".join(n.sval for n in names if hasattr(n, "sval"))
                         if type_str.startswith("pg_catalog."):
                             type_str = type_str[len("pg_catalog.") :]
+                        # pglast records array-ness in arrayBounds (one entry per
+                        # dimension, -1 = unbounded), NOT in names.  Append a '[]'
+                        # per dimension so array types survive normalisation and
+                        # stay symmetric with the introspected live side (#176).
+                        array_bounds = getattr(arg_type, "arrayBounds", None)
+                        if array_bounds:
+                            type_str += "[]" * len(array_bounds)
                         param_types.append(self._normalise_type(type_str))
 
                 result.append(
@@ -347,6 +354,11 @@ class FunctionSignatureParser:
 
         return result
 
+    # Trailing array suffix: one or more '[]' groups, each optionally sized
+    # (e.g. 'text[]', 'int[][]', 'text[5]').  PostgreSQL ignores the size, so we
+    # canonicalise every dimension to bare '[]'.
+    _ARRAY_SUFFIX_RE = re.compile(r"(?:\s*\[\s*\d*\s*\])+\s*$")
+
     def _normalise_type(self, raw: str) -> str:
         """Normalise a PostgreSQL type name to a canonical form.
 
@@ -355,10 +367,25 @@ class FunctionSignatureParser:
             'BIGINT' -> 'bigint'
             'pg_catalog.int4' -> 'integer'
             'VARCHAR(255)' -> 'character varying'
+            'int4[]' -> 'integer[]'
+            'numeric(10,2)[]' -> 'numeric[]'
+
+        The array suffix is split off first so the *base* type is aliased and the
+        canonical ``[]`` re-appended per dimension.  This keeps the source side
+        symmetric with the live side (which introspects ``format_type`` output
+        such as ``integer[]``); without it, array params falsely read as stale
+        overloads and generate a destructive ``DROP FUNCTION`` (issue #176).
         """
         clean = raw.lower().strip()
         if clean.startswith("pg_catalog."):
             clean = clean[len("pg_catalog.") :]
+        # Split off a trailing array suffix so the base can be aliased.
+        array_dims = 0
+        suffix_match = self._ARRAY_SUFFIX_RE.search(clean)
+        if suffix_match:
+            array_dims = suffix_match.group(0).count("[")
+            clean = clean[: suffix_match.start()].strip()
         # Strip precision/scale: varchar(255) -> varchar
         clean = re.sub(r"\([^)]*\)", "", clean).strip()
-        return _TYPE_ALIASES.get(clean, clean)
+        base = _TYPE_ALIASES.get(clean, clean)
+        return base + "[]" * array_dims

--- a/python/confiture/core/git_accompaniment.py
+++ b/python/confiture/core/git_accompaniment.py
@@ -49,7 +49,7 @@ class MigrationAccompanimentChecker:
         self.differ = GitSchemaDiffer(env, self.repo_path)
 
     def check_accompaniment(
-        self, base_ref: str, target_ref: str = "HEAD"
+        self, base_ref: str, target_ref: str = "HEAD", *, check_bodies: bool = False
     ) -> MigrationAccompanimentReport:
         """Check if DDL changes are accompanied by migrations.
 
@@ -61,6 +61,9 @@ class MigrationAccompanimentChecker:
         Args:
             base_ref: Base git reference (e.g., "origin/main")
             target_ref: Target git reference (default "HEAD")
+            check_bodies: Also flag function *body* changes not carried by a
+                migration (#178). Off by default — opt-in via
+                ``--require-migration-bodies``.
 
         Returns:
             MigrationAccompanimentReport with validation results
@@ -99,6 +102,13 @@ class MigrationAccompanimentChecker:
             new_migrations, base_ref, target_ref
         )
 
+        # Check function body violations (body edits need a re-defining migration)
+        body_violations = (
+            self._check_body_violations(new_migrations, base_ref, target_ref)
+            if check_bodies
+            else []
+        )
+
         return MigrationAccompanimentReport(
             has_ddl_changes=has_ddl_changes,
             has_new_migrations=len(new_migrations) > 0,
@@ -107,6 +117,7 @@ class MigrationAccompanimentChecker:
             base_ref=base_ref,
             target_ref=target_ref,
             signature_violations=signature_violations,
+            body_violations=body_violations,
         )
 
     def _check_signature_violations(
@@ -134,6 +145,33 @@ class MigrationAccompanimentChecker:
             )
         except Exception:
             # Signature check is best-effort — never block CI on unexpected errors
+            return []
+
+    def _check_body_violations(
+        self,
+        new_migrations: list[Path],
+        base_ref: str,
+        target_ref: str,
+    ) -> list:
+        """Return function body violations for changed function files (#178)."""
+        try:
+            function_files = self._get_changed_function_files(base_ref, target_ref)
+            if not function_files:
+                return []
+
+            from confiture.core.function_body_checker import (
+                FunctionBodyChecker,  # noqa: PLC0415
+            )
+
+            checker = FunctionBodyChecker(self.git_repo)
+            return checker.check(
+                changed_sql_files=function_files,
+                migration_file_paths=new_migrations,
+                base_ref=base_ref,
+                target_ref=target_ref,
+            )
+        except Exception:
+            # Body check is best-effort — never block CI on unexpected errors.
             return []
 
     def _get_changed_function_files(self, base_ref: str, target_ref: str) -> list[Path]:

--- a/python/confiture/core/live_view_catalog.py
+++ b/python/confiture/core/live_view_catalog.py
@@ -1,0 +1,72 @@
+"""Query live view (and materialized-view) definitions from a database.
+
+Enumerates ``pg_class`` relations of kind ``'v'`` (view) and ``'m'`` (materialized
+view) in the requested schemas and returns each one's deparsed definition via
+``pg_get_viewdef(oid, true)``. The same catalog is run against both the scratch
+"expected" database and the live database so both sides pass through the identical
+deparser — see :mod:`confiture.core.view_body_drift`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from confiture.core.view_body_drift import ViewDefinition
+
+if TYPE_CHECKING:
+    import psycopg
+
+# One round-trip: enumerate views/matviews in the target schemas and deparse each.
+_VIEW_DEFS_SQL = """\
+SELECT n.nspname AS schema,
+       c.relname AS name,
+       c.relkind::text AS relkind,
+       pg_get_viewdef(c.oid, true) AS definition
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind IN ('v', 'm')
+  AND n.nspname = ANY(%(schemas)s)
+ORDER BY n.nspname, c.relname
+"""
+
+
+class LiveViewCatalog:
+    """Read view/matview definitions from an open connection.
+
+    Args:
+        connection: An open psycopg connection to the target database (live or
+            the scratch expected DB).
+
+    Example::
+
+        catalog = LiveViewCatalog(conn)
+        defs = catalog.get_view_definitions(["public", "catalog"])
+        # {"public.v_orders": ViewDefinition(...), ...}
+    """
+
+    def __init__(self, connection: psycopg.Connection) -> None:
+        self._conn = connection
+
+    def get_view_definitions(self, schemas: list[str] | None = None) -> dict[str, ViewDefinition]:
+        """Return ``view_key`` → :class:`ViewDefinition` for the given schemas.
+
+        Args:
+            schemas: Schema names to enumerate (default: ``["public"]``).
+
+        Returns:
+            A dict keyed by ``"schema.name"``. Both regular views (``relkind
+            'v'``) and materialized views (``relkind 'm'``) are included.
+        """
+        schemas = schemas or ["public"]
+        result: dict[str, ViewDefinition] = {}
+        for schema, name, relkind, definition in self._conn.execute(
+            _VIEW_DEFS_SQL, {"schemas": schemas}
+        ).fetchall():
+            view = ViewDefinition(
+                schema=schema,
+                name=name,
+                relkind=relkind,
+                definition=definition,
+            )
+            result[view.view_key] = view
+        return result

--- a/python/confiture/core/temp_database.py
+++ b/python/confiture/core/temp_database.py
@@ -19,20 +19,39 @@ from confiture.core.url_redaction import libpq_env, split_password
 from confiture.exceptions import SchemaError
 
 
+def _rebuild_with_path(server_url: str, path: str) -> str:
+    """Return *server_url* with its path replaced by *path*.
+
+    ``urlunparse`` drops the ``//`` authority marker when the netloc is empty
+    (``postgresql:///db`` round-trips to the malformed ``postgresql:/db``), which
+    breaks hostless socket DSNs. Restore the marker so libpq still accepts the
+    result. Host-qualified URLs are unaffected — ``urlunparse`` already emits
+    ``//`` for a non-empty netloc.
+    """
+    parsed = urlparse(server_url)
+    rebuilt = urlunparse(parsed._replace(path=path))
+    scheme_prefix = f"{parsed.scheme}:"
+    if (
+        parsed.scheme
+        and rebuilt.startswith(scheme_prefix)
+        and not rebuilt.startswith(f"{parsed.scheme}://")
+    ):
+        rebuilt = f"{parsed.scheme}://" + rebuilt[len(scheme_prefix) :]
+    return rebuilt
+
+
 def _maintenance_url(server_url: str) -> str:
     """Replace the database component of *server_url* with ``postgres``.
 
     The maintenance DB is used to issue ``CREATE DATABASE`` / ``DROP DATABASE``
     since the user's target database may not exist yet.
     """
-    parsed = urlparse(server_url)
-    return urlunparse(parsed._replace(path="/postgres"))
+    return _rebuild_with_path(server_url, "/postgres")
 
 
 def _replace_dbname(server_url: str, dbname: str) -> str:
     """Return *server_url* with its database component replaced by *dbname*."""
-    parsed = urlparse(server_url)
-    return urlunparse(parsed._replace(path=f"/{dbname}"))
+    return _rebuild_with_path(server_url, f"/{dbname}")
 
 
 def terminate_backends(conn: psycopg.Connection, db_name: str) -> None:

--- a/python/confiture/core/validation/replay_drift.py
+++ b/python/confiture/core/validation/replay_drift.py
@@ -1,0 +1,111 @@
+"""``migrate validate --check-body-replay`` logic.
+
+Provides the *replay-based* function-body drift signal (#179): rebuild the
+expected database deterministically by replaying base + all migrations into a
+throwaway scratch DB, then diff ``pg_proc.prosrc`` against live. The difference
+is exactly the definitions no migration produced — true out-of-band hot-patches.
+
+Unlike ``--check-body`` (whose expected side is built from source DDL and is thus
+dominated by the build-vs-migrate backlog), this path builds the expected side
+from ``ExpectedSchemaDB.from_base_plus_migrations()``. Both sides are real
+databases introspected identically via :class:`LiveFunctionCatalog`, so the
+signature pairing is exact — this sidesteps the text-parse asymmetry class of bug
+(#176) entirely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from confiture.core.connection import load_config, open_connection
+from confiture.core.validation.signature_drift import _ssh_override
+from confiture.core.validation.view_drift import _config_database_url
+from confiture.exceptions import ConfigurationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
+
+    from confiture.core.function_body_drift import FunctionBodyDriftReport
+
+
+@dataclass
+class ReplayDriftResult:
+    """Outcome of a replay-based body-drift check.
+
+    ``ssh_target`` is a progress signal the caller renders as a text-mode hint.
+    """
+
+    body_report: FunctionBodyDriftReport
+    ssh_target: str | None
+
+    @property
+    def has_drift(self) -> bool:
+        return self.body_report.has_drift
+
+
+def check_replay_drift(
+    *,
+    config_path: Path,
+    migrations_dir: Path,
+    schemas: str,
+    ssh_via: str | None,
+    scratch_url: str | None = None,
+) -> ReplayDriftResult:
+    """Detect function-body drift between live and a fresh migration replay.
+
+    Builds the expected database by replaying every migration in
+    ``migrations_dir`` into a scratch DB on ``scratch_url`` (default: the live
+    server from the config), then compares live ``prosrc`` against it.
+
+    Args:
+        config_path: Config file resolving the live database connection.
+        migrations_dir: Directory of migration files to replay.
+        schemas: Comma-separated DB schema names to scan (e.g. ``"public,auth"``).
+        ssh_via: Optional ``user@host`` SSH tunnel for the *live* connection.
+        scratch_url: Writable server on which to replay the migrations. Required
+            when ``ssh_via`` is set.
+
+    Raises:
+        ConfigurationError: config missing, or ``--ssh`` without ``--scratch-url``.
+        SchemaError: a migration failed during replay (surfaced, not treated as
+            false drift).
+    """
+    from confiture.core.expected_db import ExpectedSchemaDB
+    from confiture.core.function_body_drift import FunctionBodyDriftDetector
+    from confiture.core.live_function_catalog import LiveFunctionCatalog
+
+    if not config_path.exists():
+        raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
+
+    config_data = load_config(config_path)
+    schema_list = [s.strip() for s in schemas.split(",") if s.strip()]
+
+    effective_config: Any = config_data
+    if ssh_via:
+        effective_config = _ssh_override(config_data, ssh_via)
+        if scratch_url is None:
+            raise ConfigurationError(
+                "--check-body-replay over --ssh requires --scratch-url: the migrations "
+                "are replayed on a writable local server, not the remote read-only live "
+                "server.",
+                resolution_hint="Pass --scratch-url postgresql://localhost/postgres (or a CI server).",
+            )
+
+    scratch = scratch_url or _config_database_url(config_data)
+    if not scratch:
+        raise ConfigurationError(
+            "Cannot determine a scratch server URL for the migration replay.",
+            resolution_hint="Set database_url in the config or pass --scratch-url.",
+        )
+
+    with open_connection(effective_config) as live_conn:
+        live_bodies = LiveFunctionCatalog(live_conn).get_bodies(schemas=schema_list)
+        with ExpectedSchemaDB(
+            scratch, migrations_dir=migrations_dir
+        ).from_base_plus_migrations() as scratch_conn:
+            replayed_bodies = LiveFunctionCatalog(scratch_conn).get_bodies(schemas=schema_list)
+        body_report = FunctionBodyDriftDetector().compare(replayed_bodies, live_bodies)
+
+    return ReplayDriftResult(body_report=body_report, ssh_target=ssh_via)

--- a/python/confiture/core/validation/view_drift.py
+++ b/python/confiture/core/validation/view_drift.py
@@ -1,0 +1,121 @@
+"""``migrate validate --check-body-views`` logic.
+
+Detects when a live view's (or materialized view's) definition has drifted from
+the committed DDL. Views are not stored verbatim, so both the expected and live
+sides are read through the identical ``pg_get_viewdef`` deparser: the expected
+side is built into a scratch database (:class:`ExpectedSchemaDB`) and read back
+there, the live side is read from the target connection. See
+:mod:`confiture.core.view_body_drift`.
+
+Reuses ``_resolve_source_sql`` / ``_ssh_override`` from :mod:`signature_drift`
+so the source-resolution and SSH-tunnel behaviour matches ``--check-signatures``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from confiture.core.connection import load_config, open_connection
+from confiture.core.validation.signature_drift import _resolve_source_sql, _ssh_override
+from confiture.exceptions import ConfigurationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from confiture.core.view_body_drift import ViewBodyDriftReport
+
+
+@dataclass
+class ViewDriftResult:
+    """Outcome of a view body-drift check.
+
+    ``auto_built`` / ``ssh_target`` are progress signals the caller renders as
+    text-mode hints; they carry no bearing on the gate decision.
+    """
+
+    view_report: ViewBodyDriftReport
+    auto_built: bool
+    ssh_target: str | None
+
+    @property
+    def has_drift(self) -> bool:
+        return self.view_report.has_drift
+
+
+def _config_database_url(config_data: Any) -> str | None:
+    if hasattr(config_data, "database_url"):
+        return config_data.database_url  # type: ignore[no-any-return]
+    if isinstance(config_data, dict):
+        return config_data.get("database_url")
+    return None
+
+
+def check_view_drift(
+    *,
+    config_path: Path,
+    schema_file: Path | None,
+    schemas: str,
+    ssh_via: str | None,
+    scratch_url: str | None = None,
+) -> ViewDriftResult:
+    """Detect view definition drift against the live database.
+
+    The expected views are built into a scratch database on ``scratch_url``
+    (default: the live server from the config) and read back through
+    ``pg_get_viewdef`` so both sides normalise identically.
+
+    Args:
+        config_path: Config file resolving the live database connection.
+        schema_file: Explicit source schema SQL; auto-built from DDL if ``None``.
+        schemas: Comma-separated DB schema names to scan (e.g. ``"public,catalog"``).
+        ssh_via: Optional ``user@host`` SSH tunnel for the *live* connection.
+        scratch_url: Writable server on which to build the expected scratch DB.
+            Required when ``ssh_via`` is set (the scratch DB cannot be built on a
+            remote read-only live server through the tunnel).
+
+    Raises:
+        ConfigurationError: config missing, auto-build failed, or ``--ssh`` was
+            used without ``--scratch-url``.
+    """
+    from confiture.core.expected_db import ExpectedSchemaDB
+    from confiture.core.live_view_catalog import LiveViewCatalog
+    from confiture.core.view_body_drift import ViewBodyDriftDetector
+
+    if not config_path.exists():
+        raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
+
+    config_data = load_config(config_path)
+    schema_list = [s.strip() for s in schemas.split(",") if s.strip()]
+
+    source_sql, auto_built = _resolve_source_sql(config_data, schema_file)
+
+    effective_config: Any = config_data
+    if ssh_via:
+        effective_config = _ssh_override(config_data, ssh_via)
+        if scratch_url is None:
+            raise ConfigurationError(
+                "--check-body-views over --ssh requires --scratch-url: the scratch "
+                "database is built on a writable local server, not the remote "
+                "read-only live server.",
+                resolution_hint="Pass --scratch-url postgresql://localhost/postgres (or a CI server).",
+            )
+
+    scratch = scratch_url or _config_database_url(config_data)
+    if not scratch:
+        raise ConfigurationError(
+            "Cannot determine a scratch server URL for building the expected views.",
+            resolution_hint="Set database_url in the config or pass --scratch-url.",
+        )
+
+    with open_connection(effective_config) as live_conn:
+        live_defs = LiveViewCatalog(live_conn).get_view_definitions(schema_list)
+        with ExpectedSchemaDB(scratch).from_source(schema_sql=source_sql) as scratch_conn:
+            src_defs = LiveViewCatalog(scratch_conn).get_view_definitions(schema_list)
+        view_report = ViewBodyDriftDetector().compare(src_defs, live_defs)
+
+    return ViewDriftResult(
+        view_report=view_report,
+        auto_built=auto_built,
+        ssh_target=ssh_via,
+    )

--- a/python/confiture/core/view_body_drift.py
+++ b/python/confiture/core/view_body_drift.py
@@ -1,0 +1,210 @@
+"""View (and materialized-view) body-drift detection.
+
+Compares view definitions between the committed source schema and the live
+database, detecting a view whose predicate/projection was changed directly in
+the database without updating the DDL.
+
+Unlike functions — whose ``pg_proc.prosrc`` is stored verbatim — a view's
+definition is not stored as text: PostgreSQL keeps the parsed query tree and
+``pg_get_viewdef(oid, true)`` returns a *deparsed* rendering (schema-qualified,
+``*``-expanded, reparenthesised, alias-normalised). Text-normalising the source
+``CREATE VIEW`` against that deparsed live form yields false positives on
+semantically-identical views.
+
+The fix (see :mod:`confiture.core.expected_db`): build the expected views into a
+scratch database and run the **same** ``pg_get_viewdef(oid, true)`` there, then
+compare the two deparsed strings. Both sides pass through pg's identical deparser,
+so string equality is semantic equality. This detector therefore takes the
+already-deparsed definitions from both sides and needs only trivial
+normalisation (trailing-whitespace trim) before comparing — aggressive
+normalisation is unnecessary and could mask real drift.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import difflib
+import hashlib
+import time
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True)
+class ViewDefinition:
+    """A deparsed view definition, from either the scratch or the live DB.
+
+    Attributes:
+        schema: PostgreSQL schema name.
+        name: View (or materialized view) name.
+        relkind: ``'v'`` for a regular view, ``'m'`` for a materialized view.
+        definition: ``pg_get_viewdef(oid, true)`` output (pretty-printed).
+    """
+
+    schema: str
+    name: str
+    relkind: str
+    definition: str
+
+    @property
+    def view_key(self) -> str:
+        """Canonical key — ``"schema.name"``."""
+        return f"{self.schema}.{self.name}"
+
+
+@dataclasses.dataclass(frozen=True)
+class ViewBodyDrift:
+    """A single view whose deparsed definition differs between source and DB.
+
+    Attributes:
+        schema: PostgreSQL schema name.
+        name: View name.
+        relkind: ``'v'`` (view) or ``'m'`` (materialized view).
+        source_hash: 12-char hex of the normalised expected definition.
+        db_hash: 12-char hex of the normalised live definition.
+        expected_def: Deparsed expected definition (from the scratch DB).
+        live_def: Deparsed live definition.
+        unified_diff: ``difflib`` unified diff of the two definitions — empty when
+            the definitions are not surfaced (e.g. constructed directly).
+    """
+
+    schema: str
+    name: str
+    relkind: str
+    source_hash: str
+    db_hash: str
+    expected_def: str = ""
+    live_def: str = ""
+    unified_diff: str = ""
+
+    def to_dict(self, *, include_defs: bool = False) -> dict[str, Any]:
+        """Serialize this drift record.
+
+        Args:
+            include_defs: When ``True``, add ``expected_def``, ``live_def``, and
+                ``unified_diff``. Defaults to ``False`` so the terse hash-only
+                shape matches ``--check-body``'s default output.
+        """
+        payload: dict[str, Any] = {
+            "schema": self.schema,
+            "name": self.name,
+            "relkind": self.relkind,
+            "source_hash": self.source_hash,
+            "db_hash": self.db_hash,
+        }
+        if include_defs:
+            payload["expected_def"] = self.expected_def
+            payload["live_def"] = self.live_def
+            payload["unified_diff"] = self.unified_diff
+        return payload
+
+
+@dataclasses.dataclass
+class ViewBodyDriftReport:
+    """Summary of the view body-drift comparison run.
+
+    Attributes:
+        body_drifts: Views whose normalised definition differs.
+        views_checked: Number of views compared (intersection of source and live
+            keys).
+        has_drift: ``True`` iff at least one view drift was detected.
+        detection_time_ms: Wall-clock time of the comparison in milliseconds.
+    """
+
+    body_drifts: list[ViewBodyDrift]
+    views_checked: int
+    has_drift: bool
+    detection_time_ms: float
+
+    def to_dict(self, *, include_defs: bool = False) -> dict[str, Any]:
+        """Serialize the report to the CLI's ``view_drift`` JSON shape."""
+        return {
+            "has_drift": self.has_drift,
+            "body_drifts": [d.to_dict(include_defs=include_defs) for d in self.body_drifts],
+            "views_checked": self.views_checked,
+            "detection_time_ms": self.detection_time_ms,
+        }
+
+
+def _normalize_viewdef(definition: str) -> str:
+    """Trim trailing whitespace per line and surrounding blank lines.
+
+    Both sides are already deparsed by the identical ``pg_get_viewdef`` call, so
+    only cosmetic trailing-whitespace differences (rare) need suppressing. No
+    lowercasing or internal-whitespace collapse — that could mask genuine drift.
+    """
+    return "\n".join(line.rstrip() for line in definition.strip().splitlines())
+
+
+def _hash_viewdef(definition: str) -> str:
+    """Return a 12-char hex digest of the normalised *definition*."""
+    return hashlib.sha256(_normalize_viewdef(definition).encode()).hexdigest()[:12]
+
+
+class ViewBodyDriftDetector:
+    """Compare deparsed view definitions between the expected and live schema.
+
+    Usage::
+
+        detector = ViewBodyDriftDetector()
+        report = detector.compare(source_defs, live_defs)
+        for drift in report.body_drifts:
+            print(f"{drift.schema}.{drift.name}", drift.unified_diff)
+    """
+
+    def compare(
+        self,
+        source_defs: dict[str, ViewDefinition],
+        live_defs: dict[str, ViewDefinition],
+    ) -> ViewBodyDriftReport:
+        """Detect definition drift for all views present in both dicts.
+
+        Only the *intersection* of keys is compared. Views present only on one
+        side (added/removed) are outside this detector's scope.
+
+        Args:
+            source_defs: Mapping of ``view_key`` → expected :class:`ViewDefinition`
+                (read back from the scratch DB, deparsed).
+            live_defs: Mapping of ``view_key`` → live :class:`ViewDefinition`.
+
+        Returns:
+            A :class:`ViewBodyDriftReport` with drift details and timing.
+        """
+        start = time.monotonic()
+        common_keys = set(source_defs) & set(live_defs)
+        drifts: list[ViewBodyDrift] = []
+
+        for key in sorted(common_keys):
+            src = source_defs[key]
+            live = live_defs[key]
+            src_norm = _normalize_viewdef(src.definition)
+            live_norm = _normalize_viewdef(live.definition)
+            if src_norm != live_norm:
+                unified = "\n".join(
+                    difflib.unified_diff(
+                        src_norm.splitlines(),
+                        live_norm.splitlines(),
+                        fromfile=f"{key} (expected)",
+                        tofile=f"{key} (live)",
+                        lineterm="",
+                    )
+                )
+                drifts.append(
+                    ViewBodyDrift(
+                        schema=live.schema,
+                        name=live.name,
+                        relkind=live.relkind,
+                        source_hash=_hash_viewdef(src.definition),
+                        db_hash=_hash_viewdef(live.definition),
+                        expected_def=src.definition,
+                        live_def=live.definition,
+                        unified_diff=unified,
+                    )
+                )
+
+        elapsed = (time.monotonic() - start) * 1000
+        return ViewBodyDriftReport(
+            body_drifts=drifts,
+            views_checked=len(common_keys),
+            has_drift=len(drifts) > 0,
+            detection_time_ms=elapsed,
+        )

--- a/python/confiture/models/git.py
+++ b/python/confiture/models/git.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 from confiture.models.schema import SchemaChange
 
 if TYPE_CHECKING:
+    from confiture.core.function_body_checker import FunctionBodyViolation
     from confiture.core.function_signature_checker import FunctionSignatureViolation
 
 
@@ -51,11 +52,17 @@ class MigrationAccompanimentReport:
     base_ref: str | None = None
     target_ref: str | None = None
     signature_violations: list[FunctionSignatureViolation] = field(default_factory=list)
+    body_violations: list[FunctionBodyViolation] = field(default_factory=list)
 
     @property
     def has_signature_violations(self) -> bool:
         """True if any function parameter type changes lack a DROP FUNCTION migration."""
         return len(self.signature_violations) > 0
+
+    @property
+    def has_body_violations(self) -> bool:
+        """True if any function body change lacks a re-defining migration (#178)."""
+        return len(self.body_violations) > 0
 
     @property
     def is_valid(self) -> bool:
@@ -64,12 +71,12 @@ class MigrationAccompanimentReport:
         Valid if:
         - No DDL changes (nothing to accompany), or
         - DDL changes exist AND new migrations exist
-        AND no function signature violations.
+        AND no function signature violations AND no function body violations.
 
         Returns:
             True if validation passed, False otherwise
         """
-        if self.has_signature_violations:
+        if self.has_signature_violations or self.has_body_violations:
             return False
         if not self.has_ddl_changes:
             return True
@@ -111,6 +118,7 @@ class MigrationAccompanimentReport:
             "base_ref": self.base_ref,
             "target_ref": self.target_ref,
             "signature_violations": [v.to_dict() for v in self.signature_violations],
+            "body_violations": [v.to_dict() for v in self.body_violations],
         }
 
 

--- a/tests/integration/test_drift_build_roundtrip.py
+++ b/tests/integration/test_drift_build_roundtrip.py
@@ -1,0 +1,70 @@
+"""Integration test for issue #175 — confiture build output round-trips through
+``confiture drift``.
+
+The expected-schema parser used by ``drift --schema`` must parse the DDL that
+``confiture build`` itself emits (block-comment file separators, ``--`` line
+comments including non-ASCII). Previously it yielded zero tables and reported
+every live table as spurious ``extra_table`` drift with exit 0.
+
+Requires a running PostgreSQL server accessible via CONFITURE_TEST_DB_URL.
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from confiture.core.drift import DriftType, SchemaDriftDetector
+
+# The exact block-comment file separator SchemaBuilder emits by default.
+_SEP = "\n/* " + "=" * 42 + "\n * File: {rel}\n * " + "=" * 42 + " */\n\n"
+
+_LIVE_DDL = """
+CREATE TABLE tb_machine (
+    pk_machine UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    status TEXT DEFAULT 'active'
+);
+CREATE TABLE tb_part (
+    pk_part UUID PRIMARY KEY,
+    fk_machine UUID REFERENCES tb_machine(pk_machine),
+    label TEXT NOT NULL
+);
+"""
+
+# What `confiture build` would write: the same DDL, wrapped in the default
+# block-comment separators and a non-ASCII line comment.
+_BUILD_OUTPUT = (
+    _SEP.format(rel="db/schema/10_tables/10_machine.sql")
+    + "-- Machine registry — core entity\n"
+    + "CREATE TABLE tb_machine (\n"
+    + "    pk_machine UUID PRIMARY KEY,\n"
+    + "    name TEXT NOT NULL,\n"
+    + "    status TEXT DEFAULT 'active'\n"
+    + ");\n"
+    + _SEP.format(rel="db/schema/10_tables/20_part.sql")
+    + "CREATE TABLE tb_part (\n"
+    + "    pk_part UUID PRIMARY KEY,\n"
+    + "    fk_machine UUID REFERENCES tb_machine(pk_machine),\n"
+    + "    label TEXT NOT NULL\n"
+    + ");\n"
+)
+
+
+def test_build_output_round_trips_through_drift(
+    clean_test_db: psycopg.Connection, tmp_path
+) -> None:
+    conn = clean_test_db
+    with conn.cursor() as cur:
+        cur.execute(_LIVE_DDL)
+    conn.commit()
+
+    schema_file = tmp_path / "schema_local.sql"
+    schema_file.write_text(_BUILD_OUTPUT)
+
+    report = SchemaDriftDetector(conn).compare_with_schema_file(str(schema_file))
+
+    # Both tables parsed and compared — not reported as spurious extra tables.
+    assert report.tables_checked == 2, report.to_dict()
+    extra = [d for d in report.drift_items if d.drift_type == DriftType.EXTRA_TABLE]
+    assert extra == [], [d.message for d in extra]
+    assert not report.has_drift, report.to_dict()

--- a/tests/integration/test_expected_db.py
+++ b/tests/integration/test_expected_db.py
@@ -1,0 +1,170 @@
+"""Integration tests for ``ExpectedSchemaDB`` (Phase 4 foundation).
+
+Builds an "expected" schema into a throwaway database and reads it back through
+a live connection — the reusable primitive that Phases 5–7 use to normalise the
+expected side through Postgres' own deparser (``pg_get_viewdef``, ``prosrc``)
+instead of text-normalising source DDL.
+
+Requires a PostgreSQL server at ``CONFITURE_TEST_DB_URL``
+(default ``postgresql://localhost/confiture_test``).
+"""
+
+from __future__ import annotations
+
+import os
+
+import psycopg
+import pytest
+
+from confiture.core.expected_db import ExpectedSchemaDB
+
+
+@pytest.fixture
+def server_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+@pytest.fixture
+def _require_server(server_url: str) -> None:
+    """Skip the whole module cleanly when no server is reachable."""
+    try:
+        psycopg.connect(server_url.replace("/confiture_test", "/postgres"), autocommit=True).close()
+    except psycopg.OperationalError as exc:  # pragma: no cover - env dependent
+        pytest.skip(f"PostgreSQL not available: {exc}")
+
+
+_TWO_TABLES_ONE_VIEW = """
+CREATE TABLE authors (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE books (
+    id BIGSERIAL PRIMARY KEY,
+    author_id BIGINT NOT NULL REFERENCES authors(id),
+    title TEXT NOT NULL
+);
+
+CREATE VIEW author_book_counts AS
+    SELECT a.id, a.name, count(b.id) AS book_count
+    FROM authors a
+    LEFT JOIN books b ON b.author_id = a.id
+    GROUP BY a.id, a.name;
+"""
+
+
+def _scratch_db_names(server_url: str) -> set[str]:
+    maint = server_url.replace("/confiture_test", "/postgres")
+    with psycopg.connect(maint, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT datname FROM pg_database WHERE datname LIKE 'confiture_tmp_%'"
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+@pytest.mark.integration
+def test_from_source_yields_connection_with_expected_objects(
+    server_url: str, _require_server: None
+) -> None:
+    before = _scratch_db_names(server_url)
+
+    with ExpectedSchemaDB(server_url).from_source(schema_sql=_TWO_TABLES_ONE_VIEW) as conn:
+        # The scratch connection sees the built objects.
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+            ).fetchall()
+        }
+        assert {"authors", "books"} <= tables
+
+        views = {
+            r[0]
+            for r in conn.execute(
+                "SELECT viewname FROM pg_views WHERE schemaname = 'public'"
+            ).fetchall()
+        }
+        assert "author_book_counts" in views
+
+        # And pg's own deparser is available for the readback the later phases need.
+        viewdef = conn.execute(
+            "SELECT pg_get_viewdef('public.author_book_counts'::regclass, true)"
+        ).fetchone()[0]
+        assert "book_count" in viewdef
+
+        # Capture the scratch DB name so we can assert it is gone afterwards.
+        scratch_name = conn.execute("SELECT current_database()").fetchone()[0]
+
+    # The scratch DB is dropped on exit — no orphan left behind.
+    assert scratch_name.startswith("confiture_tmp_")
+    after = _scratch_db_names(server_url)
+    assert scratch_name not in after
+    assert after <= before  # created no net-new scratch DBs
+
+
+_BASE_SQL = """
+CREATE TABLE widgets (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+"""
+
+
+@pytest.mark.integration
+def test_from_base_plus_migrations_applies_all_migrations(
+    server_url: str, _require_server: None, tmp_path
+) -> None:
+    # Two migrations on top of the base: add a column, then a function.
+    (tmp_path / "20260708000001_add_price.up.sql").write_text(
+        "ALTER TABLE widgets ADD COLUMN price NUMERIC(10,2) NOT NULL DEFAULT 0;\n"
+    )
+    (tmp_path / "20260708000001_add_price.down.sql").write_text(
+        "ALTER TABLE widgets DROP COLUMN price;\n"
+    )
+    (tmp_path / "20260708000002_add_fn.up.sql").write_text(
+        "CREATE FUNCTION public.widget_total() RETURNS numeric\n"
+        "LANGUAGE sql AS $$ SELECT coalesce(sum(price), 0) FROM widgets $$;\n"
+    )
+    (tmp_path / "20260708000002_add_fn.down.sql").write_text(
+        "DROP FUNCTION public.widget_total();\n"
+    )
+
+    with ExpectedSchemaDB(server_url, migrations_dir=tmp_path).from_base_plus_migrations(
+        base_sql=_BASE_SQL
+    ) as conn:
+        # Column added by migration 1 is present.
+        columns = {
+            r[0]
+            for r in conn.execute(
+                "SELECT column_name FROM information_schema.columns WHERE table_name = 'widgets'"
+            ).fetchall()
+        }
+        assert {"id", "name", "price"} <= columns
+
+        # Function added by migration 2 is present and callable.
+        total = conn.execute("SELECT public.widget_total()").fetchone()[0]
+        assert total == 0
+
+        # The replay recorded both migrations in the tracking table.
+        applied = conn.execute("SELECT count(*) FROM tb_confiture").fetchone()[0]
+        assert applied == 2
+
+
+@pytest.mark.integration
+def test_from_base_plus_migrations_without_base_starts_empty(
+    server_url: str, _require_server: None, tmp_path
+) -> None:
+    """With base_sql=None the migrations build the whole schema from empty."""
+    (tmp_path / "20260708000010_create_all.up.sql").write_text(
+        "CREATE TABLE solo (id BIGSERIAL PRIMARY KEY, label TEXT);\n"
+    )
+    (tmp_path / "20260708000010_create_all.down.sql").write_text("DROP TABLE solo;\n")
+
+    with ExpectedSchemaDB(server_url, migrations_dir=tmp_path).from_base_plus_migrations() as conn:
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+            ).fetchall()
+        }
+        assert "solo" in tables

--- a/tests/integration/test_function_body_drift_live.py
+++ b/tests/integration/test_function_body_drift_live.py
@@ -1,0 +1,96 @@
+"""Integration test: function body drift + unified diff against real prosrc.
+
+Reproduces the epic's core scenario — a function hot-patched directly in the
+database (``CREATE OR REPLACE`` on prod) while the committed source SQL still
+carries the old body — and asserts that the detector surfaces both bodies and a
+readable, line-oriented unified diff built from the live ``pg_proc.prosrc``.
+
+Requires a PostgreSQL server at ``CONFITURE_TEST_DB_URL``
+(default ``postgresql://localhost/confiture_test``).
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from confiture.core.function_body_drift import FunctionBodyDriftDetector
+from confiture.core.function_signature_parser import FunctionSignatureParser
+from confiture.core.live_function_catalog import LiveFunctionCatalog
+
+# The committed source — what the repo believes the function body is.
+_SOURCE_SQL = """
+CREATE OR REPLACE FUNCTION public.calc_total(amount numeric)
+RETURNS numeric
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Apply 20% VAT
+    RETURN amount * 1.20;
+END;
+$$;
+"""
+
+# The live (hot-patched) body — VAT rate quietly changed in prod.
+_LIVE_HOTPATCH_SQL = """
+CREATE OR REPLACE FUNCTION public.calc_total(amount numeric)
+RETURNS numeric
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN amount * 1.196;
+END;
+$$;
+"""
+
+
+@pytest.fixture
+def _hotpatched_function(
+    test_db_connection: psycopg.Connection,
+) -> psycopg.Connection:
+    """Install the hot-patched function; drop it afterwards."""
+    conn = test_db_connection
+    try:
+        with conn.cursor() as cur:
+            cur.execute(_LIVE_HOTPATCH_SQL)
+        conn.commit()
+        yield conn
+    finally:
+        with conn.cursor() as cur:
+            cur.execute("DROP FUNCTION IF EXISTS public.calc_total(numeric);")
+        conn.commit()
+
+
+def test_body_drift_unified_diff_from_live_prosrc(
+    _hotpatched_function: psycopg.Connection,
+) -> None:
+    conn = _hotpatched_function
+
+    # Source side: parse the committed DDL into signature → body.
+    source_bodies = {
+        sig.signature_key(): body
+        for sig, body in FunctionSignatureParser().parse_with_bodies(_SOURCE_SQL)
+    }
+    assert "public.calc_total(numeric)" in source_bodies
+
+    # Live side: read the real prosrc back out of the database.
+    live_bodies = LiveFunctionCatalog(conn).get_bodies(
+        schemas=["public"], sig_keys=set(source_bodies)
+    )
+
+    report = FunctionBodyDriftDetector().compare(source_bodies, live_bodies)
+
+    assert report.has_drift
+    drift = report.body_drifts[0]
+    assert drift.signature_key == "public.calc_total(numeric)"
+
+    # The raw live body comes straight from pg_proc.prosrc.
+    assert "1.196" in drift.live_body
+    assert "1.20" in drift.expected_body
+
+    # The unified diff is line-oriented, comment-stripped, and pinpoints the change.
+    assert "-return amount * 1.20;" in drift.unified_diff
+    assert "+return amount * 1.196;" in drift.unified_diff
+    # The unchanged BEGIN/END scaffold is not reported as +/- churn, and the
+    # "-- Apply 20% VAT" comment is normalised away rather than shown as drift.
+    assert "20% vat" not in drift.unified_diff.lower()

--- a/tests/integration/test_replay_drift.py
+++ b/tests/integration/test_replay_drift.py
@@ -1,0 +1,158 @@
+"""DB-backed tests for replay-based function-body drift (#179).
+
+The clean production drift signal: rebuild the expected database by replaying
+base + all migrations into a scratch DB (no hot-patches), then diff function
+bodies against live. ``live − replayed`` is exactly the definitions that no
+migration produced — true out-of-band hot-patches.
+
+The contrast with ``--check-body`` (which builds the expected side from source
+DDL) is the whole point: a body that changed in the DDL but never got a migration
+is *backlog*, and would swamp ``--check-body``; replay excludes it because it
+never consults the source DDL.
+
+Requires a PostgreSQL server at ``CONFITURE_TEST_DB_URL``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from confiture.core._migrator.session import MigratorSession
+from confiture.core.validation.replay_drift import check_replay_drift
+from confiture.exceptions import SchemaError
+
+
+def _server_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+def _maint(url: str) -> str:
+    # postgresql:///confiture_test → postgresql:///postgres, host form preserved.
+    return url.rsplit("/", 1)[0] + "/postgres"
+
+
+@pytest.fixture
+def live_db() -> Generator[str, None, None]:
+    """A fresh, persistent live database (dropped after the test)."""
+    server = _server_url()
+    maint = _maint(server)
+    name = f"confiture_replay_live_{uuid.uuid4().hex[:8]}"
+    try:
+        conn = psycopg.connect(maint, autocommit=True)
+    except psycopg.OperationalError as exc:  # pragma: no cover - env dependent
+        pytest.skip(f"PostgreSQL not available: {exc}")
+    conn.execute(f'CREATE DATABASE "{name}"')
+    conn.close()
+
+    live_url = server.rsplit("/", 1)[0] + f"/{name}"
+    yield live_url
+
+    conn = psycopg.connect(maint, autocommit=True)
+    conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    conn.close()
+
+
+# Two migrations: create a table + a function, then a second function.
+_MIG_1 = (
+    "CREATE TABLE widgets (id bigint, price numeric);\n"
+    "CREATE FUNCTION public.total() RETURNS numeric\n"
+    "LANGUAGE sql AS $$ SELECT coalesce(sum(price), 0) FROM widgets $$;\n"
+)
+_MIG_1_DOWN = "DROP FUNCTION public.total();\nDROP TABLE widgets;\n"
+
+
+def _write_migrations(migrations_dir: Path) -> None:
+    migrations_dir.mkdir(parents=True, exist_ok=True)
+    (migrations_dir / "20260708000001_init.up.sql").write_text(_MIG_1)
+    (migrations_dir / "20260708000001_init.down.sql").write_text(_MIG_1_DOWN)
+
+
+def _config(tmp_path: Path, live_url: str) -> Path:
+    config = tmp_path / "confiture.yaml"
+    config.write_text(f"name: replaytest\ndatabase_url: {live_url}\ninclude_dirs:\n  - db/schema\n")
+    return config
+
+
+def _replay_into(live_url: str, migrations_dir: Path) -> None:
+    with MigratorSession(
+        config=None, migrations_dir=migrations_dir, database_url_override=live_url
+    ) as session:
+        result = session.up()
+    assert result.success, f"live replay failed: {result.errors}"
+
+
+@pytest.mark.integration
+def test_hotpatch_reported(live_db: str, tmp_path: Path) -> None:
+    migrations_dir = tmp_path / "migrations"
+    _write_migrations(migrations_dir)
+    _replay_into(live_db, migrations_dir)
+
+    # Hot-patch a function directly on live — no migration carries this change.
+    with psycopg.connect(live_db, autocommit=True) as conn:
+        conn.execute(
+            "CREATE OR REPLACE FUNCTION public.total() RETURNS numeric "
+            "LANGUAGE sql AS $$ SELECT coalesce(sum(price), 0) * 1.2 FROM widgets $$;"
+        )
+
+    result = check_replay_drift(
+        config_path=_config(tmp_path, live_db),
+        migrations_dir=migrations_dir,
+        schemas="public",
+        ssh_via=None,
+    )
+
+    assert result.has_drift
+    keys = {d.signature_key for d in result.body_report.body_drifts}
+    assert keys == {"public.total()"}, f"expected only the hot-patched fn, got {keys}"
+
+
+@pytest.mark.integration
+def test_backlog_not_reported(live_db: str, tmp_path: Path) -> None:
+    """Live built purely from migrations (no hot-patch) → no drift.
+
+    Replay reproduces exactly what the migrations produced, so a body that only
+    ever lived in source DDL (never migrated) can never appear here.
+    """
+    migrations_dir = tmp_path / "migrations"
+    _write_migrations(migrations_dir)
+    _replay_into(live_db, migrations_dir)
+
+    result = check_replay_drift(
+        config_path=_config(tmp_path, live_db),
+        migrations_dir=migrations_dir,
+        schemas="public",
+        ssh_via=None,
+    )
+
+    assert not result.has_drift, (
+        "a clean migration replay must match live; "
+        f"drifts={[d.signature_key for d in result.body_report.body_drifts]}"
+    )
+
+
+@pytest.mark.integration
+def test_broken_migration_is_error_not_false_drift(live_db: str, tmp_path: Path) -> None:
+    """A migration that fails at HEAD surfaces as an error, not as drift."""
+    migrations_dir = tmp_path / "migrations"
+    _write_migrations(migrations_dir)
+    _replay_into(live_db, migrations_dir)
+
+    # A later migration that is broken (references a non-existent table).
+    (migrations_dir / "20260708000002_broken.up.sql").write_text(
+        "ALTER TABLE does_not_exist ADD COLUMN x int;\n"
+    )
+    (migrations_dir / "20260708000002_broken.down.sql").write_text("SELECT 1;\n")
+
+    with pytest.raises(SchemaError, match="[Mm]igration replay"):
+        check_replay_drift(
+            config_path=_config(tmp_path, live_db),
+            migrations_dir=migrations_dir,
+            schemas="public",
+            ssh_via=None,
+        )

--- a/tests/integration/test_signature_drift_arrays.py
+++ b/tests/integration/test_signature_drift_arrays.py
@@ -1,0 +1,73 @@
+"""Integration test for issue #176 — array-typed function signatures.
+
+An array-typed function present identically in the source DDL and the live
+database must NOT be reported as a stale overload, and must never produce a
+destructive ``DROP FUNCTION`` remediation.  This exercises the real
+``pg_catalog.format_type`` output from a live server (``text[]``, ``bigint[]``,
+…), which is the symmetry the parser fix must preserve.
+
+Requires a running PostgreSQL server accessible via CONFITURE_TEST_DB_URL.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from confiture.core.function_signature_drift import FunctionSignatureDriftDetector
+from confiture.core.function_signature_parser import FunctionSignatureParser
+from confiture.core.live_function_catalog import LiveFunctionCatalog
+
+# The pglast AST path is the production path and the one that dropped '[]'.
+pytest.importorskip("pglast")
+
+_DDL = """
+CREATE SCHEMA IF NOT EXISTS sig176;
+
+CREATE FUNCTION sig176.merge_to_tenant_statistics(
+    p_tenant text,
+    p_dates date[],
+    p_ids bigint[],
+    p_uuids uuid[]
+) RETURNS void LANGUAGE plpgsql AS $$ BEGIN END $$;
+
+CREATE FUNCTION sig176.build_response(
+    a text,
+    tags text[] DEFAULT ARRAY[]::text[]
+) RETURNS void LANGUAGE plpgsql AS $$ BEGIN END $$;
+"""
+
+
+@pytest.fixture
+def array_fn_db(clean_test_db: psycopg.Connection) -> psycopg.Connection:
+    conn = clean_test_db
+    with conn.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS sig176 CASCADE")
+        cur.execute(_DDL)
+    conn.commit()
+    yield conn
+    with conn.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS sig176 CASCADE")
+    conn.commit()
+
+
+def test_array_functions_not_stale_against_live_db(array_fn_db: psycopg.Connection) -> None:
+    source_sigs = FunctionSignatureParser().parse(_DDL)
+    live_sigs = LiveFunctionCatalog(array_fn_db).get_signatures(schemas=["sig176"])
+
+    report = FunctionSignatureDriftDetector().compare(
+        source_sigs, live_sigs, schemas_checked=["sig176"]
+    )
+
+    # No false stale overload, and — critically — no destructive DROP emitted.
+    assert not report.has_drift, report.to_dict()["stale_overloads"]
+    assert report.to_dict()["remediation_sql"] == []
+
+
+def test_live_array_signature_matches_source(array_fn_db: psycopg.Connection) -> None:
+    """The live introspected signature keeps its array suffix and equals source."""
+    live_sigs = LiveFunctionCatalog(array_fn_db).get_signatures(schemas=["sig176"])
+    keys = {s.signature_key() for s in live_sigs}
+
+    assert "sig176.merge_to_tenant_statistics(text,date[],bigint[],uuid[])" in keys, keys
+    assert "sig176.build_response(text,text[])" in keys, keys

--- a/tests/integration/test_view_body_drift_db.py
+++ b/tests/integration/test_view_body_drift_db.py
@@ -1,0 +1,137 @@
+"""DB-backed tests for view body-drift with scratch normalisation (#174).
+
+The crux: a view whose *source* DDL differs from the *live* form only in
+formatting / schema-qualification / ``*``-expansion must NOT be reported as
+drift. Both sides are read back through the identical ``pg_get_viewdef(oid,
+true)`` deparser (the source side via a scratch DB built by
+:class:`ExpectedSchemaDB`), so string equality means semantic equality.
+
+Both the "live" and the "expected" schemas are materialised into throwaway
+databases here, so the test is fully self-contained.
+
+Requires a PostgreSQL server at ``CONFITURE_TEST_DB_URL``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import psycopg
+import pytest
+
+from confiture.core.expected_db import ExpectedSchemaDB
+from confiture.core.live_view_catalog import LiveViewCatalog
+from confiture.core.view_body_drift import ViewBodyDriftDetector
+
+
+@pytest.fixture
+def server_url() -> str:
+    return os.getenv("CONFITURE_TEST_DB_URL", "postgresql://localhost/confiture_test")
+
+
+@pytest.fixture
+def _require_server(server_url: str) -> None:
+    try:
+        psycopg.connect(server_url.replace("/confiture_test", "/postgres"), autocommit=True).close()
+    except psycopg.OperationalError as exc:  # pragma: no cover - env dependent
+        pytest.skip(f"PostgreSQL not available: {exc}")
+
+
+_BASE = "CREATE TABLE things (id bigint, name text, active boolean);\n"
+
+
+def _compare(server_url: str, live_ddl: str, source_ddl: str):
+    with (
+        ExpectedSchemaDB(server_url).from_source(schema_sql=live_ddl) as live_conn,
+        ExpectedSchemaDB(server_url).from_source(schema_sql=source_ddl) as scratch_conn,
+    ):
+        live_defs = LiveViewCatalog(live_conn).get_view_definitions(["public"])
+        src_defs = LiveViewCatalog(scratch_conn).get_view_definitions(["public"])
+        return ViewBodyDriftDetector().compare(src_defs, live_defs)
+
+
+@pytest.mark.integration
+def test_predicate_change_is_drift(server_url: str, _require_server: None) -> None:
+    live = _BASE + "CREATE VIEW v AS SELECT id FROM things WHERE id > (5 + 1);\n"
+    source = _BASE + "CREATE VIEW v AS SELECT id FROM things WHERE id > 5;\n"
+
+    report = _compare(server_url, live, source)
+
+    assert report.has_drift
+    assert len(report.body_drifts) == 1
+    drift = report.body_drifts[0]
+    assert drift.schema == "public"
+    assert drift.name == "v"
+    assert drift.relkind == "v"
+    # The deparsed diff pinpoints the predicate change.
+    assert "5" in drift.unified_diff
+
+
+@pytest.mark.integration
+def test_semantically_identical_no_false_positive(server_url: str, _require_server: None) -> None:
+    """Formatting / schema-qualification differences must NOT be drift.
+
+    This is the whole reason for scratch-normalisation — a naive text compare of
+    source DDL vs live pg_get_viewdef would flag these as false positives.
+    """
+    live = _BASE + "CREATE VIEW v AS SELECT id, name FROM public.things WHERE active;\n"
+    source = (
+        _BASE
+        + "CREATE VIEW v AS\n"
+        + "    SELECT\n"
+        + "        id,\n"
+        + "        name\n"
+        + "    FROM things\n"
+        + "    WHERE active;\n"
+    )
+
+    report = _compare(server_url, live, source)
+
+    assert not report.has_drift, (
+        "semantically-identical views must not drift; "
+        f"drifts={[d.unified_diff for d in report.body_drifts]}"
+    )
+    assert report.views_checked == 1
+
+
+@pytest.mark.integration
+def test_star_expansion_no_false_positive(server_url: str, _require_server: None) -> None:
+    """`SELECT *` in source vs explicit columns in live must not drift."""
+    live = _BASE + "CREATE VIEW v AS SELECT id, name, active FROM things;\n"
+    source = _BASE + "CREATE VIEW v AS SELECT * FROM things;\n"
+
+    report = _compare(server_url, live, source)
+
+    assert not report.has_drift, (
+        f"star-expansion should normalise away; drifts={[d.unified_diff for d in report.body_drifts]}"
+    )
+
+
+@pytest.mark.integration
+def test_materialized_view_covered(server_url: str, _require_server: None) -> None:
+    live = _BASE + "CREATE MATERIALIZED VIEW mv AS SELECT count(id) AS n FROM things;\n"
+    source = _BASE + "CREATE MATERIALIZED VIEW mv AS SELECT count(*) AS n FROM things;\n"
+
+    report = _compare(server_url, live, source)
+
+    assert report.has_drift
+    assert report.body_drifts[0].relkind == "m"
+    assert report.body_drifts[0].name == "mv"
+
+
+@pytest.mark.integration
+def test_schemas_filter_is_honored(server_url: str, _require_server: None) -> None:
+    """Only views in the requested schemas are enumerated."""
+    ddl = (
+        "CREATE SCHEMA other;\n"
+        + _BASE
+        + "CREATE VIEW v AS SELECT id FROM things;\n"
+        + "CREATE TABLE other.t (id bigint);\n"
+        + "CREATE VIEW other.ov AS SELECT id FROM other.t;\n"
+    )
+    with ExpectedSchemaDB(server_url).from_source(schema_sql=ddl) as conn:
+        public_only = LiveViewCatalog(conn).get_view_definitions(["public"])
+        both = LiveViewCatalog(conn).get_view_definitions(["public", "other"])
+
+    assert set(public_only) == {"public.v"}
+    assert {"public.v", "other.ov"} <= set(both)

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -12,6 +12,12 @@ from confiture.core.drift import (
     SchemaDriftDetector,
 )
 from confiture.core.schema_analyzer import SchemaInfo
+from confiture.exceptions import SchemaError
+
+# Exact block-comment file separator emitted by SchemaBuilder (block_comment is
+# the default separator style) — reproduced here so the drift parser is proven
+# to round-trip confiture's own build output (issue #175).
+_BUILD_BLOCK_SEP = "\n/* " + "=" * 42 + "\n * File: {rel}\n * " + "=" * 42 + " */\n\n"
 
 
 class TestDriftItem:
@@ -406,3 +412,105 @@ class TestSchemaDriftDetector:
         # Incompatible pairs
         assert not detector._types_compatible("integer", "text")
         assert not detector._types_compatible("boolean", "integer")
+
+    # ------------------------------------------------------------------ #
+    # Issue #175 — comment handling + silent-failure guard                #
+    # ------------------------------------------------------------------ #
+
+    def test_parse_schema_with_block_comment_separators(self, mock_connection):
+        """confiture build's default block-comment file separators must not hide
+        the CREATE TABLE that follows them (issue #175)."""
+        conn, _ = mock_connection
+        detector = SchemaDriftDetector(conn)
+
+        sql = (
+            _BUILD_BLOCK_SEP.format(rel="db/schema/10_tables/10_machine.sql")
+            + "CREATE TABLE tb_machine (pk_machine UUID PRIMARY KEY, name TEXT NOT NULL);\n"
+            + _BUILD_BLOCK_SEP.format(rel="db/schema/10_tables/20_part.sql")
+            + "CREATE TABLE tb_part (pk_part UUID PRIMARY KEY, label TEXT NOT NULL);\n"
+        )
+
+        info = detector._parse_schema_from_sql(sql)
+
+        assert set(info.tables) == {"tb_machine", "tb_part"}
+
+    def test_parse_schema_with_non_ascii_line_comment(self, mock_connection):
+        """A non-ASCII (em-dash) line comment before a table must not hide it."""
+        conn, _ = mock_connection
+        detector = SchemaDriftDetector(conn)
+
+        sql = (
+            "-- Machine registry — core entity\n"
+            "CREATE TABLE tb_machine (pk_machine UUID PRIMARY KEY, name TEXT NOT NULL);\n"
+            "COMMENT ON TABLE tb_machine IS 'Machines';\n"
+        )
+
+        info = detector._parse_schema_from_sql(sql)
+
+        assert "tb_machine" in info.tables
+        assert "name" in info.tables["tb_machine"]
+
+    def test_create_table_in_function_body_not_parsed_as_table(self, mock_connection):
+        """A dynamic ``CREATE TABLE`` inside a function body must not be mistaken
+        for a real table, and must not trip the zero-tables guard when a real
+        table is present."""
+        conn, _ = mock_connection
+        detector = SchemaDriftDetector(conn)
+
+        sql = (
+            "CREATE OR REPLACE FUNCTION make_tmp() RETURNS void LANGUAGE plpgsql AS $$\n"
+            "BEGIN\n"
+            "    EXECUTE 'CREATE TABLE tmp_scratch (id int)';\n"
+            "END;\n"
+            "$$;\n"
+            "CREATE TABLE tb_real (id UUID PRIMARY KEY);\n"
+        )
+
+        info = detector._parse_schema_from_sql(sql)
+
+        assert "tb_real" in info.tables
+        assert "tmp_scratch" not in info.tables
+
+    def test_zero_tables_from_nonempty_schema_raises(self, mock_connection, monkeypatch):
+        """A schema that declares tables but parses to zero must fail loudly
+        instead of silently reporting every live table as spurious drift."""
+        conn, _ = mock_connection
+        detector = SchemaDriftDetector(conn)
+
+        # Simulate an (unknown/future) parser breakage: no statements extracted.
+        monkeypatch.setattr("confiture.core.drift.sqlparse.parse", lambda _sql: [])
+
+        with pytest.raises(SchemaError):
+            detector._parse_schema_from_sql(
+                "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);"
+            )
+
+    def test_index_or_type_only_schema_does_not_raise(self, mock_connection):
+        """A schema with no CREATE TABLE (indexes/types only) is a legitimate
+        empty-table expectation, not a parse failure — must NOT raise."""
+        conn, _ = mock_connection
+        detector = SchemaDriftDetector(conn)
+
+        sql = "CREATE TYPE order_status AS ENUM ('pending', 'shipped');\n"
+
+        info = detector._parse_schema_from_sql(sql)  # must not raise
+
+        assert info.tables == {}
+
+    def test_function_body_only_create_table_does_not_raise(self, mock_connection):
+        """A schema whose only ``CREATE TABLE`` text lives inside a function body
+        is table-less — the guard must not false-fire on it."""
+        conn, _ = mock_connection
+        detector = SchemaDriftDetector(conn)
+
+        sql = (
+            "CREATE OR REPLACE FUNCTION make_tmp() RETURNS void LANGUAGE plpgsql AS $$\n"
+            "BEGIN\n"
+            "    EXECUTE 'CREATE TABLE tmp_scratch (id int)';\n"
+            "END;\n"
+            "$$;\n"
+        )
+
+        info = detector._parse_schema_from_sql(sql)  # must not raise
+
+        assert info.tables == {}

--- a/tests/unit/test_drift_cli.py
+++ b/tests/unit/test_drift_cli.py
@@ -172,6 +172,48 @@ class TestDriftCommand:
         assert "drift_items" in data
         assert data["has_drift"] is False
 
+    @patch("confiture.cli.commands.drift.create_connection")
+    @patch("confiture.cli.commands.drift.load_config")
+    @patch("confiture.cli.commands.drift.SchemaDriftDetector")
+    def test_drift_unparseable_schema_exits_4(
+        self, mock_detector_class, mock_load_config, mock_create_connection, tmp_path
+    ):
+        """A SCHEMA_202 parse failure (issue #175) surfaces as exit 4 with its own
+        error code, not wrapped as a generic config error."""
+        from confiture.exceptions import SchemaError
+
+        config_file = tmp_path / "confiture.yaml"
+        config_file.write_text("database_url: postgresql://localhost/test\n")
+        schema_file = tmp_path / "schema.sql"
+        schema_file.write_text("/* sep */\nCREATE TABLE users (id int);\n")
+
+        mock_load_config.return_value = MagicMock()
+        mock_create_connection.return_value = MagicMock()
+        mock_detector = MagicMock()
+        mock_detector_class.return_value = mock_detector
+        mock_detector.compare_with_schema_file.side_effect = SchemaError(
+            "Parsed 0 tables from a schema that contains CREATE TABLE statement(s)",
+            error_code="SCHEMA_202",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "drift",
+                "--config",
+                str(config_file),
+                "--schema",
+                str(schema_file),
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 4
+        data = json.loads(result.stdout)
+        assert data["ok"] is False
+        assert data["error"]["code"] == "SCHEMA_202"
+
     def test_drift_command_missing_schema_flag_is_config_error(self, tmp_path):
         """Missing --schema is a config error (exit 5), not the reserved exit 2."""
         config_file = tmp_path / "confiture.yaml"

--- a/tests/unit/test_expected_db.py
+++ b/tests/unit/test_expected_db.py
@@ -1,0 +1,85 @@
+"""Unit tests for ExpectedSchemaDB lifecycle (no database required).
+
+Covers the mode guard and — most importantly — that a failure *during* the
+build still drops the scratch database, so no orphan ``confiture_tmp_*`` DB is
+left behind.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.expected_db import ExpectedSchemaDB
+from confiture.exceptions import ConfigurationError, SchemaError
+
+
+class _FakeTempDatabase:
+    """Stand-in for TempDatabase that records whether __exit__ (drop) ran."""
+
+    instances: list[_FakeTempDatabase] = []
+
+    def __init__(self, server_url: str) -> None:
+        self.server_url = server_url
+        self.exited = False
+        self.apply_calls: list[str] = []
+        self._raise_on_apply = False
+        _FakeTempDatabase.instances.append(self)
+
+    def __enter__(self) -> str:
+        return "postgresql://localhost/confiture_tmp_fake"
+
+    def __exit__(self, *_exc: object) -> None:
+        self.exited = True
+
+    def apply_schema(self, _url: str, sql: str) -> None:
+        self.apply_calls.append(sql)
+        if self._raise_on_apply:
+            raise SchemaError("boom: schema application failed")
+
+
+@pytest.fixture(autouse=True)
+def _reset_instances() -> None:
+    _FakeTempDatabase.instances.clear()
+
+
+def test_enter_without_mode_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("confiture.core.expected_db.TempDatabase", _FakeTempDatabase)
+    edb = ExpectedSchemaDB("postgresql://localhost/x")
+    with pytest.raises(ConfigurationError, match="build mode"):
+        edb.__enter__()
+
+
+def test_cleanup_runs_when_build_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """apply_schema raising mid-build must still drop the scratch DB."""
+
+    def _factory(server_url: str) -> _FakeTempDatabase:
+        td = _FakeTempDatabase(server_url)
+        td._raise_on_apply = True
+        return td
+
+    monkeypatch.setattr("confiture.core.expected_db.TempDatabase", _factory)
+
+    edb = ExpectedSchemaDB("postgresql://localhost/x").from_source(
+        schema_sql="CREATE TABLE t (id int);"
+    )
+    with pytest.raises(SchemaError, match="boom"):
+        edb.__enter__()
+
+    assert len(_FakeTempDatabase.instances) == 1
+    assert _FakeTempDatabase.instances[0].exited is True  # dropped despite the failure
+
+
+def test_from_source_requires_env_or_schema_sql(monkeypatch: pytest.MonkeyPatch) -> None:
+    """from_source() with neither env nor schema_sql fails before touching a DB."""
+    monkeypatch.setattr("confiture.core.expected_db.TempDatabase", _FakeTempDatabase)
+    edb = ExpectedSchemaDB("postgresql://localhost/x").from_source()
+    with pytest.raises(ConfigurationError, match="env or explicit schema_sql"):
+        edb.__enter__()
+    # The scratch DB was created for the attempt, then dropped on the failure.
+    assert _FakeTempDatabase.instances[0].exited is True
+
+
+def test_from_source_and_from_base_return_self() -> None:
+    edb = ExpectedSchemaDB("postgresql://localhost/x")
+    assert edb.from_source(schema_sql="") is edb
+    assert edb.from_base_plus_migrations() is edb

--- a/tests/unit/test_function_body_checker.py
+++ b/tests/unit/test_function_body_checker.py
@@ -1,0 +1,129 @@
+"""Unit tests for FunctionBodyChecker (#178).
+
+Mirrors ``test_function_signature_checker.py``. The checker is git-based and
+static (no DB): it compares function *bodies* between two refs and requires a
+body change to be carried by a migration that re-defines the function.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from confiture.core.function_body_checker import (
+    FunctionBodyChecker,
+    FunctionBodyViolation,
+)
+
+
+def _make_checker(old_content: str | None, new_content: str | None) -> FunctionBodyChecker:
+    """Build a checker whose git_repo returns fixed content at refs."""
+    git_repo = MagicMock()
+
+    def show_at_ref(path, ref):
+        return old_content if ref == "HEAD~1" else new_content
+
+    git_repo.show_file_at_ref.side_effect = show_at_ref
+    return FunctionBodyChecker(git_repo)
+
+
+def _fn(body: str) -> str:
+    return (
+        f"CREATE OR REPLACE FUNCTION public.calc(p_id integer) RETURNS numeric\n"
+        f"LANGUAGE sql AS $$ {body} $$;"
+    )
+
+
+OLD = _fn("SELECT p_id * 1")
+NEW_SAME_LOGIC_DIFF_FORMAT = _fn("select   p_id * 1  -- unchanged\n")
+NEW_CHANGED = _fn("SELECT p_id * 2")
+
+
+class TestNoViolation:
+    def test_unchanged_body(self):
+        checker = _make_checker(OLD, OLD)
+        assert checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD") == []
+
+    def test_body_change_only_in_formatting_is_not_drift(self):
+        """Comment/whitespace/case-only change must not count as a body change."""
+        checker = _make_checker(OLD, NEW_SAME_LOGIC_DIFF_FORMAT)
+        assert checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD") == []
+
+    def test_new_function_is_not_a_body_violation(self):
+        # Function absent in old ref — creation, handled by coarse accompaniment.
+        checker = _make_checker(None, NEW_CHANGED)
+        assert checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD") == []
+
+    def test_deleted_function_is_not_a_body_violation(self):
+        checker = _make_checker(OLD, "-- no functions")
+        assert checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD") == []
+
+    def test_body_change_with_carrying_migration_is_clean(self, tmp_path):
+        mig = tmp_path / "20260708_fix.up.sql"
+        mig.write_text(_fn("SELECT p_id * 2"))  # migration re-defines the function
+        checker = _make_checker(OLD, NEW_CHANGED)
+        violations = checker.check([Path("db/schema/f.sql")], [mig], "HEAD~1", "HEAD")
+        assert violations == []
+
+    def test_carrying_migration_may_be_a_python_file(self, tmp_path):
+        mig = tmp_path / "20260708_fix.py"
+        mig.write_text(
+            "def up(self):\n"
+            '    self.execute("""CREATE OR REPLACE FUNCTION public.calc(p_id integer) '
+            'RETURNS numeric LANGUAGE sql AS $b$ SELECT p_id * 2 $b$;""")\n'
+        )
+        checker = _make_checker(OLD, NEW_CHANGED)
+        assert checker.check([Path("db/schema/f.sql")], [mig], "HEAD~1", "HEAD") == []
+
+    def test_signature_change_is_not_a_body_violation(self):
+        """A param-type change is a different overload — signature checker's job."""
+        old = (
+            "CREATE FUNCTION public.calc(p_id integer) RETURNS void AS $$ SELECT 1 $$ LANGUAGE sql;"
+        )
+        new = (
+            "CREATE FUNCTION public.calc(p_id bigint) RETURNS void AS $$ SELECT 2 $$ LANGUAGE sql;"
+        )
+        checker = _make_checker(old, new)
+        assert checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD") == []
+
+    def test_c_language_none_body_skipped(self):
+        old = "CREATE FUNCTION public.f() RETURNS int AS 'symbol_a' LANGUAGE c;"
+        new = "CREATE FUNCTION public.f() RETURNS int AS 'symbol_b' LANGUAGE c;"
+        checker = _make_checker(old, new)
+        # bodies are None (C) → cannot compare → not a violation
+        assert checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD") == []
+
+
+class TestViolation:
+    def test_body_change_without_migration_is_violation(self):
+        checker = _make_checker(OLD, NEW_CHANGED)
+        violations = checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD")
+        assert len(violations) == 1
+        v = violations[0]
+        assert isinstance(v, FunctionBodyViolation)
+        assert v.function_key == "public.calc"
+        assert v.signature_key == "public.calc(integer)"
+        assert v.migration_file is None
+
+    def test_violation_carries_unified_diff(self):
+        checker = _make_checker(OLD, NEW_CHANGED)
+        v = checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD")[0]
+        assert "-select p_id * 1" in v.unified_diff
+        assert "+select p_id * 2" in v.unified_diff
+
+    def test_violation_to_dict_shape(self):
+        checker = _make_checker(OLD, NEW_CHANGED)
+        v = checker.check([Path("db/schema/f.sql")], [], "HEAD~1", "HEAD")[0]
+        d = v.to_dict()
+        assert d["function_key"] == "public.calc"
+        assert d["signature_key"] == "public.calc(integer)"
+        assert d["migration_file"] is None
+        assert "unified_diff" in d
+        assert "message" in d
+
+    def test_unrelated_migration_does_not_carry_the_change(self, tmp_path):
+        mig = tmp_path / "20260708_other.up.sql"
+        mig.write_text(
+            "CREATE OR REPLACE FUNCTION public.other() RETURNS void AS $$ $$ LANGUAGE sql;"
+        )
+        checker = _make_checker(OLD, NEW_CHANGED)
+        violations = checker.check([Path("db/schema/f.sql")], [mig], "HEAD~1", "HEAD")
+        assert len(violations) == 1

--- a/tests/unit/test_function_body_drift.py
+++ b/tests/unit/test_function_body_drift.py
@@ -81,6 +81,83 @@ def test_drift_detected_only_changed_functions_listed():
 
 
 # ---------------------------------------------------------------------------
+# Cycle 2b (#177): drift record carries both bodies + a unified diff
+# ---------------------------------------------------------------------------
+
+
+def test_drift_record_includes_bodies_and_unified_diff():
+    """A drifted function exposes both raw bodies and a line-oriented diff."""
+    source = {"public.foo(integer)": "SELECT $1 + 1;"}
+    live = {"public.foo(integer)": "SELECT $1 + 2;"}
+    report = FunctionBodyDriftDetector().compare(source, live)
+
+    assert report.has_drift
+    drift = report.body_drifts[0]
+    # Raw bodies preserved verbatim.
+    assert drift.expected_body == "SELECT $1 + 1;"
+    assert drift.live_body == "SELECT $1 + 2;"
+    # Unified diff mentions both changed lines and is line-oriented.
+    assert "-select $1 + 1;" in drift.unified_diff
+    assert "+select $1 + 2;" in drift.unified_diff
+
+
+def test_unified_diff_is_line_oriented_not_collapsed():
+    """Multi-line bodies produce a per-line diff, not one collapsed line."""
+    source = {"public.f()": "SELECT a\nFROM t\nWHERE x = 1;"}
+    live = {"public.f()": "SELECT a\nFROM t\nWHERE x = 2;"}
+    report = FunctionBodyDriftDetector().compare(source, live)
+
+    drift = report.body_drifts[0]
+    # Only the WHERE line changed; the unchanged lines must not appear as +/-.
+    assert "-where x = 1;" in drift.unified_diff
+    assert "+where x = 2;" in drift.unified_diff
+    assert "-select a" not in drift.unified_diff
+    assert "-from t" not in drift.unified_diff
+
+
+def test_no_drift_produces_no_record_with_bodies():
+    """A non-drifted function still yields no record (bodies not surfaced)."""
+    source = {"public.foo(integer)": "SELECT $1 + 1;  -- comment"}
+    live = {"public.foo(integer)": "select $1 + 1;"}
+    report = FunctionBodyDriftDetector().compare(source, live)
+    assert not report.has_drift
+    assert report.body_drifts == []
+
+
+def test_drift_to_dict_hash_only_by_default():
+    """to_dict() omits bodies/diff unless include_bodies=True (back-compat)."""
+    source = {"public.foo(integer)": "SELECT $1 + 1;"}
+    live = {"public.foo(integer)": "SELECT $1 + 2;"}
+    drift = FunctionBodyDriftDetector().compare(source, live).body_drifts[0]
+
+    terse = drift.to_dict()
+    assert set(terse) == {"schema", "name", "signature_key", "source_hash", "db_hash"}
+
+    verbose = drift.to_dict(include_bodies=True)
+    assert verbose["expected_body"] == "SELECT $1 + 1;"
+    assert verbose["live_body"] == "SELECT $1 + 2;"
+    assert "unified_diff" in verbose
+
+
+def test_report_to_dict_matches_inline_shape():
+    """FunctionBodyDriftReport.to_dict() reproduces the historical JSON keys."""
+    source = {"public.foo(integer)": "SELECT $1 + 1;"}
+    live = {"public.foo(integer)": "SELECT $1 + 2;"}
+    report = FunctionBodyDriftDetector().compare(source, live)
+
+    payload = report.to_dict()
+    assert payload["has_drift"] is True
+    assert payload["functions_checked"] == 1
+    assert "detection_time_ms" in payload
+    assert len(payload["body_drifts"]) == 1
+    # Hash-only by default — no bodies leak.
+    assert "expected_body" not in payload["body_drifts"][0]
+
+    verbose = report.to_dict(include_bodies=True)
+    assert verbose["body_drifts"][0]["expected_body"] == "SELECT $1 + 1;"
+
+
+# ---------------------------------------------------------------------------
 # Cycle 3: None-body handling
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_function_body_normalizer.py
+++ b/tests/unit/test_function_body_normalizer.py
@@ -97,3 +97,40 @@ def test_hash_body_same_with_case_variation():
     a = "SELECT $1 + 1;"
     b = "select $1 + 1;"
     assert norm.hash_body(a) == norm.hash_body(b)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 (#177): normalize_for_diff — line-oriented normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_for_diff_preserves_newlines():
+    """Unlike normalize(), normalize_for_diff keeps line structure."""
+    norm = FunctionBodyNormalizer()
+    result = norm.normalize_for_diff("SELECT a\nFROM t\nWHERE x = 1;")
+    assert result.splitlines() == ["select a", "from t", "where x = 1;"]
+
+
+def test_normalize_for_diff_strips_comments_and_lowercases():
+    norm = FunctionBodyNormalizer()
+    result = norm.normalize_for_diff("-- header\nSELECT ID -- trailing\nFROM Users;")
+    assert "header" not in result
+    assert "trailing" not in result
+    assert "--" not in result
+    assert result.splitlines() == ["select id", "from users;"]
+
+
+def test_normalize_for_diff_collapses_indentation_and_blank_lines():
+    """Leading indentation, internal runs, and blank lines must not add diff noise."""
+    norm = FunctionBodyNormalizer()
+    a = norm.normalize_for_diff("SELECT   a,\n    b\nFROM t;")
+    b = norm.normalize_for_diff("SELECT a,\n\nb\nFROM t;")
+    assert a == b == "select a,\nb\nfrom t;"
+
+
+def test_normalize_for_diff_is_line_oriented_where_normalize_is_flat():
+    """normalize() collapses to one line; normalize_for_diff does not."""
+    norm = FunctionBodyNormalizer()
+    body = "SELECT 1;\nSELECT 2;"
+    assert "\n" not in norm.normalize(body)
+    assert "\n" in norm.normalize_for_diff(body)

--- a/tests/unit/test_function_signature_drift.py
+++ b/tests/unit/test_function_signature_drift.py
@@ -86,6 +86,43 @@ class TestFunctionSignatureDriftDetectorStaleOverloads:
         assert report.stale_overloads[0].schema == "auth"
 
 
+class TestFunctionSignatureDriftArraySafety:
+    """Issue #176: array-typed functions must not produce false stale overloads
+    (and never a destructive DROP) when they are present identically in source
+    and live."""
+
+    def test_array_signature_not_reported_stale(self):
+        # Same array signature in both source and live → no drift, no DROP.
+        types = ("text", "text", "uuid", "text", "jsonb", "text[]", "jsonb", "jsonb")
+        source = [_sig("build_mutation_response", types, schema="core")]
+        live = [_sig("build_mutation_response", types, schema="core")]
+        report = FunctionSignatureDriftDetector().compare(source, live)
+        assert not report.has_drift
+        assert report.stale_overloads == []
+        assert report.to_dict()["remediation_sql"] == []
+
+    def test_array_only_difference_never_emits_drop(self):
+        # Defensive guard (Change C): even if a normalisation gap leaves the live
+        # array signature differing from the source signature only by an array
+        # suffix on one position, a base-name + arity match must NOT be dropped.
+        source = [_sig("f", ("text",), schema="core")]
+        live = [
+            _sig("f", ("text",), schema="core"),
+            _sig("f", ("text[]",), schema="core"),  # differs only by []
+        ]
+        report = FunctionSignatureDriftDetector().compare(source, live)
+        assert report.stale_overloads == []
+        assert report.to_dict()["remediation_sql"] == []
+
+    def test_genuine_scalar_overload_still_flagged(self):
+        # Change C must not suppress genuine drift: different base type → still stale.
+        source = [_sig("g", ("bigint",))]
+        live = [_sig("g", ("bigint",)), _sig("g", ("integer",))]
+        report = FunctionSignatureDriftDetector().compare(source, live)
+        assert report.has_drift
+        assert report.stale_overloads[0].stale_signature == "public.g(integer)"
+
+
 class TestFunctionSignatureDriftReportToDict:
     def test_to_dict_no_drift(self):
         source = [_sig("f", ("integer",))]

--- a/tests/unit/test_function_signature_parser.py
+++ b/tests/unit/test_function_signature_parser.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from confiture.core.function_signature_parser import FunctionSignature, FunctionSignatureParser
 
 
@@ -132,6 +134,102 @@ class TestFunctionSignatureParserNormalise:
 
     def test_unknown_type_lowercased(self):
         assert self.parser._normalise_type("JSONB") == "jsonb"
+
+    # Issue #176: array suffix must survive normalisation, and the base type must
+    # still be aliased through the suffix so source and live sides stay symmetric.
+    def test_array_suffix_preserved(self):
+        assert self.parser._normalise_type("text[]") == "text[]"
+        assert self.parser._normalise_type("uuid[]") == "uuid[]"
+
+    def test_array_suffix_aliased_base(self):
+        assert self.parser._normalise_type("int[]") == "integer[]"
+        assert self.parser._normalise_type("int4[]") == "integer[]"
+        assert self.parser._normalise_type("varchar[]") == "character varying[]"
+        assert self.parser._normalise_type("bigint[]") == "bigint[]"
+
+    def test_array_suffix_with_precision(self):
+        assert self.parser._normalise_type("numeric(10,2)[]") == "numeric[]"
+
+    def test_array_suffix_sized_is_unsized(self):
+        # PostgreSQL ignores array size; format_type renders text[5] as text[].
+        assert self.parser._normalise_type("text[5]") == "text[]"
+
+    def test_multidimensional_array(self):
+        assert self.parser._normalise_type("int4[][]") == "integer[][]"
+
+    def test_pg_catalog_array(self):
+        assert self.parser._normalise_type("pg_catalog.int4[]") == "integer[]"
+
+
+class TestFunctionSignatureParserArrays:
+    """Array parameter types must round-trip with the ``[]`` suffix on BOTH tiers.
+
+    Regression for issue #176: the pglast path dropped ``[]`` (it read
+    ``argType.names`` but ignored ``argType.arrayBounds``), producing false stale
+    overloads and a destructive ``DROP FUNCTION`` for functions that exist in both
+    the DB and the DDL; the regex path kept ``[]`` but failed to alias the base
+    type through the suffix (``int[]`` vs live ``integer[]``).
+    """
+
+    def setup_method(self):
+        self.parser = FunctionSignatureParser()
+
+    def test_regex_preserves_array_suffix(self):
+        sql = "CREATE FUNCTION f(a TEXT, b TEXT[]) RETURNS void AS $$ $$ LANGUAGE sql;"
+        sigs = self.parser._parse_regex(sql)
+        assert sigs[0].param_types == ("text", "text[]")
+
+    def test_regex_aliases_base_through_array_suffix(self):
+        sql = "CREATE FUNCTION f(a INT[], b VARCHAR[], c NUMERIC(10,2)[]) RETURNS void AS $$ $$ LANGUAGE sql;"
+        sigs = self.parser._parse_regex(sql)
+        assert sigs[0].param_types == ("integer[]", "character varying[]", "numeric[]")
+
+    def test_regex_array_with_default_expression(self):
+        # The exact shape from issue #176: col TYPE[] DEFAULT ARRAY[]::TYPE[]
+        sql = (
+            "CREATE FUNCTION f(a text, b text[] DEFAULT ARRAY[]::text[]) "
+            "RETURNS void AS $$ $$ LANGUAGE sql;"
+        )
+        sigs = self.parser._parse_regex(sql)
+        assert sigs[0].param_types == ("text", "text[]")
+
+    def test_regex_multidim_array(self):
+        sql = "CREATE FUNCTION f(m INT[][]) RETURNS void AS $$ $$ LANGUAGE sql;"
+        sigs = self.parser._parse_regex(sql)
+        assert sigs[0].param_types == ("integer[][]",)
+
+    def test_pglast_preserves_array_suffix(self):
+        # parse() routes to pglast when installed — the production path.
+        pytest.importorskip("pglast")
+        sql = (
+            "CREATE FUNCTION core.build_mutation_response("
+            "a text, b text, c uuid, d text, e jsonb, tags text[], g jsonb, h jsonb) "
+            "RETURNS void AS $$ $$ LANGUAGE sql;"
+        )
+        sigs = self.parser.parse(sql)
+        assert len(sigs) == 1
+        assert sigs[0].param_types == (
+            "text",
+            "text",
+            "uuid",
+            "text",
+            "jsonb",
+            "text[]",
+            "jsonb",
+            "jsonb",
+        )
+
+    def test_pglast_aliases_base_through_array_suffix(self):
+        pytest.importorskip("pglast")
+        sql = "CREATE FUNCTION f(a INT[], b BIGINT[], c VARCHAR[]) RETURNS void AS $$ $$ LANGUAGE sql;"
+        sigs = self.parser.parse(sql)
+        assert sigs[0].param_types == ("integer[]", "bigint[]", "character varying[]")
+
+    def test_pglast_multidimensional_array(self):
+        pytest.importorskip("pglast")
+        sql = "CREATE FUNCTION f(m int[][]) RETURNS void AS $$ $$ LANGUAGE sql;"
+        sigs = self.parser.parse(sql)
+        assert sigs[0].param_types == ("integer[][]",)
 
 
 class TestFunctionSignatureKey:

--- a/tests/unit/test_live_function_catalog_bodies.py
+++ b/tests/unit/test_live_function_catalog_bodies.py
@@ -132,6 +132,31 @@ def test_get_bodies_empty_when_no_functions():
 # ---------------------------------------------------------------------------
 
 
+def test_array_signature_body_key_pairs_with_source_parser():
+    """Issue #176 blind spot: with the array suffix preserved on both sides, a
+    live array-typed function's body key must equal the source parser's key so
+    ``--check-body`` can pair (and diff) it instead of silently skipping."""
+    from confiture.core.function_signature_parser import FunctionSignatureParser
+
+    conn = MagicMock()
+    with patch("confiture.core.live_function_catalog.FunctionIntrospector") as intr_cls:
+        intr_cls.return_value.introspect.return_value = _catalog_mock(
+            [_make_fn_info("core", "build_response", ["text", "text[]", "uuid[]"], "LIVE_BODY")]
+        )
+        live = LiveFunctionCatalog(conn)
+        live_bodies = live.get_bodies(schemas=["core"])
+
+    source_sigs = FunctionSignatureParser().parse(
+        "CREATE FUNCTION core.build_response(a text, tags text[], ids uuid[]) "
+        "RETURNS void AS $$ $$ LANGUAGE sql;"
+    )
+    source_keys = {s.signature_key() for s in source_sigs}
+
+    assert "core.build_response(text,text[],uuid[])" in live_bodies
+    # The pairing key (intersection) is non-empty — the blind spot is closed.
+    assert set(live_bodies) & source_keys == {"core.build_response(text,text[],uuid[])"}
+
+
 def test_get_signatures_and_get_bodies_share_one_introspect_call():
     conn = MagicMock()
     with patch("confiture.core.live_function_catalog.FunctionIntrospector") as intr_cls:

--- a/tests/unit/test_migrate_validate_check_body_replay.py
+++ b/tests/unit/test_migrate_validate_check_body_replay.py
@@ -1,0 +1,127 @@
+"""CLI tests for `migrate validate --check-body-replay` (#179).
+
+The DB-backed detector is covered in tests/integration/test_replay_drift.py;
+here we patch ``check_replay_drift`` to exercise the CLI wiring: exit codes,
+JSON shape, --show-diff gate, and the broken-migration error path.
+"""
+
+import json
+import re
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.function_body_drift import FunctionBodyDrift, FunctionBodyDriftReport
+from confiture.core.validation.replay_drift import ReplayDriftResult
+from confiture.exceptions import SchemaError
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _clean() -> ReplayDriftResult:
+    return ReplayDriftResult(
+        body_report=FunctionBodyDriftReport(
+            body_drifts=[], functions_checked=7, has_drift=False, detection_time_ms=6.0
+        ),
+        ssh_target=None,
+    )
+
+
+def _drift() -> ReplayDriftResult:
+    return ReplayDriftResult(
+        body_report=FunctionBodyDriftReport(
+            body_drifts=[
+                FunctionBodyDrift(
+                    schema="public",
+                    name="total",
+                    signature_key="public.total()",
+                    source_hash="1111aaaa2222",
+                    db_hash="3333bbbb4444",
+                    expected_body="SELECT sum(price) FROM widgets;",
+                    live_body="SELECT sum(price) * 1.2 FROM widgets;",
+                    unified_diff=(
+                        "--- public.total() (expected)\n"
+                        "+++ public.total() (live)\n"
+                        "@@ -1 +1 @@\n"
+                        "-select sum(price) from widgets;\n"
+                        "+select sum(price) * 1.2 from widgets;"
+                    ),
+                )
+            ],
+            functions_checked=7,
+            has_drift=True,
+            detection_time_ms=11.0,
+        ),
+        ssh_target=None,
+    )
+
+
+def _invoke(tmp_path, result_or_exc, extra_args):
+    config = tmp_path / "confiture.yaml"
+    config.write_text("name: x\ndatabase_url: postgresql://localhost/test\n")
+    kwargs = (
+        {"side_effect": result_or_exc}
+        if isinstance(result_or_exc, BaseException)
+        else {"return_value": result_or_exc}
+    )
+    with patch("confiture.core.validation.replay_drift.check_replay_drift", **kwargs):
+        return runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--check-body-replay",
+                *extra_args,
+                "--config",
+                str(config),
+            ],
+        )
+
+
+def test_clean_exits_0(tmp_path):
+    result = _invoke(tmp_path, _clean(), [])
+    assert result.exit_code == 0
+    assert "hot-patch" in _strip_ansi(result.output).lower()
+
+
+def test_drift_exits_1(tmp_path):
+    result = _invoke(tmp_path, _drift(), [])
+    assert result.exit_code == 1
+    out = _strip_ansi(result.output)
+    assert "public.total()" in out
+    assert "1111aaaa2222" in out
+
+
+def test_json_hash_only_by_default(tmp_path):
+    result = _invoke(tmp_path, _drift(), ["--format", "json"])
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["check"] == "replay_body_drift"
+    assert data["has_drift"] is True
+    entry = data["body_drifts"][0]
+    assert set(entry) == {"schema", "name", "signature_key", "source_hash", "db_hash"}
+    assert "expected_body" not in entry
+
+
+def test_json_show_diff_includes_bodies(tmp_path):
+    result = _invoke(tmp_path, _drift(), ["--show-diff", "--format", "json"])
+    assert result.exit_code == 1
+    entry = json.loads(result.output)["body_drifts"][0]
+    assert entry["expected_body"].startswith("SELECT sum(price)")
+    assert "* 1.2" in entry["live_body"]
+    assert "+select sum(price) * 1.2 from widgets;" in entry["unified_diff"]
+
+
+def test_broken_migration_surfaces_error_not_drift(tmp_path):
+    """A SchemaError from a broken replay routes through fail() (not false drift)."""
+    exc = SchemaError("Migration replay into the scratch database failed: [...]")
+    result = _invoke(tmp_path, exc, ["--format", "json"])
+    assert result.exit_code != 0
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert "replay" in data["error"]["message"].lower()

--- a/tests/unit/test_migrate_validate_check_body_views.py
+++ b/tests/unit/test_migrate_validate_check_body_views.py
@@ -1,0 +1,131 @@
+"""CLI tests for `migrate validate --check-body-views` (#174).
+
+The DB-backed detector is covered in tests/integration/test_view_body_drift_db.py;
+here we patch ``check_view_drift`` to exercise the CLI wiring: exit codes, JSON
+shape, and the --show-diff gate on definition output.
+"""
+
+import json
+import re
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.validation.view_drift import ViewDriftResult
+from confiture.core.view_body_drift import ViewBodyDrift, ViewBodyDriftReport
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _clean_result() -> ViewDriftResult:
+    return ViewDriftResult(
+        view_report=ViewBodyDriftReport(
+            body_drifts=[], views_checked=3, has_drift=False, detection_time_ms=4.0
+        ),
+        auto_built=False,
+        ssh_target=None,
+    )
+
+
+def _drift_result() -> ViewDriftResult:
+    return ViewDriftResult(
+        view_report=ViewBodyDriftReport(
+            body_drifts=[
+                ViewBodyDrift(
+                    schema="public",
+                    name="v_etl_unused_meters",
+                    relkind="v",
+                    source_hash="aaaa1111bbbb",
+                    db_hash="cccc2222dddd",
+                    expected_def="SELECT id\nFROM meters\nWHERE meter_at > max_volume_date;",
+                    live_def="SELECT id\nFROM meters\nWHERE meter_at > (max_volume_date + 1);",
+                    unified_diff=(
+                        "--- public.v_etl_unused_meters (expected)\n"
+                        "+++ public.v_etl_unused_meters (live)\n"
+                        "@@ -1,3 +1,3 @@\n"
+                        " SELECT id\n"
+                        " FROM meters\n"
+                        "-WHERE meter_at > max_volume_date;\n"
+                        "+WHERE meter_at > (max_volume_date + 1);"
+                    ),
+                )
+            ],
+            views_checked=1,
+            has_drift=True,
+            detection_time_ms=12.0,
+        ),
+        auto_built=False,
+        ssh_target=None,
+    )
+
+
+def _invoke(tmp_path, result, extra_args):
+    config = tmp_path / "confiture.yaml"
+    config.write_text("database:\n  url: postgresql://localhost/test\n")
+    schema = tmp_path / "schema.sql"
+    schema.write_text("-- views")
+    with patch(
+        "confiture.core.validation.view_drift.check_view_drift",
+        return_value=result,
+    ):
+        return runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--check-body-views",
+                *extra_args,
+                "--config",
+                str(config),
+                "--schema",
+                str(schema),
+            ],
+        )
+
+
+def test_clean_exits_0(tmp_path):
+    result = _invoke(tmp_path, _clean_result(), [])
+    assert result.exit_code == 0
+    assert "view definition drift" in _strip_ansi(result.output).lower()
+
+
+def test_drift_exits_1(tmp_path):
+    result = _invoke(tmp_path, _drift_result(), [])
+    assert result.exit_code == 1
+    out = _strip_ansi(result.output)
+    assert "v_etl_unused_meters" in out
+    assert "aaaa1111bbbb" in out
+
+
+def test_json_hash_only_by_default(tmp_path):
+    result = _invoke(tmp_path, _drift_result(), ["--format", "json"])
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["check"] == "view_body_drift"
+    assert data["has_drift"] is True
+    entry = data["body_drifts"][0]
+    assert set(entry) == {"schema", "name", "relkind", "source_hash", "db_hash"}
+    assert "expected_def" not in entry
+
+
+def test_json_show_diff_includes_defs(tmp_path):
+    result = _invoke(tmp_path, _drift_result(), ["--show-diff", "--format", "json"])
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    entry = data["body_drifts"][0]
+    assert entry["expected_def"].startswith("SELECT id")
+    assert "max_volume_date + 1" in entry["live_def"]
+    assert "+WHERE meter_at > (max_volume_date + 1);" in entry["unified_diff"]
+
+
+def test_text_show_diff_prints_diff(tmp_path):
+    result = _invoke(tmp_path, _drift_result(), ["--show-diff"])
+    assert result.exit_code == 1
+    out = _strip_ansi(result.output)
+    assert "-WHERE meter_at > max_volume_date;" in out
+    assert "+WHERE meter_at > (max_volume_date + 1);" in out

--- a/tests/unit/test_migrate_validate_check_signatures.py
+++ b/tests/unit/test_migrate_validate_check_signatures.py
@@ -73,6 +73,35 @@ def _drift_body_report() -> FunctionBodyDriftReport:
     )
 
 
+def _drift_body_report_with_bodies() -> FunctionBodyDriftReport:
+    """Like _drift_body_report but with bodies + a unified diff populated."""
+    return FunctionBodyDriftReport(
+        body_drifts=[
+            FunctionBodyDrift(
+                schema="public",
+                name="my_function",
+                signature_key="public.my_function(uuid,bigint)",
+                source_hash="a3f8c1d2e4f9",
+                db_hash="7b2e09f1c3a8",
+                expected_body="SELECT $1 + 1;",
+                live_body="SELECT $1 + 2;",
+                expected_normalized="select $1 + 1;",
+                live_normalized="select $1 + 2;",
+                unified_diff=(
+                    "--- public.my_function(uuid,bigint) (expected)\n"
+                    "+++ public.my_function(uuid,bigint) (live)\n"
+                    "@@ -1 +1 @@\n"
+                    "-select $1 + 1;\n"
+                    "+select $1 + 2;"
+                ),
+            )
+        ],
+        functions_checked=1,
+        has_drift=True,
+        detection_time_ms=10.0,
+    )
+
+
 runner = CliRunner()
 
 
@@ -470,3 +499,101 @@ class TestCheckBodyFlag:
             )
 
         assert result.exit_code == expected_exit
+
+    # ------------------------------------------------------------------
+    # Cycle 6 (#177): --show-diff surfaces bodies + unified diff
+    # ------------------------------------------------------------------
+
+    def _run_show_diff(self, tmp_path, args: list[str]):
+        config = tmp_path / "confiture.yaml"
+        config.write_text("database:\n  url: postgresql://localhost/test\n")
+        schema = tmp_path / "schema.sql"
+        schema.write_text("-- no functions")
+
+        with (
+            patch(
+                "confiture.core.validation.signature_drift.load_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "confiture.core.validation.signature_drift.open_connection",
+                self._make_open_conn_mock(),
+            ),
+            patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntr,
+            patch(
+                "confiture.core.function_signature_drift.FunctionSignatureDriftDetector.compare",
+                return_value=_empty_report(),
+            ),
+            patch(
+                "confiture.core.function_body_drift.FunctionBodyDriftDetector.compare",
+                return_value=_drift_body_report_with_bodies(),
+            ),
+        ):
+            MockIntr.return_value.introspect.return_value = MagicMock(functions=[])
+            return runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "validate",
+                    "--check-signatures",
+                    "--check-body",
+                    *args,
+                    "--config",
+                    str(config),
+                    "--schema",
+                    str(schema),
+                ],
+            )
+
+    def test_show_diff_requires_check_body(self, tmp_path):
+        config = tmp_path / "confiture.yaml"
+        config.write_text("database:\n  url: postgresql://localhost/test\n")
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--check-signatures",
+                "--show-diff",
+                "--config",
+                str(config),
+            ],
+        )
+        # Usage guard routes through fail() (CONFIG_001 → exit 5), same as --check-body.
+        assert result.exit_code == 5
+
+    def test_check_body_show_diff_json_includes_bodies(self, tmp_path):
+        import json
+
+        result = self._run_show_diff(tmp_path, ["--show-diff", "--format", "json"])
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        entry = data["body_drift"]["body_drifts"][0]
+        assert entry["expected_body"] == "SELECT $1 + 1;"
+        assert entry["live_body"] == "SELECT $1 + 2;"
+        assert "-select $1 + 1;" in entry["unified_diff"]
+        assert "+select $1 + 2;" in entry["unified_diff"]
+        # Hashes still present (back-compat).
+        assert entry["source_hash"] == "a3f8c1d2e4f9"
+
+    def test_check_body_without_show_diff_stays_hash_only(self, tmp_path):
+        import json
+
+        # Even when the report carries bodies, the default JSON must not leak them.
+        result = self._run_show_diff(tmp_path, ["--format", "json"])
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        entry = data["body_drift"]["body_drifts"][0]
+        assert set(entry) == {"schema", "name", "signature_key", "source_hash", "db_hash"}
+        assert "expected_body" not in entry
+        assert "unified_diff" not in entry
+
+    def test_check_body_show_diff_text_prints_diff(self, tmp_path):
+        result = self._run_show_diff(tmp_path, ["--show-diff"])
+
+        assert result.exit_code == 1
+        output = _strip_ansi(result.output)
+        assert "-select $1 + 1;" in output
+        assert "+select $1 + 2;" in output

--- a/tests/unit/test_migrate_validate_require_migration_bodies.py
+++ b/tests/unit/test_migrate_validate_require_migration_bodies.py
@@ -1,0 +1,112 @@
+"""CLI tests for `migrate validate --require-migration-bodies` / `--list-unmigrated-bodies` (#178).
+
+The FunctionBodyChecker logic is covered in test_function_body_checker.py; here we
+patch the accompaniment checker to exercise the CLI wiring: enforcement exit
+codes, JSON shape, and the report-only (non-failing) backlog mode.
+"""
+
+import json
+import re
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.function_body_checker import FunctionBodyViolation
+from confiture.models.git import MigrationAccompanimentReport
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _violation() -> FunctionBodyViolation:
+    return FunctionBodyViolation(
+        function_key="public.calc",
+        signature_key="public.calc(integer)",
+        migration_file=None,
+        message="body changed with no migration",
+        unified_diff="-select p_id * 1\n+select p_id * 2",
+    )
+
+
+def _report(*, body_violations) -> MigrationAccompanimentReport:
+    return MigrationAccompanimentReport(
+        has_ddl_changes=False,
+        has_new_migrations=False,
+        base_ref="origin/main",
+        target_ref="HEAD",
+        body_violations=body_violations,
+    )
+
+
+def _invoke(args, report):
+    with (
+        patch("confiture.cli.git_validation.validate_git_flags_in_repo", return_value=None),
+        patch(
+            "confiture.core.git_accompaniment.MigrationAccompanimentChecker.check_accompaniment",
+            return_value=report,
+        ),
+    ):
+        return runner.invoke(app, ["migrate", "validate", *args])
+
+
+# ---------------------------------------------------------------------------
+# --require-migration-bodies (enforce)
+# ---------------------------------------------------------------------------
+
+
+def test_require_bodies_clean_exits_0():
+    result = _invoke(["--require-migration-bodies"], _report(body_violations=[]))
+    assert result.exit_code == 0
+
+
+def test_require_bodies_violation_exits_1():
+    result = _invoke(
+        ["--require-migration-bodies", "--format", "json"], _report(body_violations=[_violation()])
+    )
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["check"] == "accompaniment"
+    assert data["is_valid"] is False
+    assert data["body_violations"][0]["signature_key"] == "public.calc(integer)"
+
+
+def test_require_bodies_text_shows_fix_hint():
+    result = _invoke(["--require-migration-bodies"], _report(body_violations=[_violation()]))
+    assert result.exit_code == 1
+    out = _strip_ansi(result.output)
+    assert "public.calc(integer)" in out
+    assert "CREATE OR REPLACE FUNCTION public.calc" in out
+
+
+# ---------------------------------------------------------------------------
+# --list-unmigrated-bodies (report-only, never fails)
+# ---------------------------------------------------------------------------
+
+
+def test_list_unmigrated_bodies_reports_without_failing():
+    result = _invoke(
+        ["--list-unmigrated-bodies", "--format", "json"], _report(body_violations=[_violation()])
+    )
+    assert result.exit_code == 0  # report-only never fails
+    data = json.loads(result.output)
+    assert data["check"] == "unmigrated_bodies"
+    assert data["count"] == 1
+    assert data["body_violations"][0]["signature_key"] == "public.calc(integer)"
+
+
+def test_list_unmigrated_bodies_clean_exits_0():
+    result = _invoke(["--list-unmigrated-bodies"], _report(body_violations=[]))
+    assert result.exit_code == 0
+    assert "no un-migrated function body" in _strip_ansi(result.output).lower()
+
+
+def test_require_migration_without_bodies_flag_does_not_check_bodies():
+    """Back-compat: plain --require-migration never surfaces body violations."""
+    # Even if the (patched) checker were asked, --require-migration passes
+    # check_bodies=False; a report with no body_violations stays valid.
+    result = _invoke(["--require-migration"], _report(body_violations=[]))
+    assert result.exit_code == 0

--- a/tests/unit/test_no_raw_exit_convention.py
+++ b/tests/unit/test_no_raw_exit_convention.py
@@ -55,9 +55,10 @@ _ALLOWLIST: dict[str, int] = {
     # MigrateDiffResult domain formatter), migrate fix-signatures, and migrate
     # preflight (already mostly fail()-routed via computed Exit(exit_code)).
     # TODO(follow-up): finish diff / fix-signatures / preflight contract sweep.
-    # +1 (28): --check-body-views drift gate (Exit(1), success-signal — same kind
-    # as the --check-signatures gate; a CI drift signal, not a failure path).
-    "commands/migrate_analysis.py": 28,
+    # +2 (29): --check-body-views (28) and --check-body-replay (29) drift gates —
+    # both Exit(1) success-signals (CI drift signals, same kind as the
+    # --check-signatures gate), not failure paths.
+    "commands/migrate_analysis.py": 29,
     # ---- migrate_core: status/up/down/generate/estimate ----
     # Mix of success-signal (status→1 pending) and not-yet-converted failures;
     # already partially routed through fail(). Paid down opportunistically.

--- a/tests/unit/test_no_raw_exit_convention.py
+++ b/tests/unit/test_no_raw_exit_convention.py
@@ -55,7 +55,9 @@ _ALLOWLIST: dict[str, int] = {
     # MigrateDiffResult domain formatter), migrate fix-signatures, and migrate
     # preflight (already mostly fail()-routed via computed Exit(exit_code)).
     # TODO(follow-up): finish diff / fix-signatures / preflight contract sweep.
-    "commands/migrate_analysis.py": 27,
+    # +1 (28): --check-body-views drift gate (Exit(1), success-signal — same kind
+    # as the --check-signatures gate; a CI drift signal, not a failure path).
+    "commands/migrate_analysis.py": 28,
     # ---- migrate_core: status/up/down/generate/estimate ----
     # Mix of success-signal (status→1 pending) and not-yet-converted failures;
     # already partially routed through fail(). Paid down opportunistically.

--- a/tests/unit/test_temp_database.py
+++ b/tests/unit/test_temp_database.py
@@ -37,11 +37,23 @@ class TestMaintenanceUrl:
         result = _maintenance_url("postgresql://host:5432")
         assert result == "postgresql://host:5432/postgres"
 
+    def test_hostless_socket_dsn_keeps_authority_marker(self) -> None:
+        """A hostless DSN (postgresql:///db) must not lose its '//' marker.
+
+        urlunparse drops the authority marker for an empty netloc, yielding the
+        malformed 'postgresql:/postgres'; it must round-trip to a libpq-valid
+        'postgresql:///postgres'.
+        """
+        assert _maintenance_url("postgresql:///confiture_test") == "postgresql:///postgres"
+
 
 class TestReplaceDbname:
     def test_replaces_database_component(self) -> None:
         result = _replace_dbname("postgresql://user:pass@host:5432/myapp", "new_db")
         assert result == "postgresql://user:pass@host:5432/new_db"
+
+    def test_hostless_socket_dsn_keeps_authority_marker(self) -> None:
+        assert _replace_dbname("postgresql:///myapp", "tmp_db") == "postgresql:///tmp_db"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_view_body_drift.py
+++ b/tests/unit/test_view_body_drift.py
@@ -1,0 +1,175 @@
+"""Unit tests for ViewBodyDriftDetector and ViewBodyDriftReport.
+
+Mirrors ``test_function_body_drift.py``. The detector compares *already-deparsed*
+view definitions (``pg_get_viewdef`` output from both the scratch/expected DB and
+the live DB), so the inputs here are the pg-normalised strings the catalog yields.
+"""
+
+from confiture.core.view_body_drift import (
+    ViewBodyDrift,
+    ViewBodyDriftDetector,
+    ViewBodyDriftReport,
+    ViewDefinition,
+)
+
+
+def _v(schema: str, name: str, relkind: str, definition: str) -> ViewDefinition:
+    return ViewDefinition(schema=schema, name=name, relkind=relkind, definition=definition)
+
+
+# ---------------------------------------------------------------------------
+# No drift
+# ---------------------------------------------------------------------------
+
+
+def test_no_drift_identical_definitions():
+    src = {"public.v": _v("public", "v", "v", "SELECT a\n   FROM t;")}
+    live = {"public.v": _v("public", "v", "v", "SELECT a\n   FROM t;")}
+    report = ViewBodyDriftDetector().compare(src, live)
+    assert not report.has_drift
+    assert report.body_drifts == []
+    assert report.views_checked == 1
+
+
+def test_no_drift_trailing_whitespace_only():
+    """Trailing whitespace per line must not register as drift."""
+    src = {"public.v": _v("public", "v", "v", "SELECT a  \nFROM t;   ")}
+    live = {"public.v": _v("public", "v", "v", "SELECT a\nFROM t;")}
+    report = ViewBodyDriftDetector().compare(src, live)
+    assert not report.has_drift
+
+
+# ---------------------------------------------------------------------------
+# Drift detected
+# ---------------------------------------------------------------------------
+
+
+def test_drift_detected_changed_predicate():
+    src = {"public.v": _v("public", "v", "v", "SELECT a\nFROM t\nWHERE x > y;")}
+    live = {"public.v": _v("public", "v", "v", "SELECT a\nFROM t\nWHERE x > (y + 1);")}
+    report = ViewBodyDriftDetector().compare(src, live)
+    assert report.has_drift
+    assert len(report.body_drifts) == 1
+    drift = report.body_drifts[0]
+    assert drift.schema == "public"
+    assert drift.name == "v"
+    assert drift.relkind == "v"
+    assert drift.source_hash != drift.db_hash
+    assert len(drift.source_hash) == 12
+    assert len(drift.db_hash) == 12
+
+
+def test_drift_record_carries_defs_and_unified_diff():
+    src = {"public.v": _v("public", "v", "v", "SELECT a\nFROM t\nWHERE x > y;")}
+    live = {"public.v": _v("public", "v", "v", "SELECT a\nFROM t\nWHERE x > (y + 1);")}
+    drift = ViewBodyDriftDetector().compare(src, live).body_drifts[0]
+    assert drift.expected_def == "SELECT a\nFROM t\nWHERE x > y;"
+    assert drift.live_def == "SELECT a\nFROM t\nWHERE x > (y + 1);"
+    assert "-WHERE x > y;" in drift.unified_diff
+    assert "+WHERE x > (y + 1);" in drift.unified_diff
+    # Unchanged lines are not reported as +/- churn.
+    assert "-SELECT a" not in drift.unified_diff
+
+
+def test_only_changed_views_listed():
+    src = {
+        "public.v1": _v("public", "v1", "v", "SELECT 1;"),
+        "public.v2": _v("public", "v2", "v", "SELECT 2;"),
+    }
+    live = {
+        "public.v1": _v("public", "v1", "v", "SELECT 1;"),
+        "public.v2": _v("public", "v2", "v", "SELECT 99;"),
+    }
+    report = ViewBodyDriftDetector().compare(src, live)
+    assert len(report.body_drifts) == 1
+    assert report.body_drifts[0].name == "v2"
+    assert report.views_checked == 2
+
+
+def test_materialized_view_covered():
+    src = {"public.mv": _v("public", "mv", "m", "SELECT sum(x) AS s\nFROM t;")}
+    live = {"public.mv": _v("public", "mv", "m", "SELECT avg(x) AS s\nFROM t;")}
+    report = ViewBodyDriftDetector().compare(src, live)
+    assert report.has_drift
+    assert report.body_drifts[0].relkind == "m"
+
+
+# ---------------------------------------------------------------------------
+# Intersection-only comparison
+# ---------------------------------------------------------------------------
+
+
+def test_source_only_view_not_compared():
+    src = {
+        "public.v": _v("public", "v", "v", "SELECT 1;"),
+        "public.ghost": _v("public", "ghost", "v", "SELECT 2;"),
+    }
+    live = {"public.v": _v("public", "v", "v", "SELECT 1;")}
+    report = ViewBodyDriftDetector().compare(src, live)
+    assert not report.has_drift
+    assert report.views_checked == 1
+
+
+def test_live_only_view_not_compared():
+    src = {"public.v": _v("public", "v", "v", "SELECT 1;")}
+    live = {
+        "public.v": _v("public", "v", "v", "SELECT 1;"),
+        "public.extra": _v("public", "extra", "v", "SELECT 2;"),
+    }
+    report = ViewBodyDriftDetector().compare(src, live)
+    assert not report.has_drift
+    assert report.views_checked == 1
+
+
+# ---------------------------------------------------------------------------
+# to_dict shapes
+# ---------------------------------------------------------------------------
+
+
+def test_drift_to_dict_hash_only_by_default():
+    src = {"public.v": _v("public", "v", "v", "SELECT a\nWHERE x > y;")}
+    live = {"public.v": _v("public", "v", "v", "SELECT a\nWHERE x > (y + 1);")}
+    drift = ViewBodyDriftDetector().compare(src, live).body_drifts[0]
+    terse = drift.to_dict()
+    assert set(terse) == {"schema", "name", "relkind", "source_hash", "db_hash"}
+    verbose = drift.to_dict(include_defs=True)
+    assert verbose["expected_def"] == "SELECT a\nWHERE x > y;"
+    assert verbose["live_def"] == "SELECT a\nWHERE x > (y + 1);"
+    assert "unified_diff" in verbose
+
+
+def test_report_to_dict_shape():
+    src = {"public.v": _v("public", "v", "v", "SELECT a\nWHERE x > y;")}
+    live = {"public.v": _v("public", "v", "v", "SELECT a\nWHERE x > (y + 1);")}
+    report = ViewBodyDriftDetector().compare(src, live)
+    payload = report.to_dict()
+    assert payload["has_drift"] is True
+    assert payload["views_checked"] == 1
+    assert "detection_time_ms" in payload
+    assert len(payload["body_drifts"]) == 1
+    assert "expected_def" not in payload["body_drifts"][0]  # hash-only by default
+    verbose = report.to_dict(include_defs=True)
+    assert verbose["body_drifts"][0]["expected_def"] == "SELECT a\nWHERE x > y;"
+
+
+def test_report_dataclass_fields_directly_constructable():
+    report = ViewBodyDriftReport(
+        body_drifts=[],
+        views_checked=0,
+        has_drift=False,
+        detection_time_ms=0.0,
+    )
+    assert report.body_drifts == []
+    assert not report.has_drift
+
+
+def test_drift_is_frozen_dataclass():
+    drift = ViewBodyDrift(
+        schema="public",
+        name="v",
+        relkind="v",
+        source_hash="aabbccddeeff",
+        db_hash="112233445566",
+    )
+    assert drift.schema == "public"
+    assert drift.relkind == "v"


### PR DESCRIPTION
Ships the **2026-07-08 drift-guard epic** — one PrintOptim production drift audit, eight phases, cut as **0.36.0**.

## What this fixes / adds

**Bug fixes (correctness):**
- **#176** — the `--check-signatures` parser dropped the `[]` array suffix, so array-typed functions falsely read as stale overloads and generated a **destructive `DROP FUNCTION`** for functions that exist in both the DB and the DDL. Fixed on both parser tiers + a drift-detector safety net.
- **#175** — `drift --schema` parsed **zero tables** on any commented DDL (including `confiture build`'s own separators) → 100% false `extra_table` drift with exit 0. Comments now stripped before parsing; a declares-tables-but-parses-zero schema fails loudly (`SCHEMA_202`).

**New body-drift family on `migrate validate`** (all reuse the Phase 4 scratch-DB foundation + Phase 3 diff output):
- **#177** — `--check-body --show-diff` emits the expected body, live body, and a unified diff (was two 12-char hashes).
- **#174** — `--check-body-views` detects view/matview definition drift, scratch-normalized through the same `pg_get_viewdef` deparser so formatting/schema-qualification/`*`-expansion differences don't false-positive.
- **#179** — `--check-body-replay` rebuilds the expected DB by replaying migrations into a scratch DB and diffs `prosrc` vs live → isolates true out-of-band hot-patches (excludes the build-vs-migrate backlog).
- **#178** — `--require-migration-bodies` (+ report-only `--list-unmigrated-bodies`) fails a body change with no accompanying migration at PR time (static, git-based). Layers with #179's runtime check.

**Foundation:** `ExpectedSchemaDB` (build the expected schema into a throwaway DB, read it back through pg's deparser) + a fix for hostless socket DSNs (`postgresql:///db`) in the scratch-DB machinery.

**Deferred RFCs:** #150 and #158 dispositioned as tracked RFCs (no code) — see their issue comments.

## Verification
- ✅ 8103 unit pass, 41 skipped; view/replay/expected_db/body_drift integration green against PG 17.8
- ✅ `ruff check` + `ruff format --check` + `ty check` clean
- ✅ Every phase strict TDD with a real-DB / real-CLI empirical verification

Pre-1.0; #176 changes stale-overload remediation behaviour (flagged in CHANGELOG). Closes #174, #175, #176, #177, #178, #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)