### PR TITLE
feat(errors): machine-readable exit-code semantic-class contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Machine-readable exit-code contract for wrapper authors.** Each exit integer
+  `0..8` now carries a stable *semantic class* (`ok`, `internal_error`,
+  `precondition_failed`, `db_unreachable`, `schema_error`, `invalid_config`,
+  `lock_contention`, `git_error`, `irreversible_rollback`), exposed as
+  `EXIT_CODE_SEMANTIC_CLASS` in `confiture.core.error_codes` and emitted as JSON by
+  a new hidden `confiture --exit-codes-json` flag (alongside the human
+  `--exit-codes`). This is the single source of truth the FraiseQL `fraisier`
+  migration adapters (Rust `fraisier-core` and Python `fraisier`) project onto
+  their own error taxonomies, replacing two independently hand-maintained copies
+  that had drifted. The Rust adapter vendors the JSON and diffs it against the live
+  command; the Python adapter reads it when the installed confiture is new enough.
+  The class names are a frozen contract (a rename is a breaking change), covered by
+  `tests/unit/test_exit_code_convention.py` and pinned from the consumer's side in
+  `tests/contract/test_fraisier_adapter_surface.py`. See
+  `docs/reference/exit-codes.md` and `docs/reference/fraisier-adapter-contract.md`.
+
 ## [0.37.0] - 2026-07-20
 
 Ship-gate ergonomics: two contract bugs found by wiring confiture into a CI

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -178,6 +178,49 @@ Going forward, the exit-code convention is **frozen**:
 The one sanctioned break before this contract took effect was the #146
 renumbering documented in the reconciliation appendix above.
 
+## Semantic classes (machine-readable)
+
+Each exit integer also carries a stable **semantic class** — a short token wrapper
+authors branch on instead of the bare number. The classes are a frozen contract
+alongside the meanings above (renaming one is a breaking change): exactly one class
+per exit code, from this fixed set.
+
+| Exit | Class |
+|------|-------|
+| 0 | `ok` |
+| 1 | `internal_error` |
+| 2 | `precondition_failed` |
+| 3 | `db_unreachable` |
+| 4 | `schema_error` |
+| 5 | `invalid_config` |
+| 6 | `lock_contention` |
+| 7 | `git_error` |
+| 8 | `irreversible_rollback` |
+
+The authoritative source is `EXIT_CODE_SEMANTIC_CLASS` in
+[`error_codes.py`](../../python/confiture/core/error_codes.py). Emit the whole
+contract as JSON with **`confiture --exit-codes-json`**:
+
+```json
+{
+  "no_ledger_error_code": "PRECON_1001",
+  "classes": ["ok", "internal_error", "precondition_failed", "…"],
+  "exit_codes": {
+    "2": {
+      "class": "precondition_failed",
+      "meaning": "Tracking table absent …",
+      "symbolic_codes": ["PRECON_1001"]
+    }
+  }
+}
+```
+
+This is the seam the FraiseQL `fraisier` migration adapters consume to keep their
+own exit-code classifiers in lockstep with this contract (the Rust adapter vendors
+the JSON and diffs it against the live command; the Python adapter reads it when
+the installed confiture is new enough). See the [fraisier adapter
+contract](fraisier-adapter-contract.md).
+
 ## See also
 
 - [Symbolic error-code reference](../error-reference.md)

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -166,6 +166,22 @@ The full universe of codes is `0..8`; the contract test asserts every observed
 exit code falls within it, and that `PRECON_1001`/`CONFIG_010`/`LOCK_1300` keep
 the integer values the adapter hardcodes.
 
