### PR TITLE
0.37.0 — ship-gate ergonomics (#182, #181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,16 @@ ship gate, where the gate broke on states confiture should treat as normal.
 - `docs/reference/cli.md` gained `migrate verify` and `verify-checksums`
   sections; neither command was documented there before.
 
+### Changed
+
+- The `ast` extra now requires `pglast>=6.0,<8` rather than `pglast>=6.0`.
+  pglast 8.0 reshaped the AST that the idempotency detector, the
+  `sec_002` security-definer rule and the operation classifier walk — ALTER
+  TABLE subtype handling, OWNER TO detection and constraint nodes all moved.
+  Installing `fraiseql-confiture[ast]` alongside pglast 8.x previously produced
+  silently degraded analysis; it is now a resolver conflict instead.  If you
+  need pglast 8, stay on the regex fallback until 8.x support lands.
+
 ### Known scope limits
 
 `--base-ref` scoping covers `--idempotent` only.  The other directory-wide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-07-20
+
+Ship-gate ergonomics: two contract bugs found by wiring confiture into a CI
+ship gate, where the gate broke on states confiture should treat as normal.
+
+### BREAKING
+
+- `migrate verify` now exits **2** (`PRECON_1001`) instead of crashing to exit 1
+  when the database has no migration ledger, and its JSON payload gained a
+  `ledger_present` field.  Both are contract changes under the fraisier adapter
+  contract, amended in step: exit 2 from `verify` means "no migration ledger",
+  **not** `InvalidConfig`.  Consumers validating against the previous
+  `migrate-verify` schema must update — it sets `additionalProperties: false`.
+  `ledger_present` is declared optional, so it is not added to `required`.
+
+### Fixed
+
+- `verify-checksums`, its deprecated `verify` alias, and `migrate verify` no
+  longer surface a raw `relation "tb_confiture" does not exist` against a
+  database with no migration ledger.  They report the state clearly and exit 2.
+  Previously this crashed to exit 1 — the same code `verify-checksums` uses for
+  "checksum mismatches found" — so a CI gate could not tell the two apart.
+  (#182)
+- `MigratorSession.preflight()` no longer raises on a ledger-less database; it
+  skips the checksum step and reports `checksum_skipped_reason`, consistent
+  with `status()` and `current_revision()`.  This third call site is
+  library-only, but it is the documented idiom.  (#182)
+- `migrate verify -c <config>` crashed with `AttributeError: 'str' object has
+  no attribute 'exists'` — the command's own documented primary invocation.  It
+  passed `str(config)` to `load_config`, which calls `config_file.exists()`;
+  every other call site in the CLI passes the `Path`.
+- `--base-ref` scoping anchors on the merge-base and diffs two-dot, so it works
+  in shallow CI clones where a three-dot diff fails with "no merge base" (rc
+  128, previously unclassified and reported without a remedy).  The same fix
+  applies to `--require-migration --base-ref`, which carried the latent bug.
+- `--base-ref` scoping resolves the repository root explicitly, so it is
+  correct when run from a subdirectory.  `GitRepository.repo_path` is the
+  subprocess cwd, not the root, while `git diff --name-only` reports
+  root-relative paths — the mismatch produced an empty selection and a gate
+  that passed having scanned nothing.
+- `--idempotent` combined with `--check-drift`, `--require-migration`,
+  `--require-migration-bodies` or `--require-grant-migration` now errors
+  instead of silently running only the first: all branches end in a bare
+  `return` and are evaluated in source order.
+- Corrected `confiture migrate verify-checksums` → `confiture verify-checksums`
+  in the shipped CI templates (GitHub Actions, GitLab, Argo, Jenkins) and the
+  operations docs — 11 sites, none of which named an existing command.  Also
+  removed a non-existent `--env` flag and a non-existent `--full` flag from the
+  examples, and corrected `pip install confiture` to `fraiseql-confiture`.
+
+### Added
+
+- `--allow-uninitialized` on `verify-checksums` and `migrate verify`: treat "no
+  migration ledger" as success (exit 0), for gates that legitimately run
+  against schema-built databases.  Opt-in rather than default, because the
+  failure mode of forgetting it is a green ship gate against an unmigrated
+  database.  (#182)
+- `--base-ref` / `--since` on `migrate validate --idempotent`: validate only
+  migrations added or modified since a git ref, so the check is usable as a
+  hard gate in a project with an unremediated back-catalogue.  Requires an
+  **explicit** flag — the option's `origin/main` default does not scope, and
+  the unscoped behaviour is unchanged.  (#181)
+- `--staged` now works with `--idempotent`, analyzing the staging **index**
+  rather than the working tree, for pre-commit gates.  Previously the
+  combination was silently ignored and idempotency never ran.  (#181)
+- `ledger_present` in `migrate verify` JSON; `meta.scope` in
+  `migrate validate --idempotent` JSON (absent entirely when unscoped).
+- New `GIT_003` (exit 7): base ref unreachable in this checkout, with the
+  `fetch-depth: 0` / `git fetch --unshallow` remedy stated in the message.
+- `confiture.core.ledger.ledger_exists()` — one connection-level ledger probe,
+  replacing two byte-identical copies of the query in `core/_migrator/state.py`.
+- `docs/reference/cli.md` gained `migrate verify` and `verify-checksums`
+  sections; neither command was documented there before.
+
+### Known scope limits
+
+`--base-ref` scoping covers `--idempotent` only.  The other directory-wide
+`migrate validate` checks — `--check-acls`, `--check-ownership-coverage`,
+`--check-function-uniqueness`, `--check-security-definer`, `--check-imports` —
+still scan everything, and three of them block on any violation.
+
 ## [0.36.0] - 2026-07-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.36.0
-**Last Updated**: 2026-07-08
+**Version**: 0.37.0
+**Last Updated**: 2026-07-20
 **Current Status**: Production-Ready
 
 > **Status**: Production-ready. Actively used in production since March 2026.
@@ -926,8 +926,8 @@ When stuck, ask:
 
 ---
 
-**Last Updated**: 2026-07-08
-**Version**: 0.36.0
+**Last Updated**: 2026-07-20
+**Version**: 0.37.0
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,7 @@ confiture/
 │   │   │   └── sql_ast.py          # CTENode, JSONBKey
 │   │   ├── connection.py        # create_connection, load_config
 │   │   ├── error_codes.py       # ErrorCodeDefinition, ErrorCodeRegistry
+│   │   ├── ledger.py            # ledger_exists() — shared migration-ledger probe
 │   │   ├── linting/             # SchemaLinter and rules
 │   │   ├── seed/                # Seed validation system (5 levels)
 │   │   ├── seed_validation/     # PrepSeedOrchestrator and validators

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,13 +10,13 @@
 
 ```bash
 # Install with pip
-pip install confiture
+pip install fraiseql-confiture
 
 # Install with uv (recommended)
 uv add confiture
 
 # With Rust acceleration (10-50x faster)
-pip install confiture[rust]
+pip install fraiseql-confiture[rust]
 ```
 
 ---

--- a/docs/api/migrator.md
+++ b/docs/api/migrator.md
@@ -177,7 +177,7 @@ atomically (no partial rollback) if any is missing.
 |--------|---------|
 | `reinit(...)` | Rebuild the tracking table from the migration files on disk. |
 | `rebuild(...)` | Drop and recreate the tracking table (recovery). |
-| `preflight(...)` | Static safety checks on pending migrations (the `migrate preflight` engine). |
+| `preflight(...)` | Static safety checks on pending migrations (the `migrate preflight` engine). On a database with no migration ledger it skips the checksum step and sets `checksum_verified=False` with a `checksum_skipped_reason`, rather than raising — consistent with `status()` and `current_revision()`. |
 | `run_against(...)` | SAVEPOINT-replay pending migrations against a target database. |
 | `is_locked()` | Whether the migration advisory lock is currently held. |
 | `get_lock_holder()` | Details of the process holding the lock, or `None`. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ Install Confiture using pip or uv:
 
 ```bash
 # Using pip
-pip install confiture
+pip install fraiseql-confiture
 
 # Using uv (recommended)
 uv add confiture
@@ -408,7 +408,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Validate schema changes
         run: |

--- a/docs/guides/01-build-from-ddl.md
+++ b/docs/guides/01-build-from-ddl.md
@@ -143,7 +143,7 @@ Check `include_dirs` in your environment config matches your directory structure
 Add `IF NOT EXISTS` to all CREATE statements.
 
 ### Build slow (>5s)
-Rust extension may not be installed. Reinstall with: `pip install confiture`
+Rust extension may not be installed. Reinstall with: `pip install fraiseql-confiture`
 
 ---
 

--- a/docs/guides/copy-format-examples.md
+++ b/docs/guides/copy-format-examples.md
@@ -178,7 +178,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install confiture
+          pip install fraiseql-confiture
           pip install -r requirements-test.txt
 
       - name: Build database with seeds
@@ -441,7 +441,7 @@ FROM postgres:16-alpine AS builder
 
 # Install Python and Confiture
 RUN apk add --no-cache python3 py3-pip
-RUN pip install confiture
+RUN pip install fraiseql-confiture
 
 # Copy schema and seeds
 COPY db/schema /app/db/schema

--- a/docs/guides/copy-format-loading.md
+++ b/docs/guides/copy-format-loading.md
@@ -503,7 +503,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Build and seed database
         run: |

--- a/docs/guides/git-aware-validation.md
+++ b/docs/guides/git-aware-validation.md
@@ -91,7 +91,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Validate schema changes
         run: |
@@ -109,7 +109,7 @@ jobs:
 validate_schema:
   stage: test
   script:
-    - pip install confiture
+    - pip install fraiseql-confiture
     - confiture migrate validate \
         --check-drift \
         --require-migration \

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -57,7 +57,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Dry-run migrations
         env:
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Run migrations
         env:
@@ -143,7 +143,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Extract modified tables
         id: tables
@@ -222,7 +222,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Extract feature info
         id: feature
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Export coordination status
         env:
@@ -333,7 +333,7 @@ schema-conflict-check:
   variables:
     COORDINATION_DB_URL: $COORDINATION_DB_URL
   before_script:
-    - pip install confiture
+    - pip install fraiseql-confiture
   script:
     - |
       # Extract modified tables

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -317,6 +317,111 @@ Python migrations are intentionally **not** auto-rewritten — unparsing
 the AST would lose comments and formatting. Violations in `.py` files
 must be fixed by hand.
 
+### Scoping to changed migrations — `--base-ref` / `--since` / `--staged`
+
+*New in 0.37.0.*
+
+By default `--idempotent` scans **every** migration in the directory. In a
+project that adopted the check after accumulating a back-catalogue, that makes
+it unusable as a hard gate: every branch fails on violations it did not
+introduce, so the gate gets set to warn-only and stops protecting anything.
+
+Scope it instead to what the branch actually changed, and the gate becomes a
+ratchet — new migrations must be idempotent, the backlog drains on its own
+schedule:
+
+```bash
+confiture migrate validate --idempotent --base-ref origin/main
+```
+
+**In CI, `fetch-depth: 0` is required.** `actions/checkout` defaults to a
+shallow clone with no `origin/main` and no merge base:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0          # ← required
+- run: confiture migrate validate --idempotent --base-ref origin/main
+```
+
+Omit it and the run fails with `GIT_003` (exit 7) naming the remedy. That is
+deliberate — see *fail loud*, below.
+
+#### Pre-commit hooks: use `--staged`
+
+`--base-ref` compares **committed trees**, so a migration that is staged but
+not yet committed is invisible to it and a pre-commit hook would scope to zero
+and pass. `--staged` reads the **staging index** instead:
+
+```yaml
+# .pre-commit-config.yaml
+- repo: local
+  hooks:
+    - id: confiture-idempotent
+      name: Validate staged migrations are idempotent
+      entry: confiture migrate validate --idempotent --staged
+      language: system
+      pass_filenames: false
+```
+
+It analyzes the index blob, not the working tree — the two differ when a file is
+staged and then edited further, and the hook must judge what is about to be
+committed. When both `--staged` and `--base-ref` are passed, `--staged` wins.
+
+#### Scoping requires an explicit flag
+
+⚠️ `--base-ref` carries a default value of `origin/main`, but **that default
+does not scope**. A bare `confiture migrate validate --idempotent` scans
+everything, exactly as it did before 0.37.0, and still works outside a git
+repository entirely. Only an explicitly passed `--base-ref`, `--since`, or
+`--staged` turns scoping on.
+
+This matters more than it looks: gating on the *value* rather than on whether
+the flag was passed would silently scope every run in the project, and make a
+plain `--idempotent` fail on any non-git tree.
+
+#### Fail loud, never silently empty
+
+Scoping errors are hard failures rather than empty selections, because a gate
+that scanned zero files reports success while checking nothing — strictly worse
+than the backlog problem it was introduced to solve:
+
+| Situation | Outcome |
+|---|---|
+| Base ref not in this checkout (shallow clone) | `GIT_003`, exit 7, message names `fetch-depth: 0` |
+| Not in a git repository, with an explicit scope flag | `GIT_002`, exit 7 |
+| `--migrations-dir` outside the repository | Configuration error — the intersection could only ever be empty |
+| Nothing changed since the base ref | **Exit 0**, with a message distinct from "directory is empty" |
+
+Shallow clones that *do* have the ref but no merge base still work: scoping
+anchors on `git merge-base` and diffs two-dot, which is equivalent to three-dot
+wherever a merge base exists and survives where it cannot be computed.
+
+#### Reporting
+
+Text mode prints the selection before the backend banner:
+
+```
+🔍 Scoped to 3 migration(s) changed since origin/main (412 skipped)
+```
+
+JSON reports it under `meta.scope`:
+
+```json
+"meta": {
+  "backend": "ast",
+  "scope": {"mode": "base-ref", "base_ref": "origin/main",
+            "files_selected": 3, "files_skipped": 412}
+}
+```
+
+An unscoped run emits no `scope` key at all, so a consumer can tell the two
+apart.
+
+⚠️ Only `--idempotent` is scopable today. The other directory-wide checks —
+`--check-acls`, `--check-ownership-coverage`, `--check-function-uniqueness`,
+`--check-security-definer`, `--check-imports` — still scan everything.
+
 ## `--check-signatures` and `--check-body`
 
 These two flags compare the functions declared in your source DDL against the

--- a/docs/guides/migration-naming-best-practices.md
+++ b/docs/guides/migration-naming-best-practices.md
@@ -377,7 +377,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Validate migration naming
         run: |

--- a/docs/guides/prep-seed-validation.md
+++ b/docs/guides/prep-seed-validation.md
@@ -373,7 +373,7 @@ FROM postgres:15
 
 # Install confiture
 COPY requirements.txt .
-RUN pip install confiture
+RUN pip install fraiseql-confiture
 
 # Copy seed files
 COPY db/ /app/db/

--- a/docs/guides/schema-linting.md
+++ b/docs/guides/schema-linting.md
@@ -425,7 +425,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Lint schema
         run: confiture lint --strict

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ confiture migrate schema-to-schema --source old --target new
 
 ```bash
 # Install
-pip install confiture
+pip install fraiseql-confiture
 
 # Initialize project
 confiture init

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -62,10 +62,10 @@ Confiture is available on PyPI:
 
 ```bash
 # Install with pip
-pip install confiture
+pip install fraiseql-confiture
 
 # Or with uv (recommended)
-uv pip install confiture
+uv pip install fraiseql-confiture
 ```
 
 ### First Lint Command
@@ -794,7 +794,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: pip install confiture
+      - run: pip install fraiseql-confiture
       - run: confiture lint --env production --fail-on-warning
 ```
 

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -224,7 +224,7 @@ sudo systemctl start postgresql
 
 # Verify recovery
 confiture migrate status
-confiture migrate verify-checksums
+confiture verify-checksums
 ```
 
 **Recovery Option B: Full Restore**
@@ -366,7 +366,7 @@ This command:
 ```bash
 confiture migrate status
 confiture migrate drift-detect
-confiture migrate verify-checksums
+confiture verify-checksums
 ```
 
 **If sync-history is not available:**
@@ -442,11 +442,18 @@ pg_waldump /var/lib/postgresql/data/pg_wal/0000000100000001000000AB
 
 ### Verification Commands
 
+> After a restore the migration ledger may legitimately be absent — a database
+> rebuilt from schema files has none. `verify-checksums` and `migrate verify`
+> report that state and exit **2** (`PRECON_1001`) rather than failing with a
+> raw psycopg error. Add `--allow-uninitialized` when a ledger-less database is
+> the expected outcome of the recovery path you took; leave it off when the
+> restore was supposed to bring the ledger back, so its absence still trips.
+
 ```bash
 # Schema verification
 confiture migrate status
 confiture migrate drift-detect
-confiture migrate verify-checksums
+confiture verify-checksums
 
 # Database integrity
 psql << 'EOF'

--- a/docs/operations/performance-tuning.md
+++ b/docs/operations/performance-tuning.md
@@ -528,7 +528,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Download baseline
         uses: actions/download-artifact@v4

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -63,8 +63,16 @@ Overall: HEALTHY
 ### Verify Checksums
 
 ```bash
-confiture migrate verify-checksums
+confiture verify-checksums
 ```
+
+> A database with **no migration ledger** — one built from schema files rather
+> than migrated, which includes some restore paths — exits **2**
+> (`PRECON_1001`) with a message saying so, rather than a raw psycopg error.
+> If that state is expected for the database you are checking, add
+> `--allow-uninitialized` to treat it as success (exit 0). Do not add it
+> blanket-wide: against a database that *should* be migrated, exit 2 is the
+> signal you want.
 
 **Expected Output:**
 ```
@@ -348,7 +356,7 @@ PoolExhaustedError: No connections available (max: 10)
 
 ```cron
 # First of every month at 1 AM
-0 1 1 * * confiture migrate verify-checksums --full >> /var/log/confiture/checksum-audit.log 2>&1
+0 1 1 * * confiture verify-checksums >> /var/log/confiture/checksum-audit.log 2>&1
 ```
 
 ### Daily: Health Check (for Monitoring)
@@ -477,7 +485,7 @@ PoolExhaustedError: No connections available (max: 10)
 | Rollback one | `confiture migrate down --steps 1` |
 | Dry run | `confiture migrate up --dry-run` |
 | Check drift | `confiture migrate drift-detect` |
-| Verify checksums | `confiture migrate verify-checksums` |
+| Verify checksums | `confiture verify-checksums` |
 | Health check | `confiture health check` |
 
 ### Environment Variables

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1498,6 +1498,91 @@ fi
 
 ---
 
+### `confiture migrate verify` — runtime correctness
+
+Runs each applied migration's `.verify.sql` sidecar (a `SELECT` returning a
+truthy value) inside a read-only `SAVEPOINT`. This checks *runtime state*; for
+*file integrity* — have applied migration files been modified since? — use
+[`confiture verify-checksums`](#confiture-verify-checksums--file-integrity).
+
+#### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--migrations-dir` | Path | `db/migrations` | Migrations directory |
+| `--config` / `-c` | Path | None | Configuration file |
+| `--database-url` / `-d` | String | None | Tracking DB DSN |
+| `--version` | String | None | Verify a single migration version |
+| `--format` / `-f` | Text | `text` | `text` or `json` |
+| `--output` / `-o` | Path | None | Write output to a file |
+| `--allow-uninitialized` | Flag | `False` | Treat "no migration ledger" as success (exit 0) instead of exit 2 |
+
+#### Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | All verified (or no ledger, under `--allow-uninitialized`) |
+| `1` | At least one `.verify.sql` failed |
+| `2` | `PRECON_1001` — the database has no migration ledger |
+| `3` | Database connection failed |
+| `5` | Configuration problem |
+
+The JSON payload carries `ledger_present` (0.37.0+): `false` means the database
+has no migration ledger at all, and is only emitted under
+`--allow-uninitialized`. A present-but-empty ledger reports `true` with
+`total_applied: 0` — "not initialized" and "nothing applied yet" are different
+states.
+
+```bash
+# CI gate against a migrated database
+confiture migrate verify -c db/environments/production.yaml
+
+# A database built from schema files legitimately has no ledger
+confiture migrate verify -c db/environments/ci.yaml --allow-uninitialized
+```
+
+---
+
+### `confiture verify-checksums` — file integrity
+
+Compares SHA-256 checksums of migration files against the checksums stored when
+they were applied, detecting files modified after application (tampering /
+schema drift). Top-level, **not** a `migrate` subcommand.
+
+`confiture verify` is a deprecated alias, removed in the next major; it accepts
+the same options.
+
+#### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--migrations-dir` | Path | `db/migrations` | Migrations directory |
+| `--config` / `-c` | Path | `db/environments/local.yaml` | Configuration file |
+| `--fix` | Flag | `False` | Update stored checksums to match current files (dangerous) |
+| `--allow-uninitialized` | Flag | `False` | Treat "no migration ledger" as success (exit 0) instead of exit 2 |
+
+#### Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | All checksums verified (or no ledger, under `--allow-uninitialized`) |
+| `1` | Checksum mismatches found — the CI gate this command exists to trip |
+| `2` | `PRECON_1001` — the database has no migration ledger |
+
+Before 0.37.0 an absent ledger crashed to exit 1 with a raw psycopg
+`relation "tb_confiture" does not exist`, making it indistinguishable from
+"checksums are wrong". See [exit codes](exit-codes.md) for why exit 2 rather
+than 0 was chosen.
+
+```bash
+confiture verify-checksums --config db/environments/production.yaml
+
+# Post-restore, where the ledger may legitimately be absent
+confiture verify-checksums --allow-uninitialized
+```
+
+---
+
 ### `confiture migrate validate` - Git-Aware Schema Validation
 
 Enable automatic validation of database schema changes using git history. Perfect for CI/CD pipelines, pre-commit hooks, and code review gates.
@@ -1519,6 +1604,65 @@ Enable automatic validation of database schema changes using git history. Perfec
 # Static, no database connection.  Pre-merge gate.
 confiture migrate validate --check-acl-coverage --config confiture.yaml
 ```
+
+#### Scoping `--idempotent` to changed migrations (0.37.0)
+
+**In CI you must set `fetch-depth: 0`.** `actions/checkout` defaults to a
+shallow clone with no `origin/main` and no merge base; without full history the
+run fails with `GIT_003` (exit 7).
+
+`--idempotent` scans every migration by default. In a project with an
+unremediated back-catalogue that makes it unusable as a hard gate, since every
+branch trips on violations it did not introduce. Scope it to what the branch
+actually changed:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0          # required
+- run: confiture migrate validate --idempotent --base-ref origin/main
+```
+
+For a pre-commit hook use `--staged`, which reads the **staging index** rather
+than the working tree — so it judges what is about to be committed, and catches
+a migration that has been staged but not yet committed (`--base-ref` compares
+committed trees and cannot see one):
+
+```bash
+confiture migrate validate --idempotent --staged
+```
+
+⚠️ **Scoping requires an explicit flag.** `--base-ref` carries a default of
+`origin/main`, but that default does **not** scope — a bare
+`confiture migrate validate --idempotent` scans everything, exactly as before,
+and still works outside a git repository. Only an explicitly passed
+`--base-ref`, `--since`, or `--staged` turns scoping on. When both `--staged`
+and `--base-ref` are given, `--staged` wins.
+
+Scoping fails loud rather than silently selecting nothing: an unreachable base
+ref is `GIT_003` (exit 7), a migrations directory outside the repository is a
+configuration error, and running outside a git repository with an explicit
+scope flag is `GIT_002` (exit 7). A gate that scanned zero files must never be
+mistakable for a gate that passed.
+
+Under `--format json`, a scoped run reports its selection under `meta.scope`:
+
+```json
+"meta": {
+  "backend": "ast",
+  "scope": {"mode": "base-ref", "base_ref": "origin/main",
+            "files_selected": 3, "files_skipped": 412}
+}
+```
+
+An unscoped run emits no `scope` key at all. When the scope selects no
+migrations the run succeeds with a `message` explaining that nothing changed
+since the base ref — deliberately distinct from the "directory contains no
+files" message, since the remedies differ.
+
+⚠️ `--idempotent` cannot be combined with `--check-drift`,
+`--require-migration`, `--require-migration-bodies`, or
+`--require-grant-migration`: only one check would run. Invoke them separately.
 
 #### Examples
 
@@ -1667,7 +1811,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Validate schema
         run: |

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -57,6 +57,7 @@ resolution hint surfaced in the envelope.
 | `GEN_001` | 3 | error | External generator error | Check the external generator command and its output |
 | `GIT_001` | 7 | error | Git operation error | Check git repository status |
 | `GIT_002` | 7 | error | Not a git repository | Initialize a git repository or use a valid repository path |
+| `GIT_003` | 7 | error | Base ref unreachable in this checkout | In CI, set fetch-depth: 0 (actions/checkout) or run 'git fetch --unshallow origin <branch>' |
 | `GIT_800` | 7 | error | Git command failed | Check git repository status |
 | `GIT_801` | 7 | error | Invalid git reference: {ref} | Check the git reference name |
 | `GIT_802` | 7 | error | Not a git repository | Initialize a git repository or use a valid repository path |

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -47,7 +47,7 @@ reference from the CLI with `confiture --exit-codes`.
 - **6** — Lock or connection-pool contention — another writer holds the lock
   - LOCK_1300, LOCK_1301, POOL_1200, POOL_1201
 - **7** — Git / pgGit / grant-accompaniment error
-  - GIT_001, GIT_002, GIT_800, GIT_801, GIT_802, GRANT_001, PGGIT_900, PGGIT_901
+  - GIT_001, GIT_002, GIT_003, GIT_800, GIT_801, GIT_802, GRANT_001, PGGIT_900, PGGIT_901
 - **8** — Irreversible rollback, or inconsistent state after rollback
   - ROLLBACK_001, ROLLBACK_600, ROLLBACK_601, ROLLBACK_602
 <!-- END GENERATED -->

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -76,6 +76,50 @@ number:
 exist" signal and **2** for "tracking table absent" — both are
 success-with-signal exit codes specific to that command, not errors.
 
+### `GIT_003` — base ref unreachable in this checkout
+
+New in 0.37.0, exits **7** like the rest of the git family. Raised when
+`--base-ref`/`--since` names a ref that does not resolve in the current
+checkout, or when the histories are too shallow to compare.
+
+This is the one git failure a CI author can act on, so it is a distinct,
+greppable code rather than a reuse of `GIT_001`, and the message states the
+remedy verbatim:
+
+```
+Base ref 'origin/main' is not available in this checkout.
+In CI, set fetch-depth: 0 (actions/checkout) or run 'git fetch --unshallow origin main'.
+```
+
+`actions/checkout`'s default `fetch-depth: 1` triggers it. Confiture fails loud
+here rather than silently scanning nothing, because a scoping gate that selects
+zero files reports success while checking nothing at all.
+
+### Commands that emit exit 2 for an absent migration ledger
+
+Since 0.37.0, `verify-checksums` (and its deprecated `verify` alias) and
+`migrate verify` also exit **2** (`PRECON_1001`) when the database has no
+migration ledger — typically a database built from schema files rather than
+migrated. Previously both surfaced a raw psycopg `relation "tb_confiture" does
+not exist` and exited **1**.
+
+Exit 2 rather than 0 is deliberate. `verify-checksums` already uses exit 1 for
+"checksum mismatches found" — the CI gate the command exists to trip — so
+before 0.37.0 "no ledger" and "checksums are wrong" were *the same integer*.
+Returning 0 would merely have merged it with the other neighbour. Exit 2 is the
+only choice that adds information, and `PRECON_1001` → 2 is an already-frozen
+contract (see the carve-out table above and the reconciliation appendix below).
+
+Pass `--allow-uninitialized` to treat "no ledger" as success (exit 0). That is
+the sanctioned downgrade for gates that legitimately run against schema-built
+databases — a post-restore check, for instance. It is opt-in rather than the
+default because the failure mode of forgetting it is a green ship gate against
+an unmigrated production database.
+
+Note that "no ledger" and "ledger present but empty" stay distinct: a database
+with an empty `tb_confiture` is initialized, so it succeeds normally and
+reports `ledger_present: true` with `total_applied: 0`.
+
 ## How the convention was decided (issue #146)
 
 Confiture 0.18.0 shipped **three incompatible** exit-code conventions: the CLI's

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -57,6 +57,14 @@ The adapter-consumed fields per command:
 - **up** — `applied[].version` (the new head).
 - **down-to** — `from`, `to`, `rolled_back[]`.
 - **verify** — `failed_count` (ok ⇔ `0`) and each `results[].{version, name, status, error}`.
+  The `ok ⇔ failed_count == 0` rule is **unchanged** in 0.37.0. That release
+  added an optional `ledger_present` boolean: `false` means the database has no
+  migration ledger at all — typically built from schema files rather than
+  migrated — and is only emitted under `--allow-uninitialized`, since without
+  that flag the same state raises `PRECON_1001` (exit 2). It is declared in the
+  schema but **not required**, so payloads from earlier versions stay valid.
+  Note that the schema sets `additionalProperties: false`, so consumers pinned
+  to the pre-0.37.0 schema must update to accept the new field.
 - **preflight** — `ok`, the top-level `window_safe` verdict (the typed blue-green
   window-safety contract — see [below](#replica-forward-compatibility-namespace-window-safety-seam)),
   `summary`, each `issues[].{severity, code, message, migration}`.

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -149,8 +149,8 @@ codes it specifically recognises:
 | Exit | Adapter handling |
 |------|------------------|
 | `0` | success |
-| `2` (`PRECON_1001`) | from `current`: a reachable-but-uninitialised DB → "no current revision" (not an error) |
-| `2`, `5` | `InvalidConfig` (configuration problem) |
+| `2` (`PRECON_1001`) | a reachable-but-uninitialised DB (no migration ledger). From `current` → "no current revision"; from `verify` and `verify-checksums` → "nothing recorded to verify". **Not an error, and never `InvalidConfig`** — pass `--allow-uninitialized` to get exit 0 instead. |
+| `2`, `5` | `InvalidConfig` (configuration problem) — only when the code is **not** `PRECON_1001` |
 | `6` (`LOCK_1300`) | migration lock held by another process — **retriable** |
 | everything else | execution failure |
 

--- a/docs/reference/json-schemas/migrate-verify.schema.json
+++ b/docs/reference/json-schemas/migrate-verify.schema.json
@@ -23,6 +23,10 @@
       "type": "integer",
       "description": "Total applied migrations considered."
     },
+    "ledger_present": {
+      "type": "boolean",
+      "description": "Whether the migration ledger table (tracking_table, default tb_confiture) exists. False means the database has no recorded migrations at all — typically built from schema files rather than migrated — and is only emitted under --allow-uninitialized, since without that flag the absent ledger raises PRECON_1001 (exit 2). Distinct from a present-but-empty ledger, which reports true with total_applied 0. Added in 0.37.0; not required, so payloads from earlier versions remain valid."
+    },
     "results": {
       "type": "array",
       "description": "Per-migration verification outcome.",

--- a/examples/01-basic-migration/README.md
+++ b/examples/01-basic-migration/README.md
@@ -17,7 +17,7 @@ This example demonstrates the fundamental workflow of using Confiture for Postgr
 
 - Python 3.11 or higher
 - PostgreSQL 14 or higher
-- Confiture installed: `pip install confiture`
+- Confiture installed: `pip install fraiseql-confiture`
 
 ```bash
 # Verify installation

--- a/examples/04-production-sync-anonymization/QUICK_START.md
+++ b/examples/04-production-sync-anonymization/QUICK_START.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites Checklist
 
-- [ ] Confiture installed: `pip install confiture`
+- [ ] Confiture installed: `pip install fraiseql-confiture`
 - [ ] PostgreSQL client tools: `psql`, `pg_dump`
 - [ ] Production database credentials (read-only)
 - [ ] Staging database credentials (read-write)

--- a/examples/04-production-sync-anonymization/README.md
+++ b/examples/04-production-sync-anonymization/README.md
@@ -131,7 +131,7 @@ GRANT ALL PRIVILEGES ON DATABASE ecommerce_staging TO confiture_sync_user;
 
 ```bash
 # Confiture installed
-pip install confiture
+pip install fraiseql-confiture
 
 # PostgreSQL client tools (for pg_dump/restore)
 sudo apt-get install postgresql-client-15
@@ -894,7 +894,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Sync Production to Staging
         env:

--- a/examples/04-production-sync-anonymization/sync_script.sh
+++ b/examples/04-production-sync-anonymization/sync_script.sh
@@ -93,7 +93,7 @@ check_prerequisites() {
 
     # Check if confiture is installed
     if ! command -v confiture &> /dev/null; then
-        log ERROR "confiture command not found. Install with: pip install confiture"
+        log ERROR "confiture command not found. Install with: pip install fraiseql-confiture"
         exit 1
     fi
 
@@ -258,7 +258,7 @@ verify_anonymization() {
     # First, run built-in confiture verification
     log INFO "Step 1/2: Built-in verification checks..."
 
-    if confiture verify --env staging --config "$CONFIG_FILE" 2>&1 | tee -a "$LOG_FILE"; then
+    if confiture verify-checksums --config "$CONFIG_FILE" 2>&1 | tee -a "$LOG_FILE"; then
         log SUCCESS "Built-in verification passed"
     else
         log ERROR "Built-in verification failed"

--- a/examples/05-multi-environment-workflow/.github/workflows/ci.yml
+++ b/examples/05-multi-environment-workflow/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install confiture pytest pytest-cov psycopg[binary]
+          pip install fraiseql-confiture pytest pytest-cov psycopg[binary]
 
       - name: Build schema from DDL
         run: |

--- a/examples/05-multi-environment-workflow/.github/workflows/deploy-production.yml
+++ b/examples/05-multi-environment-workflow/.github/workflows/deploy-production.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install Confiture
         run: |
-          pip install confiture psycopg[binary]
+          pip install fraiseql-confiture psycopg[binary]
 
       - name: Pre-deployment notification
         uses: slackapi/slack-github-action@v1.24.0

--- a/examples/05-multi-environment-workflow/.github/workflows/deploy-staging.yml
+++ b/examples/05-multi-environment-workflow/.github/workflows/deploy-staging.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Confiture
         run: |
-          pip install confiture psycopg[binary]
+          pip install fraiseql-confiture psycopg[binary]
 
       - name: Check migration status
         run: |

--- a/examples/05-multi-environment-workflow/Makefile
+++ b/examples/05-multi-environment-workflow/Makefile
@@ -151,7 +151,7 @@ format:
 # Environment setup
 setup:
 	@echo "🛠️  Setting up development environment..."
-	@command -v confiture >/dev/null 2>&1 || { echo "Installing confiture..."; pip install confiture; }
+	@command -v confiture >/dev/null 2>&1 || { echo "Installing confiture..."; pip install fraiseql-confiture; }
 	@command -v pytest >/dev/null 2>&1 || { echo "Installing pytest..."; pip install pytest pytest-cov; }
 	@command -v sqlfluff >/dev/null 2>&1 || { echo "Installing sqlfluff..."; pip install sqlfluff; }
 	@command -v ruff >/dev/null 2>&1 || { echo "Installing ruff..."; pip install ruff; }

--- a/examples/05-multi-environment-workflow/README.md
+++ b/examples/05-multi-environment-workflow/README.md
@@ -78,7 +78,7 @@ changes     testing        build       test     approval    approval
 
 - **Python 3.11+**: `python --version`
 - **PostgreSQL 14+**: `psql --version`
-- **Confiture**: `pip install confiture`
+- **Confiture**: `pip install fraiseql-confiture`
 - **Git**: `git --version`
 - **Make** (optional but recommended): `make --version`
 
@@ -458,7 +458,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install confiture pytest pytest-cov
+          pip install fraiseql-confiture pytest pytest-cov
 
       - name: Build schema
         run: |
@@ -528,7 +528,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Check migration status
         env:
@@ -651,7 +651,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Backup production database
         run: |

--- a/examples/06-prep-seed-validation/README.md
+++ b/examples/06-prep-seed-validation/README.md
@@ -77,7 +77,7 @@ VALUES
 
 ```bash
 cd examples/06-prep-seed-validation
-pip install confiture
+pip install fraiseql-confiture
 ```
 
 ### 2. Quick Test (Levels 1-3)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -23,7 +23,7 @@ blog_app
 ### 1. Install Confiture
 
 ```bash
-pip install confiture
+pip install fraiseql-confiture
 ```
 
 ### 2. Set Up Database

--- a/examples/cicd/argo/migration-workflow.yaml
+++ b/examples/cicd/argo/migration-workflow.yaml
@@ -61,7 +61,7 @@ spec:
             echo "Linting migrations..."
             confiture lint db/migrations/
             echo "Verifying checksums..."
-            confiture migrate verify-checksums
+            confiture verify-checksums
 
     # Dry run migrations
     - name: dry-run-migration
@@ -277,7 +277,7 @@ spec:
           - |
             pip install --quiet confiture
             confiture lint db/migrations/
-            confiture migrate verify-checksums
+            confiture verify-checksums
 
     - name: dry-run-migration
       inputs:

--- a/examples/cicd/github-actions/migration-check.yml
+++ b/examples/cicd/github-actions/migration-check.yml
@@ -18,6 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Required by --base-ref scoping below: the default fetch-depth of 1
+          # leaves no origin/main to compare against, and no merge base to
+          # anchor on. Confiture reports this as GIT_003 (exit 7) rather than
+          # scanning nothing, but the fix belongs here.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -25,13 +31,20 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Lint migrations
         run: confiture lint db/migrations/
 
+      # Scoped to migrations this PR actually touched, so a pre-existing
+      # backlog does not block the branch. Drop --base-ref to scan everything.
+      - name: Validate idempotency (changed migrations only)
+        run: confiture migrate validate --idempotent --base-ref origin/main
+
+      # A database built from schema files has no migration ledger; without
+      # --allow-uninitialized that is exit 2, not a pass.
       - name: Verify checksums
-        run: confiture migrate verify-checksums
+        run: confiture verify-checksums
 
   dry-run:
     name: Dry Run Migration
@@ -61,7 +74,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Build test schema
         env:
@@ -108,7 +121,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Check schema drift
         env:

--- a/examples/cicd/github-actions/migration-deploy.yml
+++ b/examples/cicd/github-actions/migration-deploy.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Check pending migrations
         id: check
@@ -91,7 +91,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Pre-migration health check
         env:
@@ -166,7 +166,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Confiture
-        run: pip install confiture
+        run: pip install fraiseql-confiture
 
       - name: Attempt rollback
         env:

--- a/examples/cicd/gitlab-ci/.gitlab-ci.yml
+++ b/examples/cicd/gitlab-ci/.gitlab-ci.yml
@@ -31,7 +31,7 @@ lint-migrations:
   stage: lint
   script:
     - confiture lint db/migrations/
-    - confiture migrate verify-checksums
+    - confiture verify-checksums
   rules:
     - changes:
         - db/migrations/**/*

--- a/examples/cicd/jenkins/Jenkinsfile
+++ b/examples/cicd/jenkins/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                 echo 'Installing Confiture...'
                 sh '''
                     python -m pip install --upgrade pip
-                    pip install confiture
+                    pip install fraiseql-confiture
                 '''
             }
         }
@@ -41,7 +41,7 @@ pipeline {
             steps {
                 echo 'Linting migrations...'
                 sh 'confiture lint db/migrations/'
-                sh 'confiture migrate verify-checksums'
+                sh 'confiture verify-checksums'
             }
         }
 

--- a/examples/linting/ci_github_actions.yaml
+++ b/examples/linting/ci_github_actions.yaml
@@ -80,7 +80,7 @@ jobs:
       # Install dependencies
       - name: Install dependencies
         run: |
-          uv pip install confiture
+          uv pip install fraiseql-confiture
 
       # Run linting on staging environment
       - name: Lint schema (staging)
@@ -141,7 +141,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install confiture
+          uv pip install fraiseql-confiture
 
       # Validate production schema with strict mode
       - name: Validate production schema (strict)
@@ -191,7 +191,7 @@ jobs:
       - name: Install dependencies
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv pip install confiture
+          uv pip install fraiseql-confiture
 
       # Generate lint report
       - name: Generate lint report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
     "ruff>=0.6.0",
     "ty>=0.0.7",  # Astral's ultra-fast type checker (replaces mypy)
     "maturin>=1.7.0",
-    "pglast>=6.0",
+    "pglast>=6.0,<8",  # see the `ast` extra for why the upper bound is pinned
     "fastapi>=0.111",
     "httpx>=0.27",
     "jsonschema>=4",  # Validate JSON output schemas in docs/reference/json-schemas/
@@ -85,7 +85,18 @@ seed-uuid = [
 ]
 
 ast = [
-    "pglast>=6.0",
+    # Upper bound is deliberate. pglast 8.0 reshaped the AST that
+    # `core/idempotency/ast_detector.py`, `core/linting/libraries/security_definer.py`
+    # and `core/operation_classifier.py` walk — ALTER TABLE subtype handling,
+    # OWNER TO detection and constraint nodes all moved, which is 19 test
+    # failures and 3 ty errors, not a typing nit. Supporting 8.x is real work
+    # with its own risk surface; until then, cap rather than resolve into it.
+    #
+    # This matters more than usual here: `uv.lock` is gitignored, so CI resolves
+    # the dependency tree fresh on every run. An unbounded specifier means an
+    # upstream major release turns CI red on an unrelated PR — which is exactly
+    # what pglast 8.2 (2026-07-10) did to the first PR opened after it landed.
+    "pglast>=6.0,<8",
 ]
 
 mcp-http = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.36.0"
+version = "0.37.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/admin.py
+++ b/python/confiture/cli/commands/admin.py
@@ -17,7 +17,26 @@ from confiture.cli.helpers import (
 )
 from confiture.core.connection import create_connection
 from confiture.core.error_handler import handle_cli_error
-from confiture.exceptions import ConfigurationError, ConfiturError
+from confiture.exceptions import (
+    ConfigurationError,
+    ConfiturError,
+    DatabaseNotInitializedError,
+)
+
+#: Shared by `verify-checksums` and `migrate verify` — both hit the same state
+#: (a database built from schema files rather than migrated) and both offer the
+#: same three ways forward.
+_NO_LEDGER_HINT = (
+    "This database has no recorded migrations — it was likely built from schema "
+    "files rather than migrated. Run `confiture migrate up` to apply migrations, "
+    "`confiture migrate baseline --through <version>` if the schema is already "
+    "present, or pass --allow-uninitialized to treat 'no ledger' as success."
+)
+
+ALLOW_UNINITIALIZED_HELP = (
+    "Treat a database with no migration ledger as success (exit 0) instead of "
+    "exit 2.  For gates that legitimately run against schema-built databases."
+)
 
 
 def install_helpers(
@@ -184,6 +203,11 @@ def verify_checksums(
         "--fix",
         help="Update stored checksums to match current files (dangerous)",
     ),
+    allow_uninitialized: bool = typer.Option(
+        False,
+        "--allow-uninitialized",
+        help=ALLOW_UNINITIALIZED_HELP,
+    ),
 ) -> None:
     """Verify migration file integrity against stored checksums.
 
@@ -216,11 +240,30 @@ def verify_checksums(
         MigrationChecksumVerifier,
     )
     from confiture.core.connection import create_connection, load_config
+    from confiture.core.ledger import ledger_exists
 
     try:
         # Load config and connect
         config_data = load_config(config)
         conn = create_connection(config_data)
+
+        # Probe before building the verifier: if verify_all() returned [] for
+        # "no table", that would be indistinguishable from "no mismatches" —
+        # the absent-vs-empty conflation this guard exists to prevent.
+        tracking_table = _get_tracking_table(config_data)
+        if not ledger_exists(conn, tracking_table):
+            conn.close()
+            if allow_uninitialized:
+                console.print(
+                    f"[yellow]ℹ️  No migration ledger found (`{tracking_table}` is not "
+                    "present in this database) — 0 migrations recorded, nothing to "
+                    "verify.[/yellow]"
+                )
+                return
+            raise DatabaseNotInitializedError(
+                f"No migration ledger found: `{tracking_table}` is not present in this database",
+                resolution_hint=_NO_LEDGER_HINT,
+            )
 
         # Run verification (warn mode - we'll handle display)
         verifier = MigrationChecksumVerifier(
@@ -229,7 +272,7 @@ def verify_checksums(
                 enabled=True,
                 on_mismatch=ChecksumMismatchBehavior.WARN,
             ),
-            migration_table=_get_tracking_table(config_data),
+            migration_table=tracking_table,
         )
         mismatches = verifier.verify_all(migrations_dir)
 
@@ -288,6 +331,11 @@ def verify_deprecated(
         "--fix",
         help="Update stored checksums to match current files (dangerous)",
     ),
+    allow_uninitialized: bool = typer.Option(
+        False,
+        "--allow-uninitialized",
+        help=ALLOW_UNINITIALIZED_HELP,
+    ),
 ) -> None:
     """[DEPRECATED] Alias for `confiture verify-checksums`.
 
@@ -301,7 +349,12 @@ def verify_deprecated(
         "future major release. Use 'confiture verify-checksums' for checksum "
         "integrity (or 'confiture migrate verify' for runtime correctness).[/yellow]"
     )
-    verify_checksums(migrations_dir=migrations_dir, config=config, fix=fix)
+    verify_checksums(
+        migrations_dir=migrations_dir,
+        config=config,
+        fix=fix,
+        allow_uninitialized=allow_uninitialized,
+    )
 
 
 def validate_config(

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -20,6 +20,7 @@ from confiture.cli.helpers import (
     console,
     error_console,
     is_json,
+    param_is_explicit,
 )
 from confiture.core._migrator.session import MigratorSession
 from confiture.core.connection import create_connection, load_config, open_connection
@@ -200,6 +201,7 @@ def _emit_pattern_catalog(format_output: str, output_file: Path | None) -> None:
 
 
 def migrate_validate(
+    ctx: typer.Context,
     migrations_dir: Path = typer.Option(
         Path("db/migrations"),
         "--migrations-dir",
@@ -597,6 +599,33 @@ def migrate_validate(
             _emit_pattern_catalog(format_output, output_file)
             return
 
+        # Every branch below ends in a bare `return` and they are evaluated in
+        # source order, so a git-accompaniment flag combined with --idempotent
+        # would run only the former and silently skip idempotency. #181 fixed
+        # the --staged case by dispatch; fail loud on the rest rather than
+        # leave another silently-lying combination behind.
+        if idempotent:
+            _conflicting = [
+                name
+                for name, on in (
+                    ("--check-drift", check_drift),
+                    ("--require-migration", require_migration),
+                    ("--require-migration-bodies", require_migration_bodies),
+                    ("--require-grant-migration", require_grant_migration),
+                )
+                if on
+            ]
+            if _conflicting:
+                raise ConfigurationError(
+                    f"--idempotent cannot be combined with {', '.join(_conflicting)}: "
+                    "only one check would run.",
+                    resolution_hint=(
+                        "Run the checks as separate invocations, e.g. "
+                        "`confiture migrate validate --idempotent` then "
+                        f"`confiture migrate validate {_conflicting[0]}`."
+                    ),
+                )
+
         # Resolve --env / --config to a single config path (raises
         # ConfigurationError, funneled through the fail() boundary below).
         config = _resolve_config(config, env)
@@ -622,7 +651,12 @@ def migrate_validate(
             or require_migration
             or require_migration_bodies
             or require_grant_migration
-            or staged
+            # #181/D4: --staged used to enter this block and return, so
+            # `--idempotent --staged` silently never ran idempotency. When
+            # --idempotent is set and no git-accompaniment check was asked
+            # for, fall through to the idempotency branch, which now scopes
+            # to the staging index itself.
+            or (staged and not idempotent)
         ):
             from confiture.cli.git_validation import (
                 validate_git_drift,
@@ -966,7 +1000,20 @@ def migrate_validate(
 
         # Handle idempotency validation
         if idempotent:
-            _validate_idempotency(migrations_dir, format_output, output_file, strict_cor=strict_cor)
+            # #181: --base-ref carries a truthy default ("origin/main"), so the
+            # value alone cannot say whether the operator asked for scoping.
+            # Gate on the parameter source; without this every unscoped run
+            # would silently scope, and a plain --idempotent in a non-git tree
+            # would exit 7.
+            scoping_requested = staged or param_is_explicit(ctx, "base_ref", "since")
+            _validate_idempotency(
+                migrations_dir,
+                format_output,
+                output_file,
+                strict_cor=strict_cor,
+                base_ref=(since or base_ref) if scoping_requested and not staged else None,
+                staged=staged,
+            )
             return
 
         # Use Migrator to find orphaned files (needs instance for method)

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -1407,6 +1407,15 @@ def migrate_verify(
         "-o",
         help="Save output to file (default: stdout)",
     ),
+    allow_uninitialized: bool = typer.Option(
+        False,
+        "--allow-uninitialized",
+        help=(
+            "Treat a database with no migration ledger as success (exit 0) instead "
+            "of exit 2.  For gates that legitimately run against schema-built "
+            "databases."
+        ),
+    ),
 ) -> None:
     """Verify applied migrations using .verify.sql sidecar files (runtime correctness).
 
@@ -1432,6 +1441,7 @@ def migrate_verify(
       confiture migrate status  - View migration history
       confiture migrate up      - Apply pending migrations
     """
+    from confiture.cli.commands.admin import _NO_LEDGER_HINT
     from confiture.cli.formatters.migrate_formatter import format_verify_results
     from confiture.cli.helpers import (
         _get_tracking_table,
@@ -1442,6 +1452,7 @@ def migrate_verify(
     from confiture.core.connection import create_connection, load_config
     from confiture.core.migration_verifier import MigrationVerifier
     from confiture.core.migrator import Migrator
+    from confiture.exceptions import DatabaseNotInitializedError
     from confiture.models.results import VerifyAllResult
 
     json_mode = is_json(format_output)
@@ -1461,7 +1472,7 @@ def migrate_verify(
             if _db_url_override is not None:
                 config_data = {"database_url": _db_url_override}
             elif config and config.exists():
-                config_data = load_config(str(config))
+                config_data = load_config(config)
         if config_data is None:
             raise ConfigurationError("Config file or --database-url required for migrate verify")
         tracking_table = _get_tracking_table(config_data)
@@ -1469,6 +1480,35 @@ def migrate_verify(
         conn = create_connection(config_data)
         try:
             migrator = Migrator(connection=conn, migration_table=tracking_table)
+
+            # #182: get_applied_versions() raises psycopg's UndefinedTable on an
+            # absent ledger. Absent is a distinct state from "present but empty",
+            # so probe rather than swallowing the error into an empty result.
+            if not migrator.tracking_table_exists():
+                if not allow_uninitialized:
+                    raise DatabaseNotInitializedError(
+                        f"No migration ledger found: `{tracking_table}` is not present "
+                        "in this database",
+                        resolution_hint=_NO_LEDGER_HINT,
+                    )
+                empty = VerifyAllResult(
+                    results=[],
+                    verified_count=0,
+                    failed_count=0,
+                    skipped_count=0,
+                    total_applied=0,
+                    ledger_present=False,
+                )
+                if format_output == "json":
+                    _output_json(empty.to_dict(), output_file, console)
+                else:
+                    console.print(
+                        f"[yellow]ℹ️  No migration ledger found (`{tracking_table}` is not "
+                        "present in this database) — 0 migrations recorded, nothing to "
+                        "verify.[/yellow]"
+                    )
+                return
+
             applied_versions = migrator.get_applied_versions()
 
             verifier = MigrationVerifier(connection=conn, migrations_dir=migrations_dir)

--- a/python/confiture/cli/generate.py
+++ b/python/confiture/cli/generate.py
@@ -50,21 +50,13 @@ def _detect_repo_root(schema_dir: Path) -> Path | None:
     when the test layout is ``tmp_path/schema/`` rather than
     ``tmp_path/db/schema/``).
     """
+    from confiture.core.git import GitRepository
+    from confiture.exceptions import ConfiturError
+
     resolved = schema_dir.resolve()
     try:
-        out = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=str(resolved if resolved.exists() else Path.cwd()),
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=5,
-        )
-        if out.returncode == 0:
-            top = out.stdout.strip()
-            if top:
-                return Path(top)
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return GitRepository(resolved if resolved.exists() else Path.cwd()).get_repo_root()
+    except (ConfiturError, FileNotFoundError, subprocess.TimeoutExpired):
         pass
     # Canonical layout fallback only — don't guess outside it.
     if resolved.parent.name == "db":

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -370,6 +370,42 @@ def resolve_database_url(
     return None
 
 
+def param_is_explicit(ctx: Any, *params: str) -> bool:
+    """Whether any named parameter was set on the command line / via env.
+
+    The generic core of :func:`config_is_explicit`. A typer option with a
+    truthy default cannot be told apart from an operator-supplied value by
+    inspecting the value alone — ``--base-ref`` defaults to ``"origin/main"``,
+    so ``if base_ref:`` is always true. Click's parameter source can tell them
+    apart, and that distinction is what keeps an unscoped ``--idempotent`` run
+    unscoped (#181).
+
+    Compares the ``click.core.ParameterSource`` enum by member name rather than
+    importing it: ``click`` is only a transitive dependency (via typer), so a
+    direct ``import click`` is not guaranteed to resolve. ``ctx`` is already a
+    typer/click Context, so no import is needed.
+
+    Args:
+        ctx: The typer/click context.
+        params: Parameter names to check. A parameter the command does not
+            declare yields no source and is ignored, so passing a superset is
+            safe.
+
+    Returns:
+        True if *any* named parameter was set explicitly; False defensively
+        when no source is available.
+    """
+    for param in params:
+        try:
+            source = ctx.get_parameter_source(param)
+        except Exception:  # noqa: BLE001 — no/!click ctx → treat as default
+            continue
+        name = getattr(source, "name", None)
+        if name is not None and name not in ("DEFAULT", "DEFAULT_MAP"):
+            return True
+    return False
+
+
 def config_is_explicit(ctx: Any, *params: str) -> bool:
     """Whether ``--config`` or ``--env`` was set explicitly, not defaulted (#152).
 
@@ -388,16 +424,11 @@ def config_is_explicit(ctx: Any, *params: str) -> bool:
     importing it: ``click`` is only a transitive dependency (via typer), so a
     direct ``import click`` is not guaranteed to resolve. ``ctx`` is already a
     typer/click Context, so no import is needed.
+
+    Thin wrapper over :func:`param_is_explicit` supplying the ``#152`` default
+    parameter set; the mechanism is shared, the defaults are not.
     """
-    for param in params or ("config", "env"):
-        try:
-            source = ctx.get_parameter_source(param)
-        except Exception:  # noqa: BLE001 — no/!click ctx → treat as default
-            continue
-        name = getattr(source, "name", None)
-        if name is not None and name not in ("DEFAULT", "DEFAULT_MAP"):
-            return True
-    return False
+    return param_is_explicit(ctx, *(params or ("config", "env")))
 
 
 def has_intentional_dsn_source(ctx: Any, flag: str | None, no_config: bool) -> bool:
@@ -535,11 +566,24 @@ def _print_orphaned_files_warning(orphaned_files: list[Path], console: Console) 
     console.print("[yellow]Learn more: https://github.com/evoludigit/confiture/issues/13[/yellow]")
 
 
+def _repo_root_for(path: Path) -> Path:
+    """Resolve the project root that owns ``path``, for extractor boundaries.
+
+    Delegates to the extractor's own anchor search so a staged ``.py``
+    migration analyzed from a temp file gets the same ``execute_file``
+    boundary it would have had on disk.
+    """
+    from confiture.core.idempotency.python_migration_extractor import _resolve_project_root
+
+    return _resolve_project_root(path)
+
+
 def _collect_idempotency_report(
     sql_files: list[Path],
     py_files: list[Path],
     validator: Any,
     project_root: Path | None = None,
+    staged_content: dict[Path, str] | None = None,
 ) -> Any:
     """Run the idempotency validator against .sql files and Python migrations.
 
@@ -551,25 +595,48 @@ def _collect_idempotency_report(
     path-boundary checking; passing ``None`` lets the extractor auto-detect
     the root (the nearest ancestor with ``pyproject.toml``, ``.git``, or
     ``db/``).
+
+    ``staged_content`` maps a path to its **staging-index** blob. When a path
+    is present there, that content is analyzed instead of the working tree —
+    the two differ when a file is staged and then edited further, and a
+    pre-commit gate must judge what is about to be committed (#181, D4).
     """
+    import tempfile
+
     from confiture.core.idempotency.models import IdempotencyReport
     from confiture.core.idempotency.python_migration_extractor import (
         extract_sql_from_python_migration,
     )
 
     combined = IdempotencyReport()
+    staged_content = staged_content or {}
 
     for sql_path in sorted(sql_files):
-        if not sql_path.is_file():
+        if sql_path in staged_content:
+            file_report = validator.validate_sql(staged_content[sql_path], file_path=str(sql_path))
+        elif sql_path.is_file():
+            file_report = validator.validate_file(sql_path)
+        else:
             continue
-        file_report = validator.validate_file(sql_path)
         for scanned in file_report.scanned_files:
             combined.add_file_scanned(scanned)
         for violation in file_report.violations:
             combined.add_violation(violation)
 
     for py_path in sorted(py_files):
-        extraction = extract_sql_from_python_migration(py_path, project_root=project_root)
+        if py_path in staged_content:
+            # The extractor only reads from disk, so materialize the index
+            # blob. project_root is passed explicitly, since auto-detection
+            # from a temp directory would find the wrong boundary.
+            with tempfile.TemporaryDirectory() as td:
+                staged_py = Path(td) / py_path.name
+                staged_py.write_text(staged_content[py_path], encoding="utf-8")
+                extraction = extract_sql_from_python_migration(
+                    staged_py,
+                    project_root=project_root or _repo_root_for(py_path),
+                )
+        else:
+            extraction = extract_sql_from_python_migration(py_path, project_root=project_root)
         combined.add_file_scanned(str(py_path))
         combined.warnings.extend(extraction.warnings)
         for snippet in extraction.snippets:
@@ -582,7 +649,92 @@ def _collect_idempotency_report(
     return combined
 
 
-def _idempotent_backend_banner(format_output: str) -> dict[str, str]:
+def _scope_files_to_git(
+    candidates: list[Path],
+    migrations_dir: Path,
+    *,
+    base_ref: str | None,
+    staged: bool,
+) -> tuple[list[Path], dict[str, Any]]:
+    """Narrow ``candidates`` to the files changed on this branch or staged (#181).
+
+    Intersects **glob ∩ diff** rather than iterating the diff, which makes
+    deletions safe by construction: a deleted migration appears in the diff but
+    not in the glob, so it is never handed to the analyzer.
+
+    Args:
+        candidates: The full globbed file set (already on disk).
+        migrations_dir: The directory those files were globbed from.
+        base_ref: Git ref to scope against, or None when ``staged``.
+        staged: Scope to the staging index instead of a ref comparison.
+
+    Returns:
+        ``(selected_files, scope_meta)``.
+
+    Raises:
+        GitError: ``GIT_003`` when the base ref is unreachable in this
+            checkout, or the diff cannot be computed.
+        NotAGitRepositoryError: ``GIT_002`` when not in a git repository.
+        ConfigurationError: When ``migrations_dir`` lies outside the repository,
+            where the intersection could only ever be empty.
+    """
+    from confiture.core.git import GitRepository
+    from confiture.exceptions import ConfigurationError
+
+    repo = GitRepository()
+    if not repo.is_git_repo():
+        from confiture.exceptions import NotAGitRepositoryError
+
+        raise NotAGitRepositoryError(
+            f"Not a git repository: {Path.cwd()}",
+            resolution_hint=(
+                "--base-ref/--since/--staged scope against git history. Run from "
+                "inside a repository, or drop the flag to scan every migration."
+            ),
+        )
+
+    # `git diff --name-only` reports paths relative to the repository ROOT
+    # regardless of the directory git runs in, so they must be resolved against
+    # the root — not against cwd. Getting this wrong yields an empty
+    # intersection and a green gate that scanned nothing.
+    repo_root = repo.get_repo_root().resolve()
+
+    resolved_dir = migrations_dir.resolve()
+    if not resolved_dir.is_relative_to(repo_root):
+        raise ConfigurationError(
+            f"Cannot scope by git: migrations directory {resolved_dir} is outside "
+            f"the repository at {repo_root}",
+            error_code="CONFIG_004",
+            resolution_hint=(
+                "Point --migrations-dir at a directory inside the repository, or "
+                "drop --base-ref/--since/--staged to scan every migration."
+            ),
+        )
+
+    scope_meta: dict[str, Any]
+    if staged or base_ref is None:
+        changed = repo.get_staged_files()
+        scope_meta = {"mode": "staged"}
+    else:
+        # Preflight the ref so an unfetched origin/main names its own remedy
+        # rather than surfacing git's wording.
+        repo.require_ref(base_ref)
+        # Merge-base + two-dot rather than three-dot: equivalent whenever a
+        # merge base exists, and survives shallow clones, where three-dot fails
+        # with "no merge base". get_merge_base already degrades to base_ref.
+        anchor = repo.get_merge_base(base_ref, "HEAD") or base_ref
+        changed = repo.get_changed_files_two_dot(anchor, "HEAD")
+        scope_meta = {"mode": "base-ref", "base_ref": base_ref}
+
+    changed_abs = {(repo_root / path).resolve() for path in changed}
+    selected = [path for path in candidates if path.resolve() in changed_abs]
+
+    scope_meta["files_selected"] = len(selected)
+    scope_meta["files_skipped"] = len(candidates) - len(selected)
+    return selected, scope_meta
+
+
+def _idempotent_backend_banner(format_output: str) -> dict[str, Any]:
     """Report which idempotency backend is active.
 
     Text mode prints a one-line banner to ``console`` (stdout) — it's a
@@ -610,12 +762,80 @@ def _idempotent_backend_banner(format_output: str) -> dict[str, str]:
     return {"backend": backend}
 
 
+def _read_staged_content(paths: list[Path]) -> dict[Path, str]:
+    """Read each path's blob from the staging index (``git show :<path>``).
+
+    The index blob is what is about to be committed; it differs from the
+    working tree whenever a file was staged and then edited further. A
+    pre-commit gate must judge the former.
+    """
+    from confiture.core.git import GitRepository
+
+    repo = GitRepository()
+    repo_root = repo.get_repo_root().resolve()
+
+    content: dict[Path, str] = {}
+    for path in paths:
+        rel = path.resolve().relative_to(repo_root)
+        blob = repo.get_staged_file_content(rel)
+        if blob is not None:
+            content[path] = blob
+    return content
+
+
+def _report_empty_scope(
+    scope_meta: dict[str, Any],
+    migrations_dir: Path,
+    meta: dict[str, Any],
+    format_output: str,
+    output_file: Path | None,
+) -> None:
+    """Report "nothing in scope changed" — a real success, distinct from "no files".
+
+    Deliberately *not* the empty-directory message: the remedies differ. An
+    empty directory usually means ``--migrations-dir`` points somewhere wrong;
+    an empty scope means the branch genuinely touched no migrations.
+
+    Emits ``oneOf`` branch 2 of ``migrate-validate-idempotent.schema.json``
+    verbatim (both top-level branches set ``additionalProperties: false``, and
+    branch 2 forbids the scan counters), varying only the ``message`` string.
+    """
+    if scope_meta["mode"] == "staged":
+        message = f"No staged migration files in `{migrations_dir}` — nothing to validate."
+    else:
+        message = (
+            f"No migration files in `{migrations_dir}` changed since "
+            f"{scope_meta['base_ref']} — nothing to validate. "
+            f"({scope_meta['files_skipped']} unchanged file(s) skipped.)"
+        )
+
+    hints: list[dict[str, Any]] = []
+    _emit_hint(message, hints_list=hints, format_=format_output)
+
+    if format_output == "json":
+        _output_json(
+            {
+                "status": "ok",
+                "message": message,
+                "violations": [],
+                "meta": meta,
+                "hints": hints,
+            },
+            output_file,
+            console,
+        )
+    else:
+        console.print(f"[green]✅ {message}[/green]")
+
+
 def _validate_idempotency(
     migrations_dir: Path,
     format_output: str,
     output_file: Path | None,
     *,
     strict_cor: bool = False,
+    base_ref: str | None = None,
+    staged: bool = False,
 ) -> None:
     """Validate idempotency of SQL and Python migration files.
 
@@ -626,6 +846,13 @@ def _validate_idempotency(
         strict_cor: If True, info-severity CREATE OR REPLACE findings flip
             the exit code to 1 (default False — info findings render but
             don't fail the gate).
+        base_ref: Scope to migrations changed since this git ref. ``None``
+            means scan everything — the caller must pass ``None`` unless the
+            operator set ``--base-ref``/``--since`` *explicitly*, since the
+            option's own default (``origin/main``) is truthy and would
+            otherwise scope every run (#181).
+        staged: Scope to staged migrations, reading the index blob rather than
+            the working tree. Takes precedence over ``base_ref``.
     """
     import typer
 
@@ -639,6 +866,36 @@ def _validate_idempotency(
 
     sql_files = sorted(migrations_dir.glob("*.up.sql"))
     py_files = sorted(p for p in migrations_dir.glob("*.py") if _is_migration_file(p))
+
+    scope_meta: dict[str, Any] | None = None
+    staged_content: dict[Path, str] = {}
+    if staged or base_ref is not None:
+        candidates = sql_files + py_files
+        selected, scope_meta = _scope_files_to_git(
+            candidates, migrations_dir, base_ref=base_ref, staged=staged
+        )
+        meta["scope"] = scope_meta
+        selected_set = {p.resolve() for p in selected}
+        sql_files = [p for p in sql_files if p.resolve() in selected_set]
+        py_files = [p for p in py_files if p.resolve() in selected_set]
+
+        if staged:
+            staged_content = _read_staged_content(selected)
+
+        if not sql_files and not py_files:
+            _report_empty_scope(scope_meta, migrations_dir, meta, format_output, output_file)
+            return
+
+        if format_output == "text":
+            where = (
+                "staged"
+                if scope_meta["mode"] == "staged"
+                else f"changed since {scope_meta['base_ref']}"
+            )
+            console.print(
+                f"[cyan]🔍 Scoped to {scope_meta['files_selected']} migration(s) "
+                f"{where} ({scope_meta['files_skipped']} skipped)[/cyan]"
+            )
 
     if not sql_files and not py_files:
         # Quiet-success ambiguity: "no migrations" can mean the user
@@ -665,7 +922,9 @@ def _validate_idempotency(
             console.print("[green]✅ No migration files found to validate[/green]")
         return
 
-    combined_report = _collect_idempotency_report(sql_files, py_files, validator)
+    combined_report = _collect_idempotency_report(
+        sql_files, py_files, validator, staged_content=staged_content
+    )
     fail = combined_report.has_violations if strict_cor else combined_report.has_blocking_violations
 
     if format_output == "json":

--- a/python/confiture/core/_migrator/session.py
+++ b/python/confiture/core/_migrator/session.py
@@ -1037,6 +1037,18 @@ class MigratorSession:
 
         # Checksum verification (only when DB is connected)
         if self._conn is not None:
+            # #182: verify_all() raises psycopg's UndefinedTable on an absent
+            # ledger. preflight is an advisory aggregator, not a gate, so it
+            # skips and reports rather than raising — consistent with the
+            # probes in status() and current_revision().
+            if self._migrator is not None and not self._migrator.tracking_table_exists():
+                result.checksum_verified = False
+                result.checksum_skipped_reason = (
+                    "no migration ledger in this database — nothing recorded to "
+                    "verify checksums against"
+                )
+                return result
+
             from confiture.core.checksum import (
                 ChecksumConfig,
                 ChecksumMismatchBehavior,

--- a/python/confiture/core/_migrator/state.py
+++ b/python/confiture/core/_migrator/state.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 from psycopg import sql as pgsql
 
 from confiture.core.hooks.context import ExecutionContext
+from confiture.core.ledger import ledger_exists
 from confiture.exceptions import MigrationError, SQLError
 
 if TYPE_CHECKING:
@@ -22,6 +23,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _qualified_table(migrator: Migrator) -> str:
+    """Reassemble the migrator's tracking table into a single name.
+
+    ``Migrator`` splits the configured ``tracking_table`` into
+    ``_table_schema`` / ``_table_base``; :func:`ledger_exists` takes the
+    combined form.
+    """
+    if migrator._table_schema is not None:
+        return f"{migrator._table_schema}.{migrator._table_base}"
+    return str(migrator._table_base)
+
+
 def initialize(migrator: Migrator) -> None:
     """Create the tracking table (Trinity identity pattern). Idempotent.
 
@@ -29,32 +42,7 @@ def initialize(migrator: Migrator) -> None:
         MigrationError: If table creation fails.
     """
     try:
-        # Check if table exists (schema-aware)
-        with migrator.connection.cursor() as cursor:
-            if migrator._table_schema is not None:
-                cursor.execute(
-                    """
-                    SELECT EXISTS (
-                        SELECT FROM information_schema.tables
-                        WHERE table_schema = %s AND table_name = %s
-                    )
-                    """,
-                    (migrator._table_schema, migrator._table_base),
-                )
-            else:
-                cursor.execute(
-                    """
-                    SELECT EXISTS (
-                        SELECT FROM information_schema.tables
-                        WHERE table_name = %s
-                    )
-                    """,
-                    (migrator._table_base,),
-                )
-            result = cursor.fetchone()
-            table_exists = result[0] if result else False
-
-        if not table_exists:
+        if not ledger_exists(migrator.connection, _qualified_table(migrator)):
             # Create new table with Trinity pattern
             migrator._execute_sql(
                 pgsql.SQL("""
@@ -192,29 +180,7 @@ def get_current_revision_row(migrator: Migrator) -> dict[str, Any] | None:
 
 def tracking_table_exists(migrator: Migrator) -> bool:
     """Return True if the tracking table exists in the database."""
-    with migrator.connection.cursor() as cursor:
-        if migrator._table_schema is not None:
-            cursor.execute(
-                """
-                SELECT EXISTS (
-                    SELECT FROM information_schema.tables
-                    WHERE table_schema = %s AND table_name = %s
-                )
-                """,
-                (migrator._table_schema, migrator._table_base),
-            )
-        else:
-            cursor.execute(
-                """
-                SELECT EXISTS (
-                    SELECT FROM information_schema.tables
-                    WHERE table_name = %s
-                )
-                """,
-                (migrator._table_base,),
-            )
-        result = cursor.fetchone()
-        return bool(result[0]) if result else False
+    return ledger_exists(migrator.connection, _qualified_table(migrator))
 
 
 def trigger_hook(

--- a/python/confiture/core/error_codes.py
+++ b/python/confiture/core/error_codes.py
@@ -779,6 +779,16 @@ def _create_global_registry() -> ErrorCodeRegistry:
             resolution_hint="Initialize a git repository or use a valid repository path",
         ),
         ErrorCodeDefinition(
+            code="GIT_003",
+            message_template="Base ref unreachable in this checkout",
+            severity=ErrorSeverity.ERROR,
+            exit_code=7,
+            resolution_hint=(
+                "In CI, set fetch-depth: 0 (actions/checkout) or run "
+                "'git fetch --unshallow origin <branch>'"
+            ),
+        ),
+        ErrorCodeDefinition(
             code="GRANT_001",
             message_template="Grant accompaniment error",
             severity=ErrorSeverity.ERROR,
@@ -905,6 +915,7 @@ CANONICAL_EXIT_CODES: dict[str, int] = {
     # GIT / PGGIT / GRANT → 7.
     "GIT_001": 7,
     "GIT_002": 7,
+    "GIT_003": 7,
     "GIT_800": 7,
     "GIT_801": 7,
     "GIT_802": 7,

--- a/python/confiture/core/git.py
+++ b/python/confiture/core/git.py
@@ -24,7 +24,12 @@ class GitRepository:
     No external dependencies required.
 
     Attributes:
-        repo_path: Root directory of git repository
+        repo_path: The working directory git commands run in — **not**
+            necessarily the repository root. It defaults to ``Path.cwd()``,
+            which is a subdirectory of the root whenever the caller was
+            invoked from one. Since ``git diff --name-only`` reports paths
+            relative to the *root* regardless of cwd, resolving those paths
+            requires :meth:`get_repo_root`, not this attribute.
 
     Example:
         >>> repo = GitRepository(Path("."))
@@ -33,13 +38,46 @@ class GitRepository:
     """
 
     def __init__(self, repo_path: Path | None = None):
-        """Initialize GitRepository with optional repo path.
+        """Initialize GitRepository with optional working directory.
 
         Args:
-            repo_path: Root directory of git repository.
-                      If None, uses current directory.
+            repo_path: Directory to run git commands from (any directory
+                inside the repository). If None, uses the current directory.
+                See the class docstring: this is not the repository root.
         """
         self.repo_path = repo_path or Path.cwd()
+
+    def get_repo_root(self) -> Path:
+        """Return the repository root (``git rev-parse --show-toplevel``).
+
+        ``git diff --name-only`` reports paths relative to the repository
+        root regardless of the directory git runs in, so joining those paths
+        onto :attr:`repo_path` produces garbage whenever the caller is in a
+        subdirectory (an ordinary monorepo layout). Resolve them against this
+        instead.
+
+        Returns:
+            Absolute path to the repository root.
+
+        Raises:
+            NotAGitRepositoryError: If not in a git repository.
+            GitError: If the git command fails or times out.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise GitError("Git command timed out resolving the repository root") from e
+
+        if result.returncode != 0 or not result.stdout.strip():
+            raise NotAGitRepositoryError(f"Not a git repository: {self.repo_path}")
+
+        return Path(result.stdout.strip())
 
     def is_git_repo(self) -> bool:
         """Check if directory is a git repository.
@@ -122,8 +160,48 @@ class GitRepository:
 
         return result.stdout
 
+    def require_ref(self, ref: str) -> None:
+        """Assert a ref resolves in this checkout, or raise ``GIT_003``.
+
+        A shallow ``actions/checkout`` (the default ``fetch-depth: 1``) has no
+        ``origin/main``, so a gate scoped against it would otherwise fail with
+        git's own wording and no remedy. This is the one git failure a CI
+        author can act on, so it gets its own greppable code.
+
+        Args:
+            ref: The git reference to verify.
+
+        Raises:
+            NotAGitRepositoryError: If not in a git repository.
+            GitError: ``GIT_003`` if the ref does not resolve to a commit.
+        """
+        if not self.is_git_repo():
+            raise NotAGitRepositoryError(f"Not a git repository: {self.repo_path}")
+
+        if not _VALID_GIT_REF_RE.match(ref):
+            raise GitError(f"Invalid git reference: {ref!r}")
+
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise GitError(f"Git command timed out verifying ref '{ref}'") from e
+
+        if result.returncode != 0:
+            raise GitError(
+                f"Base ref '{ref}' is not available in this checkout. "
+                "In CI, set fetch-depth: 0 (actions/checkout) or run "
+                f"'git fetch --unshallow origin {ref.rsplit('/', 1)[-1]}'.",
+                error_code="GIT_003",
+            )
+
     def get_changed_files(self, base_ref: str, target_ref: str = "HEAD") -> list[Path]:
-        """Get list of files changed between two refs.
+        """Get list of files changed between two refs (three-dot).
 
         Args:
             base_ref: Base git reference (e.g., "origin/main")
@@ -136,6 +214,12 @@ class GitRepository:
             NotAGitRepositoryError: If not in a git repository
             GitError: If git command fails
 
+        Note:
+            Three-dot ``base...target`` fails with ``no merge base`` in a
+            shallow clone. :meth:`get_changed_files_two_dot`, anchored on
+            :meth:`get_merge_base`, is equivalent whenever a merge base exists
+            and survives when one cannot be computed.
+
         Example:
             >>> repo = GitRepository(Path("."))
             >>> files = repo.get_changed_files("origin/main", "HEAD")
@@ -144,6 +228,32 @@ class GitRepository:
             db/schema/users.sql
             db/migrations/001_add_users.up.sql
         """
+        return self._diff_name_only(f"{base_ref}...{target_ref}", base_ref, target_ref)
+
+    def get_changed_files_two_dot(self, base_ref: str, target_ref: str = "HEAD") -> list[Path]:
+        """Get list of files changed between two refs (two-dot).
+
+        Two-dot ``base..target`` asks "what does target have that base does
+        not", without needing to compute a merge base — so it works in shallow
+        clones, where three-dot dies with ``fatal: ... no merge base``. Pair it
+        with :meth:`get_merge_base` as the base to recover three-dot semantics
+        wherever a merge base is computable.
+
+        Args:
+            base_ref: Base git reference, typically a merge-base commit
+            target_ref: Target git reference (default "HEAD")
+
+        Returns:
+            List of file paths (relative to repo root) that changed
+
+        Raises:
+            NotAGitRepositoryError: If not in a git repository
+            GitError: If git command fails
+        """
+        return self._diff_name_only(f"{base_ref}..{target_ref}", base_ref, target_ref)
+
+    def _diff_name_only(self, spec: str, base_ref: str, target_ref: str) -> list[Path]:
+        """Run ``git diff --name-only <spec>`` and classify failures."""
         if not self.is_git_repo():
             raise NotAGitRepositoryError(f"Not a git repository: {self.repo_path}")
 
@@ -154,7 +264,7 @@ class GitRepository:
         # Get list of changed files (both added and modified)
         try:
             result = subprocess.run(
-                ["git", "diff", "--name-only", f"{base_ref}...{target_ref}"],
+                ["git", "diff", "--name-only", spec],
                 cwd=self.repo_path,
                 capture_output=True,
                 text=True,
@@ -167,6 +277,16 @@ class GitRepository:
             error_msg = result.stderr.strip()
             if "bad revision" in error_msg or "unknown revision" in error_msg:
                 raise GitError(f"Invalid git reference: {error_msg}")
+            if "no merge base" in error_msg or "unrelated histories" in error_msg:
+                # Shallow clone: the histories are present but truncated before
+                # their fork point. Name the remedy — this message previously
+                # fell into the generic bucket and never mentioned it.
+                raise GitError(
+                    f"Cannot compare '{base_ref}' to '{target_ref}': no merge base. "
+                    "This usually means a shallow clone. In CI, set fetch-depth: 0 "
+                    "(actions/checkout) or run 'git fetch --unshallow'.",
+                    error_code="GIT_003",
+                )
             raise GitError(f"Git command failed: {error_msg}")
 
         if not result.stdout.strip():

--- a/python/confiture/core/ledger.py
+++ b/python/confiture/core/ledger.py
@@ -1,0 +1,65 @@
+"""Migration ledger existence probe.
+
+The migration ledger (``tb_confiture`` by default, configurable via
+``tracking_table``) records which migrations have been applied.  Commands that
+read it need to distinguish *absent* from *empty*: a database built from schema
+files has no ledger at all, which is a different state from a database that has
+one with no rows in it.
+
+This module holds the single implementation of that check, callable with a raw
+connection so that callers which never build a :class:`Migrator` — such as
+``verify-checksums`` — do not have to reach into ``core._migrator``.
+
+Caveat: for a bare (unqualified) table name the probe matches the table in
+*any* schema, and respects neither ``search_path`` nor schema privileges.
+``to_regclass('tb_confiture') IS NOT NULL`` would be strictly more correct, but
+switching to it changes behaviour for ``migrate status``,
+``migrate up --auto-baseline`` and ``MigratorSession.current()``, so it is
+tracked as a follow-up rather than changed here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_QUALIFIED_SQL = """
+    SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = %s AND table_name = %s
+    )
+"""
+
+_BARE_SQL = """
+    SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_name = %s
+    )
+"""
+
+
+def ledger_exists(connection: Any, table: str) -> bool:
+    """Return True when the migration ledger table exists.
+
+    Args:
+        connection: An open DB-API connection (psycopg3).
+        table: Bare (``tb_confiture``) or schema-qualified
+            (``public.tb_confiture``) table name.  A qualified name filters on
+            the schema; a bare name matches the table in any schema.
+
+    Returns:
+        True if the table is present, False otherwise.
+
+    Example:
+        >>> ledger_exists(conn, "tb_confiture")
+        False
+    """
+    schema, _, base = table.partition(".")
+    if base:
+        sql, params = _QUALIFIED_SQL, (schema, base)
+    else:
+        sql, params = _BARE_SQL, (schema,)
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+        row = cursor.fetchone()
+        return bool(row[0]) if row else False

--- a/python/confiture/models/results.py
+++ b/python/confiture/models/results.py
@@ -636,6 +636,10 @@ class VerifyAllResult:
         failed_count: Number of migrations that failed verification
         skipped_count: Number of applied migrations with no verify file
         total_applied: Total number of applied migrations checked
+        ledger_present: Whether the migration ledger table exists.  False means
+            the database has no recorded migrations at all (built from schema
+            files rather than migrated) — distinct from a present-but-empty
+            ledger, which reports True with ``total_applied == 0``.
     """
 
     results: list[VerifyResult]
@@ -643,6 +647,7 @@ class VerifyAllResult:
     failed_count: int
     skipped_count: int
     total_applied: int
+    ledger_present: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -651,6 +656,7 @@ class VerifyAllResult:
             "failed_count": self.failed_count,
             "skipped_count": self.skipped_count,
             "total_applied": self.total_applied,
+            "ledger_present": self.ledger_present,
             "results": [
                 {
                     "version": r.version,
@@ -762,6 +768,9 @@ class PreflightResult:
     duplicate_versions: dict[str, list[str]] = field(default_factory=dict)
     checksum_mismatches: list[str] = field(default_factory=list)
     checksum_verified: bool = False
+    #: Why checksum verification did not run, when it did not. ``None`` when it
+    #: ran, or when there was no connection to run it against.
+    checksum_skipped_reason: str | None = None
 
     @property
     def all_reversible(self) -> bool:

--- a/tests/integration/test_migrate_verify_no_ledger_integration.py
+++ b/tests/integration/test_migrate_verify_no_ledger_integration.py
@@ -1,0 +1,116 @@
+"""Real-database coverage for `migrate verify` on a ledger-less DB (#182b).
+
+`clean_test_db` drops every table in `public`, so the connection is exactly the
+reported state: reachable, no migration ledger.  Both flag states, both formats.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import psycopg
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+RAW_PSYCOPG_MARKERS = ('relation "', "LINE 1:")
+
+
+@pytest.fixture
+def cfg(tmp_path: Path, test_db_url: str) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump({"name": "test", "database_url": test_db_url, "include_dirs": ["db/schema"]})
+    )
+    return p
+
+
+@pytest.fixture
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    (d / "20260101000000_init.up.sql").write_text("CREATE TABLE t (id int);")
+    return d
+
+
+def _run(cfg: Path, migrations_dir: Path, *extra: str):
+    return runner.invoke(
+        app,
+        ["migrate", "verify", "-c", str(cfg), "--migrations-dir", str(migrations_dir), *extra],
+    )
+
+
+def test_ledger_less_text_exits_2(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    result = _run(cfg, migrations_dir)
+
+    assert result.exit_code == 2
+    assert "is not present in this database" in result.output
+    for marker in RAW_PSYCOPG_MARKERS:
+        assert marker not in result.output
+
+
+def test_ledger_less_json_emits_precon_1001(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    result = _run(cfg, migrations_dir, "--format", "json")
+
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)["error"]["code"] == "PRECON_1001"
+
+
+def test_ledger_less_allow_uninitialized_text(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    result = _run(cfg, migrations_dir, "--allow-uninitialized")
+
+    assert result.exit_code == 0
+    assert "0 migrations recorded" in result.output
+
+
+def test_ledger_less_allow_uninitialized_json(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    result = _run(cfg, migrations_dir, "--allow-uninitialized", "--format", "json")
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ledger_present"] is False
+    assert payload["total_applied"] == 0
+    assert payload["results"] == []
+
+
+def test_present_but_empty_ledger_reports_ledger_present(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    """Absent != empty, against a real table."""
+    with clean_test_db.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE tb_confiture (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                pk_confiture BIGINT GENERATED ALWAYS AS IDENTITY UNIQUE,
+                slug TEXT NOT NULL UNIQUE,
+                version VARCHAR(255) NOT NULL UNIQUE,
+                name VARCHAR(255) NOT NULL,
+                applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                execution_time_ms INTEGER,
+                checksum VARCHAR(64),
+                applied_by TEXT
+            )
+            """
+        )
+        clean_test_db.commit()
+
+    result = _run(cfg, migrations_dir, "--format", "json")
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ledger_present"] is True
+    assert payload["total_applied"] == 0

--- a/tests/integration/test_verify_checksums_no_ledger_integration.py
+++ b/tests/integration/test_verify_checksums_no_ledger_integration.py
@@ -1,0 +1,112 @@
+"""Real-database coverage for `verify-checksums` on a ledger-less DB (#182a).
+
+The mocked unit tests pin the branch; this pins the *premise* — that a database
+with no `tb_confiture` really does reach the guard rather than failing earlier.
+#172 established that a real-DB test catches premise errors that mocked tests
+wave through.
+
+`clean_test_db` drops every table in `public`, so the connection it hands back
+is exactly the state under test: reachable, no migration ledger.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import psycopg
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+RAW_PSYCOPG_MARKERS = ('relation "', "LINE 1:")
+
+
+@pytest.fixture
+def cfg(tmp_path: Path, test_db_url: str) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump({"name": "test", "database_url": test_db_url, "include_dirs": ["db/schema"]})
+    )
+    return p
+
+
+@pytest.fixture
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    (d / "20260101000000_init.up.sql").write_text("CREATE TABLE t (id int);")
+    return d
+
+
+def _run(cfg: Path, migrations_dir: Path, *extra: str):
+    return runner.invoke(
+        app,
+        ["verify-checksums", "-c", str(cfg), "--migrations-dir", str(migrations_dir), *extra],
+    )
+
+
+def test_ledger_less_database_exits_2(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    result = _run(cfg, migrations_dir)
+
+    assert result.exit_code == 2
+    assert "is not present in this database" in result.output
+    for marker in RAW_PSYCOPG_MARKERS:
+        assert marker not in result.output
+
+
+def test_ledger_less_database_with_allow_uninitialized_exits_0(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    result = _run(cfg, migrations_dir, "--allow-uninitialized")
+
+    assert result.exit_code == 0
+    assert "0 migrations recorded" in result.output
+
+
+def test_present_but_empty_ledger_succeeds(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    """Absent != empty, against a real table.
+
+    An empty `tb_confiture` means "initialized, nothing applied yet" — the
+    command must succeed, not report a missing ledger.
+    """
+    with clean_test_db.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE tb_confiture (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                pk_confiture BIGINT GENERATED ALWAYS AS IDENTITY UNIQUE,
+                slug TEXT NOT NULL UNIQUE,
+                version VARCHAR(255) NOT NULL UNIQUE,
+                name VARCHAR(255) NOT NULL,
+                applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                execution_time_ms INTEGER,
+                checksum VARCHAR(64),
+                applied_by TEXT
+            )
+            """
+        )
+        clean_test_db.commit()
+
+    result = _run(cfg, migrations_dir)
+
+    assert result.exit_code == 0
+    assert "All migration checksums verified" in result.output
+    assert "no migration ledger" not in result.output.lower()
+
+
+def test_deprecated_alias_on_ledger_less_database(
+    clean_test_db: psycopg.Connection, cfg: Path, migrations_dir: Path
+) -> None:
+    result = runner.invoke(app, ["verify", "-c", str(cfg), "--migrations-dir", str(migrations_dir)])
+
+    assert result.exit_code == 2
+    assert "is not present in this database" in result.output
+    assert "deprecated" in result.output.lower()

--- a/tests/unit/cli/test_idempotent_scoping.py
+++ b/tests/unit/cli/test_idempotent_scoping.py
@@ -1,0 +1,596 @@
+"""`migrate validate --idempotent` scoping to changed migrations (#181).
+
+⚠️ Read before adding a test here.
+
+**No golden/snapshot assertions.** Rich soft-wraps at console width mid-path,
+absolute `tmp_path`s leak into messages and into JSON `scanned_files`, and
+pglast presence changes *which* violations are detected.  Assert contracts:
+parsed JSON, counts, and basename sets.
+
+**No test may assert only "zero" or only "exit 0".** "Zero files selected" is
+the shared symptom of every way this feature can be silently broken — a test
+asserting it passes while the gate scans nothing.  Every scoping test asserts a
+**positive** expected selection: the count, the basenames present, and the
+untouched basenames absent.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+# ── real-git helpers (mocking subprocess would test the mock) ─────────────────
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _init(repo: Path) -> None:
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "t@t.com")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+
+def _default_branch(repo: Path) -> str:
+    return _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+
+
+IDEMPOTENT = "CREATE TABLE IF NOT EXISTS {name} (id int);\n"
+NON_IDEMPOTENT = "CREATE TABLE {name} (id int);\n"
+
+
+def _migration(repo: Path, version: str, name: str, *, idempotent: bool) -> Path:
+    body = (IDEMPOTENT if idempotent else NON_IDEMPOTENT).format(name=name)
+    path = repo / "db" / "migrations" / f"{version}_{name}.up.sql"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+def _run_json(migrations_dir: Path, *extra: str, cwd: Path | None = None) -> tuple[int, dict]:
+    """Invoke `migrate validate --idempotent --format json` and parse stdout."""
+    import os
+
+    prev = Path.cwd()
+    if cwd is not None:
+        os.chdir(cwd)
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--migrations-dir",
+                str(migrations_dir),
+                "--format",
+                "json",
+                *extra,
+            ],
+        )
+    finally:
+        os.chdir(prev)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:  # pragma: no cover - diagnostic path
+        pytest.fail(f"non-JSON stdout (exit {result.exit_code}):\n{result.output}")
+    return result.exit_code, payload
+
+
+def _basenames(payload: dict) -> set[str]:
+    return {Path(p).name for p in payload.get("scanned_files", [])}
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def bare_dir(tmp_path: Path) -> Path:
+    """A non-git migrations directory with three idempotent migrations."""
+    d = tmp_path / "db" / "migrations"
+    d.mkdir(parents=True)
+    for version, name in (
+        ("20260101000000", "alpha"),
+        ("20260102000000", "beta"),
+        ("20260103000000", "gamma"),
+    ):
+        (d / f"{version}_{name}.up.sql").write_text(IDEMPOTENT.format(name=name))
+    return d
+
+
+# ── Cycle 1: unscoped behaviour is frozen by contract ────────────────────────
+
+
+class TestUnscopedBehaviourUnchanged:
+    """The 0.36.0 contract. These must pass on unmodified code and after.
+
+    `--base-ref` defaults to the truthy string "origin/main", so threading it
+    unconditionally would scope every run — and, per D3, make a plain
+    `--idempotent` in a non-git tree exit 7.  The `meta`-has-no-`scope`
+    assertion below is the direct regression guard for that.
+    """
+
+    def test_no_flags_scans_everything(self, bare_dir: Path) -> None:
+        exit_code, payload = _run_json(bare_dir)
+
+        assert exit_code == 0
+        assert payload["status"] == "ok"
+        assert payload["files_scanned"] == 3
+        assert _basenames(payload) == {
+            "20260101000000_alpha.up.sql",
+            "20260102000000_beta.up.sql",
+            "20260103000000_gamma.up.sql",
+        }
+        assert payload["violation_count"] == 0
+
+    def test_no_flags_emits_no_scope_key(self, bare_dir: Path) -> None:
+        """THE load-bearing assertion: an unscoped run must not report scope."""
+        _, payload = _run_json(bare_dir)
+
+        assert "scope" not in payload["meta"]
+
+    def test_no_flags_works_outside_a_git_repo(self, bare_dir: Path) -> None:
+        """A bare tmp_path is not a git repo — this must not become exit 7."""
+        exit_code, payload = _run_json(bare_dir)
+
+        assert exit_code == 0
+        assert payload["files_scanned"] == 3
+
+    def test_violations_still_reported_unscoped(self, bare_dir: Path) -> None:
+        (bare_dir / "20260104000000_delta.up.sql").write_text(NON_IDEMPOTENT.format(name="delta"))
+
+        exit_code, payload = _run_json(bare_dir)
+
+        assert exit_code == 1
+        assert payload["files_scanned"] == 4
+        assert payload["violation_count"] >= 1
+        assert "scope" not in payload["meta"]
+
+
+# ── real-repo fixture ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with three committed idempotent migrations on the default branch.
+
+    HEAD is on a `feature` branch that has not diverged yet, so each test
+    decides what "changed" means for itself.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    _init(root)
+    for version, name in (
+        ("20260101000000", "alpha"),
+        ("20260102000000", "beta"),
+        ("20260103000000", "gamma"),
+    ):
+        _migration(root, version, name, idempotent=True)
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "base")
+    return root
+
+
+@pytest.fixture
+def base(repo: Path) -> str:
+    return _default_branch(repo)
+
+
+class TestExplicitFlagDetection:
+    """T1: the option's truthy default must not scope; the flag must."""
+
+    def test_default_base_ref_does_not_scope(self, repo: Path, base: str) -> None:
+        """Inside a real repo where the base ref exists and differs from HEAD.
+
+        Rev 1's design would have scoped here — this is the test that catches it.
+        """
+        _git(repo, "checkout", "-b", "feature")
+        _migration(repo, "20260104000000", "delta", idempotent=True)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "delta")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", cwd=repo)
+
+        assert exit_code == 0
+        assert payload["files_scanned"] == 4
+        assert "scope" not in payload["meta"]
+
+    def test_explicit_base_ref_scopes(self, repo: Path, base: str) -> None:
+        _git(repo, "checkout", "-b", "feature")
+        _migration(repo, "20260104000000", "delta", idempotent=True)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "delta")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+
+        assert exit_code == 0
+        assert payload["meta"]["scope"]["mode"] == "base-ref"
+        assert payload["meta"]["scope"]["base_ref"] == base
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_delta.up.sql"}
+
+
+class TestScopingSelectsOnlyChanged:
+    def test_base_ref_selects_only_changed(self, repo: Path, base: str) -> None:
+        """Two changed of four; the three untouched must not be scanned."""
+        _git(repo, "checkout", "-b", "feature")
+        _migration(repo, "20260104000000", "delta", idempotent=False)
+        _migration(repo, "20260102000000", "beta", idempotent=False)  # modify existing
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "work")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+
+        assert payload["files_scanned"] == 2
+        assert _basenames(payload) == {
+            "20260104000000_delta.up.sql",
+            "20260102000000_beta.up.sql",
+        }
+        assert "20260101000000_alpha.up.sql" not in _basenames(payload)
+        assert "20260103000000_gamma.up.sql" not in _basenames(payload)
+        assert exit_code == 1
+        assert payload["violation_count"] >= 2
+
+    def test_untouched_violations_are_not_reported(self, repo: Path, base: str) -> None:
+        """A pre-existing violation in an untouched file stays out of scope.
+
+        This is #181's whole point: a backlog of non-idempotent migrations
+        must not block a branch that didn't touch them.
+        """
+        # Commit a non-idempotent migration onto the base branch first.
+        _migration(repo, ["20260100000000", " legacy"][0], "legacy", idempotent=False)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "legacy backlog")
+
+        _git(repo, "checkout", "-b", "feature")
+        _migration(repo, "20260104000000", "delta", idempotent=True)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "clean work")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_delta.up.sql"}
+        assert exit_code == 0
+        assert payload["violation_count"] == 0
+
+        # ...and unscoped, the very same tree DOES fail. Proves the scoped
+        # pass was a real selection, not an accidental zero.
+        unscoped_exit, unscoped = _run_json(repo / "db" / "migrations", cwd=repo)
+        assert unscoped_exit == 1
+        assert unscoped["violation_count"] >= 1
+
+
+class TestSinceParity:
+    def test_since_is_equivalent_to_base_ref(self, repo: Path, base: str) -> None:
+        _git(repo, "checkout", "-b", "feature")
+        _migration(repo, "20260104000000", "delta", idempotent=False)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "delta")
+
+        by_since = _run_json(repo / "db" / "migrations", "--since", base, cwd=repo)[1]
+        by_base = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)[1]
+
+        assert by_since["files_scanned"] == 1
+        assert _basenames(by_since) == {"20260104000000_delta.up.sql"}
+        assert _basenames(by_since) == _basenames(by_base)
+
+
+class TestSubdirectoryCwd:
+    """T2: diff paths are repo-root-relative regardless of cwd."""
+
+    def test_scoping_with_cwd_in_subdirectory(self, repo: Path, base: str) -> None:
+        subdir = repo / "backend"
+        subdir.mkdir()
+        (subdir / "marker.txt").write_text("x")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "subdir")
+
+        _git(repo, "checkout", "-b", "feature")
+        _migration(repo, "20260104000000", "delta", idempotent=False)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "delta")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=subdir)
+
+        # POSITIVE assertion — a zero here is exactly the T2 failure mode.
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_delta.up.sql"}
+        assert exit_code == 1
+
+
+class TestShallowClone:
+    """T3: three-dot dies on shallow clones; merge-base + two-dot survives."""
+
+    def test_unfetched_base_ref_names_the_remedy(self, repo: Path, tmp_path: Path) -> None:
+        clone = tmp_path / "shallow"
+        subprocess.run(
+            ["git", "clone", "--depth", "1", "--no-local", f"file://{repo}", str(clone)],
+            check=True,
+            capture_output=True,
+        )
+
+        import os
+
+        prev = Path.cwd()
+        os.chdir(clone)
+        try:
+            result = runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "validate",
+                    "--idempotent",
+                    "--migrations-dir",
+                    str(clone / "db" / "migrations"),
+                    "--base-ref",
+                    "origin/does-not-exist",
+                ],
+            )
+        finally:
+            os.chdir(prev)
+
+        assert result.exit_code == 7
+        # Rich soft-wraps at console width, so assert on short fragments only.
+        assert "fetch-depth: 0" in result.output
+
+    def test_fetched_but_shallow_base_ref_still_scopes(
+        self, repo: Path, base: str, tmp_path: Path
+    ) -> None:
+        """Ref present, no merge base: must SUCCEED via two-dot, not exit 7."""
+        _git(repo, "checkout", "-b", "feature")
+        _migration(repo, "20260104000000", "delta", idempotent=False)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "delta")
+
+        clone = tmp_path / "shallow2"
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--no-local",
+                "--branch",
+                "feature",
+                f"file://{repo}",
+                str(clone),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "fetch", "--depth", "1", "origin", f"{base}:refs/remotes/origin/{base}"],
+            cwd=clone,
+            check=True,
+            capture_output=True,
+        )
+
+        exit_code, payload = _run_json(
+            clone / "db" / "migrations", "--base-ref", f"origin/{base}", cwd=clone
+        )
+
+        # POSITIVE: a real selection, not an exit 7 and not an empty scope.
+        assert exit_code == 1
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_delta.up.sql"}
+
+
+class TestStagedScoping:
+    """T4/D4: base..HEAD cannot see a pre-commit change; --staged can."""
+
+    def test_staged_migration_is_validated(self, repo: Path) -> None:
+        _migration(repo, "20260104000000", "delta", idempotent=False)
+        _git(repo, "add", "-A")  # staged, NOT committed
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--staged", cwd=repo)
+
+        assert payload["meta"]["scope"]["mode"] == "staged"
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_delta.up.sql"}
+        assert exit_code == 1
+        assert payload["violation_count"] >= 1
+
+    def test_staged_content_differs_from_worktree(self, repo: Path) -> None:
+        """Stage a clean version, then dirty the tree: the INDEX is judged."""
+        path = _migration(repo, "20260104000000", "delta", idempotent=True)
+        _git(repo, "add", "-A")
+        path.write_text(NON_IDEMPOTENT.format(name="delta"))  # worktree now dirty
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--staged", cwd=repo)
+
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_delta.up.sql"}
+        # The staged blob is idempotent, so this passes despite the dirty tree.
+        assert exit_code == 0
+        assert payload["violation_count"] == 0
+
+    def test_staged_wins_over_base_ref(self, repo: Path, base: str) -> None:
+        _git(repo, "checkout", "-b", "feature")
+        _migration(repo, "20260104000000", "delta", idempotent=True)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "committed delta")
+        _migration(repo, "20260105000000", "epsilon", idempotent=False)
+        _git(repo, "add", "-A")  # staged only
+
+        exit_code, payload = _run_json(
+            repo / "db" / "migrations", "--staged", "--base-ref", base, cwd=repo
+        )
+
+        assert payload["meta"]["scope"]["mode"] == "staged"
+        assert _basenames(payload) == {"20260105000000_epsilon.up.sql"}
+        assert exit_code == 1
+
+
+class TestDeletionsAndRenames:
+    def test_deleted_migration_is_skipped(self, repo: Path, base: str) -> None:
+        _git(repo, "checkout", "-b", "feature")
+        _git(repo, "rm", "-q", "db/migrations/20260101000000_alpha.up.sql")
+        _migration(repo, "20260104000000", "delta", idempotent=False)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "delete alpha, add delta")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+
+        # The deleted file is in the diff but not on disk: glob ∩ diff drops it.
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_delta.up.sql"}
+        assert exit_code == 1
+
+    def test_renamed_migration_validates_new_path(self, repo: Path, base: str) -> None:
+        _git(repo, "checkout", "-b", "feature")
+        _git(
+            repo,
+            "mv",
+            "db/migrations/20260101000000_alpha.up.sql",
+            "db/migrations/20260104000000_alpha.up.sql",
+        )
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "rename")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+
+        # --name-only reports a rename as delete+add; the new path is selected.
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_alpha.up.sql"}
+        assert exit_code == 0
+
+    def test_changed_down_sql_alone_scopes_to_zero(self, repo: Path, base: str) -> None:
+        _git(repo, "checkout", "-b", "feature")
+        down = repo / "db" / "migrations" / "20260101000000_alpha.down.sql"
+        down.write_text("DROP TABLE alpha;\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "down only")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+
+        assert exit_code == 0
+        assert payload["meta"]["scope"]["files_selected"] == 0
+        assert payload["meta"]["scope"]["files_skipped"] == 3
+
+
+class TestZeroScopeReporting:
+    def test_zero_changed_migrations_message_is_distinct(self, repo: Path, base: str) -> None:
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "README.md").write_text("docs only\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "docs")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+
+        assert exit_code == 0
+        assert payload["status"] == "ok"
+        assert base in payload["message"]
+        # Distinct from the empty-directory message — different remedies.
+        assert "contains no files" not in payload["message"]
+        assert payload["message"] != "No migration files found"
+
+    def test_zero_scope_is_proven_real_not_an_artefact(self, repo: Path, base: str) -> None:
+        """A deliberately-changed file WOULD be selected under the same ref.
+
+        Without this, a zero could equally be T1/T2/T4 silently scanning nothing.
+        """
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "README.md").write_text("docs only\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "docs")
+
+        _, zero = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+        assert zero["meta"]["scope"]["files_selected"] == 0
+
+        _migration(repo, "20260104000000", "delta", idempotent=False)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "now a migration")
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--base-ref", base, cwd=repo)
+        assert payload["files_scanned"] == 1
+        assert _basenames(payload) == {"20260104000000_delta.up.sql"}
+        assert exit_code == 1
+
+
+class TestOutsideRepo:
+    def test_dir_outside_repo_errors_clearly(self, repo: Path, tmp_path: Path) -> None:
+        """A dir that can never intersect the diff must fail loud, not pass."""
+        outside = tmp_path / "elsewhere" / "migrations"
+        outside.mkdir(parents=True)
+        (outside / "20260101000000_x.up.sql").write_text(NON_IDEMPOTENT.format(name="x"))
+
+        import os
+
+        prev = Path.cwd()
+        os.chdir(repo)
+        try:
+            result = runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "validate",
+                    "--idempotent",
+                    "--migrations-dir",
+                    str(outside),
+                    "--base-ref",
+                    _default_branch(repo),
+                ],
+            )
+        finally:
+            os.chdir(prev)
+
+        assert result.exit_code != 0
+        assert "outside the repository" in result.output
+
+    def test_scoping_outside_a_git_repo_fails_loud(self, bare_dir: Path) -> None:
+        """Explicit scoping in a non-git tree is an error, never a silent zero."""
+        import os
+
+        prev = Path.cwd()
+        os.chdir(bare_dir.parent.parent)
+        try:
+            result = runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "validate",
+                    "--idempotent",
+                    "--migrations-dir",
+                    str(bare_dir),
+                    "--base-ref",
+                    "origin/main",
+                ],
+            )
+        finally:
+            os.chdir(prev)
+
+        assert result.exit_code == 7
+
+
+class TestFlagCombinationGuard:
+    def test_idempotent_with_require_migration_fails_loud(self, bare_dir: Path) -> None:
+        """Previously ran only --require-migration and silently skipped idempotency."""
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--require-migration",
+                "--migrations-dir",
+                str(bare_dir),
+            ],
+        )
+
+        assert result.exit_code != 0
+        # Short fragment: Rich soft-wraps mid-sentence at console width.
+        assert "cannot be combined with" in result.output

--- a/tests/unit/cli/test_migrate_verify_config_path.py
+++ b/tests/unit/cli/test_migrate_verify_config_path.py
@@ -1,0 +1,88 @@
+"""Regression: `migrate verify -c <config>` must not crash (found during #182).
+
+v0.36.0 passed `str(config)` to `load_config`, which calls `config_file.exists()`
+— so the command's own documented primary invocation,
+`confiture migrate verify -c db/environments/local.yaml`, died with
+`AttributeError: 'str' object has no attribute 'exists'` at exit 1.
+
+Every other `load_config` call site in the CLI passes the `Path`; this one was
+the sole outlier.  It went unnoticed because the existing `migrate verify`
+tests reach the command through `--database-url` rather than an explicit
+`--config`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": "postgresql://localhost/nonexistent_for_test",
+                "include_dirs": ["db/schema"],
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    return d
+
+
+def test_explicit_config_path_is_loaded_not_stringified(cfg: Path, migrations_dir: Path) -> None:
+    """An explicit --config reaches the ledger probe rather than crashing."""
+    with (
+        patch("confiture.core.connection.create_connection", return_value=MagicMock()),
+        patch("confiture.core.migrator.Migrator.tracking_table_exists", return_value=False),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "verify",
+                "-c",
+                str(cfg),
+                "--migrations-dir",
+                str(migrations_dir),
+                "--allow-uninitialized",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "has no attribute" not in result.output
+
+
+def test_missing_config_still_reports_config_004(tmp_path: Path, migrations_dir: Path) -> None:
+    """The Path is still validated — a missing file is a clean CONFIG_004."""
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "verify",
+            "-c",
+            str(tmp_path / "absent.yaml"),
+            "--migrations-dir",
+            str(migrations_dir),
+        ],
+    )
+
+    assert result.exit_code == 5
+    assert "has no attribute" not in result.output

--- a/tests/unit/cli/test_migrate_verify_no_ledger.py
+++ b/tests/unit/cli/test_migrate_verify_no_ledger.py
@@ -1,0 +1,160 @@
+"""`migrate verify` against a database with no migration ledger (#182b).
+
+The reporter hit this via `verify-checksums`; `migrate verify` is an
+independent crash site — it calls `migrator.get_applied_versions()`, which is
+unguarded on an absent tracking table.
+
+⚠️ BREAKING: exit 2 from `migrate verify` previously fell into the adapter
+contract's `InvalidConfig` row.  The contract row was widened in the same
+commit as this change.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+RAW_PSYCOPG_MARKERS = ('relation "', "LINE 1:")
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": "postgresql://localhost/nonexistent_for_test",
+                "include_dirs": ["db/schema"],
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    (d / "20260101000000_init.up.sql").write_text("CREATE TABLE t (id int);")
+    return d
+
+
+def _invoke(
+    cfg: Path,
+    migrations_dir: Path,
+    *extra: str,
+    ledger: bool,
+    applied: list[str] | None = None,
+):
+    """Invoke `migrate verify` with the ledger probe forced to `ledger`."""
+    with (
+        patch("confiture.core.connection.create_connection", return_value=MagicMock()),
+        patch(
+            "confiture.core.migrator.Migrator.tracking_table_exists",
+            return_value=ledger,
+        ),
+        patch(
+            "confiture.core.migrator.Migrator.get_applied_versions",
+            return_value=applied or [],
+        ),
+    ):
+        return runner.invoke(
+            app,
+            [
+                "migrate",
+                "verify",
+                "-c",
+                str(cfg),
+                "--migrations-dir",
+                str(migrations_dir),
+                *extra,
+            ],
+        )
+
+
+class TestAbsentLedgerText:
+    def test_absent_ledger_text_exits_2(self, cfg: Path, migrations_dir: Path) -> None:
+        result = _invoke(cfg, migrations_dir, ledger=False)
+
+        assert result.exit_code == 2
+        assert "is not present in this database" in result.output
+        for marker in RAW_PSYCOPG_MARKERS:
+            assert marker not in result.output
+
+    def test_absent_ledger_message_is_actionable(self, cfg: Path, migrations_dir: Path) -> None:
+        result = _invoke(cfg, migrations_dir, ledger=False)
+
+        assert "migrate up" in result.output
+        assert "baseline" in result.output
+        assert "--allow-uninitialized" in result.output
+
+
+class TestAllowUninitialized:
+    def test_allow_uninitialized_text_exits_0(self, cfg: Path, migrations_dir: Path) -> None:
+        result = _invoke(cfg, migrations_dir, "--allow-uninitialized", ledger=False)
+
+        assert result.exit_code == 0
+        assert "no migration ledger" in result.output.lower()
+
+    def test_allow_uninitialized_json_is_valid_verify_payload(
+        self, cfg: Path, migrations_dir: Path
+    ) -> None:
+        result = _invoke(
+            cfg, migrations_dir, "--allow-uninitialized", "--format", "json", ledger=False
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["failed_count"] == 0
+        assert payload["total_applied"] == 0
+        assert payload["results"] == []
+        assert payload["ledger_present"] is False
+
+
+class TestLedgerPresentField:
+    def test_ledger_present_true_on_normal_path(self, cfg: Path, migrations_dir: Path) -> None:
+        with patch(
+            "confiture.core.migration_verifier.MigrationVerifier.verify_all",
+            return_value=[],
+        ):
+            result = _invoke(
+                cfg,
+                migrations_dir,
+                "--format",
+                "json",
+                ledger=True,
+                applied=["20260101000000"],
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["ledger_present"] is True
+        assert payload["total_applied"] == 1
+
+
+class TestAbsentIsNotEmpty:
+    """A present-but-empty ledger is a different state — it must not degrade."""
+
+    def test_present_but_empty_ledger_unchanged(self, cfg: Path, migrations_dir: Path) -> None:
+        with patch(
+            "confiture.core.migration_verifier.MigrationVerifier.verify_all",
+            return_value=[],
+        ):
+            result = _invoke(cfg, migrations_dir, "--format", "json", ledger=True, applied=[])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["total_applied"] == 0
+        assert payload["ledger_present"] is True
+        # The guard branch was not taken.
+        assert "no migration ledger" not in result.output.lower()

--- a/tests/unit/cli/test_verify_checksums_no_ledger.py
+++ b/tests/unit/cli/test_verify_checksums_no_ledger.py
@@ -1,0 +1,141 @@
+"""`verify-checksums` against a database with no migration ledger (#182a).
+
+0.36.0 crashed with a raw psycopg `relation "tb_confiture" does not exist` at
+exit 1 — the same code the command uses for "checksum mismatches found", so the
+two states were indistinguishable.  It now exits 2 (`PRECON_1001`), or 0 under
+`--allow-uninitialized`.
+
+CliRunner merges stdout/stderr, so these assert on exit codes and combined
+output substrings only — never on stream identity.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+RAW_PSYCOPG_MARKERS = ('relation "', "LINE 1:")
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": "postgresql://localhost/nonexistent_for_test",
+                "include_dirs": ["db/schema"],
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    (d / "20260101000000_init.up.sql").write_text("CREATE TABLE t (id int);")
+    return d
+
+
+def _invoke(
+    cfg: Path, migrations_dir: Path, *extra: str, ledger: bool, argv0: str = "verify-checksums"
+):
+    """Invoke the command with the ledger probe forced to `ledger`.
+
+    `verify_checksums` imports both names inside the function body, so the
+    patch targets are the source modules, not `commands.admin`.
+    """
+    with (
+        patch("confiture.core.connection.create_connection", return_value=MagicMock()),
+        patch("confiture.core.ledger.ledger_exists", return_value=ledger),
+    ):
+        return runner.invoke(
+            app,
+            [argv0, "-c", str(cfg), "--migrations-dir", str(migrations_dir), *extra],
+        )
+
+
+class TestAbsentLedger:
+    def test_absent_ledger_exits_2(self, cfg: Path, migrations_dir: Path) -> None:
+        result = _invoke(cfg, migrations_dir, ledger=False)
+
+        assert result.exit_code == 2
+        assert "tb_confiture" in result.output
+        for marker in RAW_PSYCOPG_MARKERS:
+            assert marker not in result.output
+
+    def test_absent_ledger_message_is_actionable(self, cfg: Path, migrations_dir: Path) -> None:
+        result = _invoke(cfg, migrations_dir, ledger=False)
+
+        assert "is not present in this database" in result.output
+        # The three ways forward, per _NO_LEDGER_HINT.
+        assert "migrate up" in result.output
+        assert "baseline" in result.output
+        assert "--allow-uninitialized" in result.output
+
+
+class TestAllowUninitialized:
+    def test_allow_uninitialized_exits_0(self, cfg: Path, migrations_dir: Path) -> None:
+        result = _invoke(cfg, migrations_dir, "--allow-uninitialized", ledger=False)
+
+        assert result.exit_code == 0
+        assert "no migration ledger" in result.output.lower()
+        for marker in RAW_PSYCOPG_MARKERS:
+            assert marker not in result.output
+
+    def test_allow_uninitialized_reports_zero_recorded(
+        self, cfg: Path, migrations_dir: Path
+    ) -> None:
+        result = _invoke(cfg, migrations_dir, "--allow-uninitialized", ledger=False)
+
+        assert "0 migrations recorded" in result.output
+
+
+class TestAbsentIsNotEmpty:
+    """A present-but-empty ledger is a different state and still succeeds.
+
+    If this fails, the probe is in the wrong place — it is conflating "no
+    table" with "no rows", which is the bug this phase exists to fix.
+    """
+
+    def test_present_but_empty_ledger_still_succeeds(self, cfg: Path, migrations_dir: Path) -> None:
+        with patch(
+            "confiture.core.checksum.MigrationChecksumVerifier._get_stored_checksums",
+            return_value={},
+        ):
+            result = _invoke(cfg, migrations_dir, ledger=True)
+
+        assert result.exit_code == 0
+        assert "All migration checksums verified" in result.output
+        assert "no migration ledger" not in result.output.lower()
+
+
+class TestDeprecatedAliasParity:
+    def test_deprecated_verify_alias_inherits_no_ledger_handling(
+        self, cfg: Path, migrations_dir: Path
+    ) -> None:
+        result = _invoke(cfg, migrations_dir, ledger=False, argv0="verify")
+
+        assert result.exit_code == 2
+        assert "is not present in this database" in result.output
+        # The deprecation warning still fires (combined-stream assertion).
+        assert "deprecated" in result.output.lower()
+
+    def test_deprecated_alias_accepts_allow_uninitialized(
+        self, cfg: Path, migrations_dir: Path
+    ) -> None:
+        result = _invoke(cfg, migrations_dir, "--allow-uninitialized", ledger=False, argv0="verify")
+
+        assert result.exit_code == 0
+        assert "no migration ledger" in result.output.lower()

--- a/tests/unit/json_schemas/test_idempotent_scope_schema.py
+++ b/tests/unit/json_schemas/test_idempotent_scope_schema.py
@@ -1,0 +1,148 @@
+"""Schema conformance for `--idempotent` git scoping (#181).
+
+Two shapes must stay valid against
+``migrate-validate-idempotent.schema.json``:
+
+- the scoped report, whose ``meta`` gained a ``scope`` object (safe: ``meta``
+  requires only ``backend`` and does not set ``additionalProperties: false``);
+- the zero-scope report, which must reuse ``oneOf`` branch 2 verbatim — both
+  top-level branches DO set ``additionalProperties: false``, and branch 2
+  forbids the scan counters while requiring ``message``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+SCHEMAS_DIR = Path(__file__).resolve().parents[3] / "docs" / "reference" / "json-schemas"
+
+IDEMPOTENT = "CREATE TABLE IF NOT EXISTS {name} (id int);\n"
+NON_IDEMPOTENT = "CREATE TABLE {name} (id int);\n"
+
+
+def _load(name: str) -> dict:
+    return json.loads((SCHEMAS_DIR / name).read_text())
+
+
+def _validator() -> Draft202012Validator:
+    common = _load("_common.schema.json")
+    registry = Registry().with_resource(
+        uri="_common.schema.json",
+        resource=Resource.from_contents(common, default_specification=DRAFT202012),
+    )
+    return Draft202012Validator(_load("migrate-validate-idempotent.schema.json"), registry=registry)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    (root / "db" / "migrations").mkdir(parents=True)
+    _git(root, "init")
+    _git(root, "config", "user.email", "t@t.com")
+    _git(root, "config", "user.name", "t")
+    _git(root, "config", "commit.gpgsign", "false")
+    (root / "db" / "migrations" / "20260101000000_alpha.up.sql").write_text(
+        IDEMPOTENT.format(name="alpha")
+    )
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "base")
+    return root
+
+
+def _run(repo: Path, *extra: str) -> tuple[int, dict]:
+    prev = Path.cwd()
+    os.chdir(repo)
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--migrations-dir",
+                str(repo / "db" / "migrations"),
+                "--format",
+                "json",
+                *extra,
+            ],
+        )
+    finally:
+        os.chdir(prev)
+    return result.exit_code, json.loads(result.stdout)
+
+
+def test_scoped_report_validates(repo: Path) -> None:
+    base = _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "db" / "migrations" / "20260102000000_beta.up.sql").write_text(
+        NON_IDEMPOTENT.format(name="beta")
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "beta")
+
+    exit_code, payload = _run(repo, "--base-ref", base)
+
+    _validator().validate(payload)
+    assert exit_code == 1
+    assert payload["meta"]["scope"]["mode"] == "base-ref"
+    assert payload["meta"]["scope"]["files_selected"] == 1
+    assert payload["files_scanned"] == 1
+
+
+def test_zero_scope_report_validates(repo: Path) -> None:
+    base = _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "README.md").write_text("docs\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "docs")
+
+    exit_code, payload = _run(repo, "--base-ref", base)
+
+    _validator().validate(payload)
+    assert exit_code == 0
+    assert payload["status"] == "ok"
+    # Branch 2 shape: message present, scan counters absent.
+    assert "message" in payload
+    assert "files_scanned" not in payload
+    assert payload["violations"] == []
+
+
+def test_staged_scope_report_validates(repo: Path) -> None:
+    (repo / "db" / "migrations" / "20260102000000_beta.up.sql").write_text(
+        NON_IDEMPOTENT.format(name="beta")
+    )
+    _git(repo, "add", "-A")
+
+    exit_code, payload = _run(repo, "--staged")
+
+    _validator().validate(payload)
+    assert exit_code == 1
+    assert payload["meta"]["scope"]["mode"] == "staged"
+    assert payload["files_scanned"] == 1
+
+
+def test_unscoped_report_still_validates_and_has_no_scope(repo: Path) -> None:
+    exit_code, payload = _run(repo)
+
+    _validator().validate(payload)
+    assert exit_code == 0
+    assert "scope" not in payload["meta"]

--- a/tests/unit/json_schemas/test_migrate_verify_no_ledger_schema.py
+++ b/tests/unit/json_schemas/test_migrate_verify_no_ledger_schema.py
@@ -1,0 +1,124 @@
+"""Schema conformance for `migrate verify` on a ledger-less database (#182b).
+
+Two payloads must stay contract-valid:
+
+- the degraded `--allow-uninitialized` payload, against
+  `migrate-verify.schema.json` (which sets ``additionalProperties: false``, so
+  `ledger_present` had to be declared, not merely emitted);
+- the error envelope on the default path, carrying `PRECON_1001`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+SCHEMAS_DIR = Path(__file__).resolve().parents[3] / "docs" / "reference" / "json-schemas"
+
+
+def _load(name: str) -> dict:
+    return json.loads((SCHEMAS_DIR / name).read_text())
+
+
+def _envelope_validator() -> Draft202012Validator:
+    issue = _load("issue-object.schema.json")
+    registry = Registry().with_resource(
+        uri="issue-object.schema.json",
+        resource=Resource.from_contents(issue, default_specification=DRAFT202012),
+    )
+    return Draft202012Validator(_load("error-envelope.schema.json"), registry=registry)
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Path:
+    p = tmp_path / "env.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "database_url": "postgresql://localhost/nonexistent_for_test",
+                "include_dirs": ["db/schema"],
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    (d / "20260101000000_init.up.sql").write_text("CREATE TABLE t (id int);")
+    return d
+
+
+def _invoke(cfg: Path, migrations_dir: Path, *extra: str):
+    with (
+        patch("confiture.core.connection.create_connection", return_value=MagicMock()),
+        patch("confiture.core.migrator.Migrator.tracking_table_exists", return_value=False),
+    ):
+        return runner.invoke(
+            app,
+            [
+                "migrate",
+                "verify",
+                "-c",
+                str(cfg),
+                "--migrations-dir",
+                str(migrations_dir),
+                "--format",
+                "json",
+                *extra,
+            ],
+        )
+
+
+def test_verify_schema_is_valid_draft_2020_12() -> None:
+    Draft202012Validator.check_schema(_load("migrate-verify.schema.json"))
+
+
+def test_schema_declares_ledger_present_as_optional() -> None:
+    """`ledger_present` must be declared (additionalProperties is false) but
+    must NOT be required — old consumers reading the field's absence stay valid.
+    """
+    schema = _load("migrate-verify.schema.json")
+
+    assert schema["additionalProperties"] is False
+    assert "ledger_present" in schema["properties"]
+    assert "ledger_present" not in schema["required"]
+
+
+def test_absent_ledger_json_emits_error_envelope(cfg: Path, migrations_dir: Path) -> None:
+    result = _invoke(cfg, migrations_dir)
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    _envelope_validator().validate(payload)
+    assert payload["error"]["code"] == "PRECON_1001"
+
+
+def test_allow_uninitialized_payload_validates(cfg: Path, migrations_dir: Path) -> None:
+    result = _invoke(cfg, migrations_dir, "--allow-uninitialized")
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+
+    schema = _load("migrate-verify.schema.json")
+    Draft202012Validator(schema).validate(payload)
+
+    assert payload["ledger_present"] is False
+    assert payload["failed_count"] == 0
+    assert payload["total_applied"] == 0
+    assert payload["results"] == []

--- a/tests/unit/test_git_repo_root.py
+++ b/tests/unit/test_git_repo_root.py
@@ -1,0 +1,84 @@
+"""`GitRepository.get_repo_root()` — the T2 fix for #181.
+
+`repo_path` is the subprocess cwd, not the repository root (it defaults to
+`Path.cwd()`), while `git diff --name-only` reports paths relative to the
+*root* regardless of cwd. Joining diff output onto `repo_path` therefore
+produces garbage from any subdirectory — an ordinary monorepo layout — and the
+resulting empty intersection reads as a passing gate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from confiture.core.git import GitRepository
+from confiture.exceptions import NotAGitRepositoryError
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "t@t.com")
+    _git(root, "config", "user.name", "t")
+    (root / "backend" / "db").mkdir(parents=True)
+    (root / "backend" / "db" / "x.sql").write_text("SELECT 1;")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "base")
+    return root
+
+
+def test_get_repo_root_from_root(repo: Path) -> None:
+    assert GitRepository(repo).get_repo_root().resolve() == repo.resolve()
+
+
+def test_get_repo_root_from_subdirectory(repo: Path) -> None:
+    """The whole point: from a subdir, the ROOT comes back — not the subdir."""
+    subdir = repo / "backend" / "db"
+
+    root = GitRepository(subdir).get_repo_root()
+
+    assert root.resolve() == repo.resolve()
+    assert root.resolve() != subdir.resolve()
+
+
+def test_repo_path_is_not_the_root_from_a_subdirectory(repo: Path) -> None:
+    """Pins the distinction the docstring used to get wrong."""
+    subdir = repo / "backend" / "db"
+    git_repo = GitRepository(subdir)
+
+    assert git_repo.repo_path.resolve() == subdir.resolve()
+    assert git_repo.get_repo_root().resolve() == repo.resolve()
+
+
+def test_diff_paths_resolve_against_root_not_repo_path(repo: Path) -> None:
+    """The end-to-end invariant that T2 broke."""
+    base = _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "backend" / "db" / "y.sql").write_text("SELECT 2;")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "y")
+
+    from_subdir = GitRepository(repo / "backend" / "db")
+    changed = from_subdir.get_changed_files_two_dot(base, "HEAD")
+
+    assert changed == [Path("backend/db/y.sql")]
+    resolved = [(from_subdir.get_repo_root() / p).resolve() for p in changed]
+    assert resolved == [(repo / "backend" / "db" / "y.sql").resolve()]
+    # The buggy form would have produced <repo>/backend/db/backend/db/y.sql.
+    assert all(p.exists() for p in resolved)
+
+
+def test_get_repo_root_outside_a_repo(tmp_path: Path) -> None:
+    with pytest.raises(NotAGitRepositoryError):
+        GitRepository(tmp_path).get_repo_root()

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -1,0 +1,131 @@
+"""Tests for the shared ledger-existence primitive."""
+
+from unittest.mock import MagicMock, patch
+
+from confiture.core.ledger import ledger_exists
+
+
+def _conn_returning(row: tuple | None) -> tuple[MagicMock, MagicMock]:
+    """Build a connection whose cursor yields ``row`` from fetchone()."""
+    cursor = MagicMock()
+    cursor.fetchone.return_value = row
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn, cursor
+
+
+class TestLedgerExistsBareName:
+    """A bare table name matches the table in any schema."""
+
+    def test_ledger_exists_bare_name_present(self):
+        conn, cursor = _conn_returning((True,))
+
+        assert ledger_exists(conn, "tb_confiture") is True
+
+        sql, params = cursor.execute.call_args[0]
+        assert params == ("tb_confiture",)
+        assert "table_schema" not in sql
+        assert "tb_confiture" not in sql  # bound as a parameter, never interpolated
+
+    def test_ledger_exists_bare_name_absent(self):
+        conn, _ = _conn_returning((False,))
+
+        assert ledger_exists(conn, "tb_confiture") is False
+
+    def test_ledger_exists_no_row_is_false(self):
+        conn, _ = _conn_returning(None)
+
+        assert ledger_exists(conn, "tb_confiture") is False
+
+
+class TestLedgerExistsQualifiedName:
+    """A schema-qualified name filters on the schema too."""
+
+    def test_ledger_exists_qualified_name_filters_schema(self):
+        conn, cursor = _conn_returning((True,))
+
+        assert ledger_exists(conn, "public.tb_confiture") is True
+
+        sql, params = cursor.execute.call_args[0]
+        assert params == ("public", "tb_confiture")
+        assert "table_schema" in sql
+        assert "table_name" in sql
+
+    def test_qualified_name_does_not_match_other_schema(self):
+        """A `public.` qualified probe must not match tb_confiture elsewhere.
+
+        The schema filter is what enforces this; the database returns False
+        because the WHERE clause binds both parts.
+        """
+        conn, cursor = _conn_returning((False,))
+
+        assert ledger_exists(conn, "public.tb_confiture") is False
+        assert cursor.execute.call_args[0][1] == ("public", "tb_confiture")
+
+    def test_multi_dot_name_splits_on_first_dot_only(self):
+        conn, cursor = _conn_returning((True,))
+
+        ledger_exists(conn, "my_schema.weird.name")
+
+        assert cursor.execute.call_args[0][1] == ("my_schema", "weird.name")
+
+
+class TestStateDelegatesToLedgerExists:
+    """The _migrator state helpers must not carry their own copy of the SQL."""
+
+    def _migrator(self, schema: str | None, base: str) -> MagicMock:
+        migrator = MagicMock()
+        migrator._table_schema = schema
+        migrator._table_base = base
+        return migrator
+
+    def test_state_probe_delegates_to_ledger_exists(self):
+        from confiture.core._migrator import state
+
+        migrator = self._migrator("public", "tb_confiture")
+
+        with patch.object(state, "ledger_exists", return_value=True) as probe:
+            assert state.tracking_table_exists(migrator) is True
+
+        probe.assert_called_once_with(migrator.connection, "public.tb_confiture")
+
+    def test_state_probe_delegates_with_bare_name(self):
+        from confiture.core._migrator import state
+
+        migrator = self._migrator(None, "tb_confiture")
+
+        with patch.object(state, "ledger_exists", return_value=False) as probe:
+            assert state.tracking_table_exists(migrator) is False
+
+        probe.assert_called_once_with(migrator.connection, "tb_confiture")
+
+    @staticmethod
+    def _executed_sql(migrator: MagicMock) -> str:
+        return " ".join(str(call.args[0]) for call in migrator._execute_sql.call_args_list)
+
+    def test_initialize_uses_ledger_exists_and_skips_create(self):
+        """Present ledger: no CREATE TABLE, only the #137 additive ALTER."""
+        from confiture.core._migrator import state
+
+        migrator = self._migrator("public", "tb_confiture")
+
+        with patch.object(state, "ledger_exists", return_value=True) as probe:
+            state.initialize(migrator)
+
+        probe.assert_called_once_with(migrator.connection, "public.tb_confiture")
+        executed = self._executed_sql(migrator)
+        assert "CREATE TABLE" not in executed
+        assert "ADD COLUMN IF NOT EXISTS applied_by" in executed
+
+    def test_initialize_creates_table_when_ledger_absent(self):
+        from confiture.core._migrator import state
+
+        migrator = self._migrator("public", "tb_confiture")
+
+        with patch.object(state, "ledger_exists", return_value=False):
+            state.initialize(migrator)
+
+        executed = self._executed_sql(migrator)
+        assert "CREATE TABLE" in executed
+        assert "CREATE INDEX" in executed