+### Machine-readable classification seam
+
+Each exit integer maps to a stable **semantic class** (`ok`, `internal_error`,
+`precondition_failed`, `db_unreachable`, `schema_error`, `invalid_config`,
+`lock_contention`, `git_error`, `irreversible_rollback`) — the taxonomy both
+fraisier adapters project onto their own error types. Confiture is the single
+source of truth: the table lives in `EXIT_CODE_SEMANTIC_CLASS`
+([`error_codes.py`](../../python/confiture/core/error_codes.py)) and is emitted as
+JSON by **`confiture --exit-codes-json`** (see
+[exit-codes.md](exit-codes.md#semantic-classes-machine-readable)). The Rust adapter
+vendors that JSON and diffs it against the live command in its own contract test;
+the Python adapter reads it directly when the installed confiture is new enough.
+The class names are frozen — a rename is a breaking change requiring a major bump —
+and pinned from confiture's side by
+[`test_fraisier_adapter_surface.py`](../../tests/contract/test_fraisier_adapter_surface.py).
+
 ## Compatibility policy
 
 The exit-code convention and the JSON shapes above are a **stability contract**

--- a/python/confiture/cli/main.py
+++ b/python/confiture/cli/main.py
@@ -143,6 +143,21 @@ def exit_codes_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+def exit_codes_json_callback(value: bool) -> None:
+    """Print the machine-readable exit-code contract as JSON and exit.
+
+    The stable seam wrapper authors (the fraisier adapters) parse to keep their
+    exit-code classifiers in lockstep with this contract. Emitted with
+    ``typer.echo`` — raw, never through the Rich console, so the JSON's ``[``/``]``
+    are not mistaken for markup and no soft-wrapping corrupts the payload.
+    """
+    if value:
+        from confiture.core.error_codes import render_exit_codes_json
+
+        typer.echo(render_exit_codes_json())
+        raise typer.Exit()
+
+
 @app.callback()
 def main(
     version: bool = typer.Option(
@@ -159,6 +174,14 @@ def main(
         is_eager=True,
         hidden=True,
         help="Print the canonical exit-code convention and exit",
+    ),
+    exit_codes_json: bool = typer.Option(
+        False,
+        "--exit-codes-json",
+        callback=exit_codes_json_callback,
+        is_eager=True,
+        hidden=True,
+        help="Print the machine-readable exit-code contract (JSON) and exit",
     ),
 ) -> None:
     """Confiture - PostgreSQL migrations, sweetly done 🍓."""

--- a/python/confiture/core/error_codes.py
+++ b/python/confiture/core/error_codes.py
@@ -32,6 +32,7 @@ docs/reference/exit-codes.md and CANONICAL_EXIT_CODES below for the contract):
     (carve-out: LINT_1501 non-blocking advisory → 0)
 """
 
+import json
 from dataclasses import dataclass
 
 from confiture.models.error import ErrorSeverity
@@ -963,6 +964,71 @@ EXIT_CODE_MEANINGS: dict[int, str] = {
     7: "Git / pgGit / grant-accompaniment error",
     8: "Irreversible rollback, or inconsistent state after rollback",
 }
+
+# The canonical *semantic class* per exit integer — the machine-readable taxonomy
+# the fraisier migration adapters (Rust ``fraisier-core`` and Python ``fraisier``)
+# project onto their own error types. It is a stability contract alongside
+# ``EXIT_CODE_MEANINGS``: exactly one class per documented exit code, and the class
+# names are frozen (a rename is a breaking change requiring a major bump and a
+# CHANGELOG note). Consumers keep an identical table verified against
+# ``render_exit_codes_json`` / ``confiture --exit-codes-json`` so a drift fails CI
+# on both sides. See docs/reference/exit-codes.md and fraisier-adapter-contract.md.
+EXIT_CODE_SEMANTIC_CLASS: dict[int, str] = {
+    0: "ok",
+    1: "internal_error",
+    2: "precondition_failed",
+    3: "db_unreachable",
+    4: "schema_error",
+    5: "invalid_config",
+    6: "lock_contention",
+    7: "git_error",
+    8: "irreversible_rollback",
+}
+
+# The symbolic error code (exit 2) for a reachable-but-uninitialised database — no
+# migration ledger. It is the one code a consumer keys on to recognise "no ledger"
+# when only the structured ``--format json`` envelope (not the exit integer) is in
+# hand, and to distinguish it from any unrelated failure.
+NO_LEDGER_ERROR_CODE = "PRECON_1001"
+
+
+def render_exit_codes_json() -> str:
+    """Render the exit-code contract as machine-readable JSON for wrapper authors.
+
+    The fraisier migration adapters consume this (Rust vendors it and diffs it
+    against ``confiture --exit-codes-json``; Python reads it when the installed
+    confiture is new enough) to keep their exit-code classifiers in lockstep with
+    this frozen contract. Generated from the same hand-authored tables the Markdown
+    reference is (``CANONICAL_EXIT_CODES`` + ``EXIT_CODE_MEANINGS`` +
+    ``EXIT_CODE_SEMANTIC_CLASS``), so the two can never drift.
+
+    Returns:
+        A stable (sorted-key, 2-space-indented) JSON document with the shape::
+
+            {
+              "no_ledger_error_code": "PRECON_1001",
+              "classes": [<the 9 semantic class names, in exit order>],
+              "exit_codes": {
+                "<n>": {"class": ..., "meaning": ..., "symbolic_codes": [...]},
+                ...
+              }
+            }
+    """
+    used_codes = sorted(set(CANONICAL_EXIT_CODES.values()))
+    exit_codes = {
+        str(code): {
+            "class": EXIT_CODE_SEMANTIC_CLASS[code],
+            "meaning": EXIT_CODE_MEANINGS.get(code, "(reserved)"),
+            "symbolic_codes": sorted(c for c, ec in CANONICAL_EXIT_CODES.items() if ec == code),
+        }
+        for code in used_codes
+    }
+    payload = {
+        "no_ledger_error_code": NO_LEDGER_ERROR_CODE,
+        "classes": [EXIT_CODE_SEMANTIC_CLASS[code] for code in used_codes],
+        "exit_codes": exit_codes,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
 
 
 def render_exit_codes_doc() -> str:

--- a/tests/contract/test_fraisier_adapter_surface.py
+++ b/tests/contract/test_fraisier_adapter_surface.py
@@ -33,7 +33,29 @@ from referencing.jsonschema import DRAFT202012
 from typer.testing import CliRunner
 
 from confiture.cli.main import app
-from confiture.core.error_codes import CANONICAL_EXIT_CODES, EXIT_CODE_MEANINGS
+from confiture.core.error_codes import (
+    CANONICAL_EXIT_CODES,
+    EXIT_CODE_MEANINGS,
+    EXIT_CODE_SEMANTIC_CLASS,
+)
+
+# The frozen semantic-class vocabulary the fraisier adapters project onto. Pinned
+# here as a cross-repo stability commitment (a rename is a breaking change): the
+# Rust adapter vendors `confiture --exit-codes-json` and diffs it, the Python
+# adapter reads it — a rename here would silently split the two taxonomies.
+EXPECTED_SEMANTIC_CLASSES = frozenset(
+    {
+        "ok",
+        "internal_error",
+        "precondition_failed",
+        "db_unreachable",
+        "schema_error",
+        "invalid_config",
+        "lock_contention",
+        "git_error",
+        "irreversible_rollback",
+    }
+)
 
 runner = CliRunner()
 # Strip ANSI: CI (FORCE_COLOR) renders colored help that splits flag tokens.
@@ -120,6 +142,30 @@ def test_migrations_dir_gating_matches_adapter() -> None:
 def test_documented_exit_code_set_is_frozen() -> None:
     """The documented exit-code universe is exactly 0..8 (exit-codes.md contract)."""
     assert set(EXIT_CODE_MEANINGS) == set(range(9))
+
+
+def test_exit_codes_json_seam_is_the_adapter_contract() -> None:
+    """`confiture --exit-codes-json` is the machine-readable table the adapters read.
+
+    The Rust adapter vendors this exact output and diffs it in its own contract
+    test; the Python adapter reads it when the installed confiture is new enough.
+    Pin the shape, the frozen 9-class vocabulary, and the one-class-per-exit-code
+    (``0..8``) invariant so a drift fails confiture's CI, not a downstream deploy.
+    """
+    result = runner.invoke(app, ["--exit-codes-json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(_ANSI.sub("", result.output))
+
+    assert payload["no_ledger_error_code"] == UNINITIALISED_ERROR_CODE
+    assert set(payload["classes"]) == EXPECTED_SEMANTIC_CLASSES
+    # One class per documented exit integer, and the map agrees with the registry.
+    assert {int(c) for c in payload["exit_codes"]} == set(range(9))
+    for code_str, entry in payload["exit_codes"].items():
+        assert entry["class"] == EXIT_CODE_SEMANTIC_CLASS[int(code_str)]
+        assert entry["class"] in EXPECTED_SEMANTIC_CLASSES
+    # The no-ledger code the adapters key on is exit 2 → precondition_failed.
+    assert payload["exit_codes"]["2"]["class"] == "precondition_failed"
+    assert UNINITIALISED_ERROR_CODE in payload["exit_codes"]["2"]["symbolic_codes"]
 
 
 def test_adapter_pinned_error_codes_keep_their_exit_numbers() -> None:

--- a/tests/unit/test_exit_code_convention.py
+++ b/tests/unit/test_exit_code_convention.py
@@ -8,6 +8,7 @@ is the enforcement mechanism — a drift between them fails here, not in
 production. Deriving one from the other would make this test a tautology.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -15,11 +16,32 @@ import pytest
 from confiture.core.error_codes import (
     CANONICAL_EXIT_CODES,
     ERROR_CODE_REGISTRY,
+    EXIT_CODE_MEANINGS,
+    EXIT_CODE_SEMANTIC_CLASS,
+    NO_LEDGER_ERROR_CODE,
     render_exit_codes_doc,
+    render_exit_codes_json,
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _EXIT_CODES_DOC = _REPO_ROOT / "docs" / "reference" / "exit-codes.md"
+
+# The frozen semantic-class vocabulary — an independent hand-authored source, so a
+# drift from EXIT_CODE_SEMANTIC_CLASS fails here rather than in a consumer's CI.
+# This is the taxonomy the fraisier adapters (Rust + Python) project onto.
+_CANONICAL_CLASSES = frozenset(
+    {
+        "ok",
+        "internal_error",
+        "precondition_failed",
+        "db_unreachable",
+        "schema_error",
+        "invalid_config",
+        "lock_contention",
+        "git_error",
+        "irreversible_rollback",
+    }
+)
 
 
 @pytest.mark.parametrize(
@@ -96,3 +118,46 @@ def test_exit_codes_doc_embeds_current_generated_section() -> None:
     assert embedded == render_exit_codes_doc().strip(), (
         "exit-codes.md generated block is stale; regenerate with `confiture --exit-codes`"
     )
+
+
+# ---------------------------------------------------------------------------
+# Semantic classes — the machine-readable taxonomy the fraisier adapters consume
+# (fraisier-core Rust + fraisier Python). Redundancy against the hand-authored
+# _CANONICAL_CLASSES is the enforcement, exactly as above.
+# ---------------------------------------------------------------------------
+
+
+def test_semantic_class_covers_exactly_the_used_exit_codes() -> None:
+    """Every in-use exit integer has a semantic class, and no stray ones exist."""
+    used = set(CANONICAL_EXIT_CODES.values())
+    assert set(EXIT_CODE_SEMANTIC_CLASS) == used, (
+        f"only classed: {sorted(set(EXIT_CODE_SEMANTIC_CLASS) - used)}; "
+        f"only used: {sorted(used - set(EXIT_CODE_SEMANTIC_CLASS))}"
+    )
+
+
+def test_semantic_classes_are_the_frozen_vocabulary() -> None:
+    """The classes are exactly the 9 frozen names, one per exit code (a bijection)."""
+    assert set(EXIT_CODE_SEMANTIC_CLASS.values()) == _CANONICAL_CLASSES
+    assert len(set(EXIT_CODE_SEMANTIC_CLASS.values())) == len(EXIT_CODE_SEMANTIC_CLASS)
+
+
+def test_no_ledger_error_code_is_precondition_at_exit_two() -> None:
+    """The no-ledger code the adapters key on stays PRECON_1001 → exit 2 → precondition."""
+    assert NO_LEDGER_ERROR_CODE == "PRECON_1001"
+    assert CANONICAL_EXIT_CODES[NO_LEDGER_ERROR_CODE] == 2
+    assert EXIT_CODE_SEMANTIC_CLASS[2] == "precondition_failed"
+
+
+def test_render_exit_codes_json_matches_the_registry() -> None:
+    """The machine-readable emit is generated from the same tables, without drift."""
+    payload = json.loads(render_exit_codes_json())
+    assert payload["no_ledger_error_code"] == NO_LEDGER_ERROR_CODE
+    assert set(payload["classes"]) == _CANONICAL_CLASSES
+    for code_str, entry in payload["exit_codes"].items():
+        code = int(code_str)
+        assert entry["class"] == EXIT_CODE_SEMANTIC_CLASS[code]
+        assert entry["meaning"] == EXIT_CODE_MEANINGS[code]
+        symbols = sorted(c for c, ec in CANONICAL_EXIT_CODES.items() if ec == code)
+        assert entry["symbolic_codes"] == symbols
+    assert {int(c) for c in payload["exit_codes"]} == set(CANONICAL_EXIT_CODES.values())


### PR DESCRIPTION
## What

Confiture becomes the single source of truth for the `(exit_code → semantic class)` taxonomy that the FraiseQL `fraisier` migration adapters branch on. Previously each adapter (Rust `fraisier-core`, Python `fraisier`) hand-encoded confiture's exit-code contract — and the two had drifted.

- **`EXIT_CODE_SEMANTIC_CLASS`** (`error_codes.py`): exit `0..8` → one of 9 frozen class names (`ok`, `internal_error`, `precondition_failed`, `db_unreachable`, `schema_error`, `invalid_config`, `lock_contention`, `git_error`, `irreversible_rollback`), plus `NO_LEDGER_ERROR_CODE` and `render_exit_codes_json()`.
- **`confiture --exit-codes-json`** — hidden CLI flag emitting the whole contract as JSON via raw `typer.echo` (not Rich, which would mangle the JSON `[`/`]` as markup).
- **Tests**: `test_exit_code_convention.py` pins the 9 classes against an independent hand-authored set (redundancy = enforcement); `test_fraisier_adapter_surface.py` pins the `--exit-codes-json` seam the Rust adapter parses.
- **Docs**: semantic-class section in `exit-codes.md` + a note in `fraisier-adapter-contract.md`.

The class names are a frozen contract (a rename is a breaking change).

## Cross-repo

Base of a 3-repo change. Consumers derive from this: **fraisier-core** vendors `confiture --exit-codes-json` and diffs it; **fraisier** reads it live (once its `fraiseql-confiture` floor moves past this release) with a vendored fallback. This PR must ship (and this confiture version publish to PyPI) before fraisier can go fully live.

## Verification

`make lint` ✓ · `ty` ✓ · `ruff format` ✓ · unit + contract tests **8286 passed, 41 skipped**.

Release deferred — change sits in `[Unreleased]`; no version bump/tag in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)