--- a/tests/unit/test_session_preflight_no_ledger.py
+++ b/tests/unit/test_session_preflight_no_ledger.py
@@ -1,0 +1,85 @@
+"""`MigratorSession.preflight()` on a ledger-less database (#182b, third site).
+
+Not CLI-reachable, but it is the documented library idiom — and precisely what
+#182's reporter is building.  Unlike its siblings `status()` and
+`current_revision()`, `preflight()` called `verifier.verify_all()` with no
+existence probe, so it raised psycopg's `UndefinedTable`.
+
+`preflight` is an advisory aggregator rather than a gate, so it degrades:
+checksum verification is skipped and the reason reported, no exception.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from confiture.config.environment import Environment
+from confiture.core.migrator import Migrator
+
+
+@pytest.fixture
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    (d / "20260101000000_init.up.sql").write_text("CREATE TABLE t (id int);")
+    (d / "20260101000000_init.down.sql").write_text("DROP TABLE t;")
+    return d
+
+
+def _session(migrations_dir: Path, *, ledger: bool):
+    """A session with a connected mock DB whose ledger presence is forced."""
+    session = Migrator.from_config(
+        Environment.model_validate({"database_url": "postgresql://localhost/x"}),
+        migrations_dir=migrations_dir,
+    )
+    session._conn = MagicMock()
+    session._migrator = MagicMock()
+    session._migrator.migration_table = "tb_confiture"
+    session._migrator.tracking_table_exists.return_value = ledger
+    return session
+
+
+class TestPreflightAbsentLedger:
+    def test_preflight_does_not_raise_without_ledger(self, migrations_dir: Path) -> None:
+        session = _session(migrations_dir, ledger=False)
+
+        result = session.preflight(versions=["20260101000000"])
+
+        assert result.checksum_verified is False
+        assert result.checksum_mismatches == []
+
+    def test_preflight_reports_why_checksums_were_skipped(self, migrations_dir: Path) -> None:
+        session = _session(migrations_dir, ledger=False)
+
+        result = session.preflight(versions=["20260101000000"])
+
+        assert result.checksum_skipped_reason is not None
+        assert "ledger" in result.checksum_skipped_reason.lower()
+
+    def test_preflight_never_builds_a_verifier_without_ledger(self, migrations_dir: Path) -> None:
+        session = _session(migrations_dir, ledger=False)
+
+        with patch("confiture.core.checksum.MigrationChecksumVerifier.verify_all") as verify_all:
+            session.preflight(versions=["20260101000000"])
+
+        verify_all.assert_not_called()
+
+
+class TestPreflightPresentLedger:
+    """Absent != empty: a present ledger still verifies, even with no rows."""
+
+    def test_preflight_verifies_when_ledger_present(self, migrations_dir: Path) -> None:
+        session = _session(migrations_dir, ledger=True)
+
+        with patch(
+            "confiture.core.checksum.MigrationChecksumVerifier.verify_all",
+            return_value=[],
+        ) as verify_all:
+            result = session.preflight(versions=["20260101000000"])
+
+        verify_all.assert_called_once()
+        assert result.checksum_verified is True
+        assert result.checksum_skipped_reason is None


### PR DESCRIPTION
Two contract bugs at the CLI boundary, both found by wiring confiture into a CI ship gate where the gate broke on states confiture should treat as normal.

Closes #182
Closes #181

## ⚠️ BREAKING

`migrate verify` now exits **2** (`PRECON_1001`) instead of crashing to exit 1 on a database with no migration ledger, and its JSON payload gained `ledger_present`. Both are adapter-contract surfaces; `docs/reference/fraisier-adapter-contract.md` was amended **in the same commit as the code** — without it, exit 2 from `verify` fell into the `InvalidConfig` row and fraisier would have reported "configuration problem", a confidently wrong diagnosis worse than the raw error it replaces.

`migrate-verify.schema.json` sets `additionalProperties: false`, so `ledger_present` is not additive for consumers pinned to the prior schema. It is declared but **not** required.

## #182 — three crash sites, not one

The reporter hit `verify-checksums`. `migrate verify` is an independent site (unguarded `get_applied_versions()`), and `MigratorSession.preflight()` is a third — library-only, but the documented idiom and precisely what the reporter was building. All three now report the state and exit 2, or exit 0 under the new `--allow-uninitialized`.

**Absent ≠ empty** is preserved throughout: a present-but-empty ledger still succeeds, reporting `ledger_present: true` with `total_applied: 0`.

Exit 2 rather than 0 is deliberate — `verify-checksums` already uses exit 1 for "checksum mismatches found", so before this change "no ledger" and "checksums are wrong" were the *same integer*. Exit 2 is the only choice that adds information.

## #181 — `--base-ref` / `--since` / `--staged` scoping for `--idempotent`

Four failure modes, each with a designed fix and a test that would catch it:

| | Failure | Fix |
|---|---|---|
| T1 | `--base-ref` already defaults to truthy `"origin/main"` — threading it would scope **every** run and make a plain `--idempotent` exit 7 on any non-git tree | gate on `ctx.get_parameter_source` via new `param_is_explicit`, extracted from `config_is_explicit` (whose #152 behaviour is unchanged) |
| T2 | `GitRepository.repo_path` is the subprocess cwd, not the repo root, while `git diff --name-only` reports root-relative paths — from a subdirectory the intersection came back empty | real `get_repo_root()`; `cli/generate.py`'s private copy now delegates |
| T3 | three-dot diff dies in shallow CI clones with `no merge base` (rc 128), matching neither classification branch | merge-base + two-dot; also reaches `--require-migration --base-ref`, which carried the latent bug |
| T4 | `base..HEAD` compares committed trees, so a pre-commit gate scoped to zero and passed | `--staged` wired for `--idempotent`, analyzing the **index blob**, not the working tree |

Each of these ships a **silently green gate that scanned zero files** — the same class of bug this epic exists to fix. Every scoping test therefore asserts a *positive* expected selection (count + basenames present + untouched absent); no test asserts only "zero" or only "exit 0".

Unscoped behaviour is byte-identical to 0.36.0, pinned by a test asserting `meta` has **no** `scope` key.

## Also fixed (pre-existing, found while testing)

- **`migrate verify -c <config>` crashed on 0.36.0** with `AttributeError: 'str' object has no attribute 'exists'` — the command's own documented primary invocation. It passed `str(config)` to `load_config`, which calls `config_file.exists()`; the sole outlier among 19 call sites. Unnoticed because existing tests reach the command via `--database-url`. Phase 3 was unverifiable without fixing it.
- **`confiture migrate verify-checksums` names no existing command** — 11 sites across the GitHub Actions, GitLab, Argo and Jenkins templates plus the runbook and DR docs. Plus a non-existent `--env` flag, a non-existent `--full` flag, and `pip install confiture` (the package is `fraiseql-confiture`).
- `docs/reference/cli.md` had **no** `migrate verify` or `verify-checksums` section at all; both added.

## Verification

- **9002 pass**, 79 skipped
- `ruff check` + `ruff format --check` + `ty check` clean; `tests/contract/` green
- **21/21 acceptance checks** run against the real binary in the reporters' actual environments — full history, subdirectory cwd, `fetch-depth: 1` (→ `GIT_003` naming the remedy), fetched-but-shallow (succeeds via two-dot), staged-uncommitted, unscoped-unchanged; both #182 sites in text and JSON, both flag states
- Wheel builds at 0.37.0; no `.phases`, no tests
- Exit ratchet (`tests/unit/test_no_raw_exit_convention.py`) unchanged — every new failure path raises a `ConfiturError`, never a literal `typer.Exit`

## Known scope limit

Scoping covers `--idempotent` only. `--check-acls`, `--check-ownership-coverage`, `--check-function-uniqueness`, `--check-security-definer` and `--check-imports` are still unscoped, and three block on any violation. Called out in the CHANGELOG and to be raised with the reporter rather than discovered by filing four more issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)