### PR TITLE
fix(validate): honor --env in git checks + survive COPY FROM stdin blocks (#194)

### DIFF
--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -630,13 +630,20 @@ def migrate_validate(
         # ConfigurationError, funneled through the fail() boundary below).
         config = _resolve_config(config, env)
 
+        # The git checks build the expected schema via GitSchemaBuilder(env),
+        # so --env must reach them: on projects whose `local` env includes
+        # seed data, pointing at a DDL-only env is the difference between a
+        # working gate and a silent no-op (#194). --config-only callers keep
+        # the historical "local" default.
+        git_env = env or "local"
+
         # Handle git validation flags
         # Report-only backlog listing (#178) — never fails, exits 0.
         if list_unmigrated_bodies:
             from confiture.cli.git_validation import report_unmigrated_bodies
 
             body_result = report_unmigrated_bodies(
-                env="local",
+                env=git_env,
                 base_ref=since or base_ref,
                 target_ref="HEAD",
                 console=console,
@@ -685,7 +692,7 @@ def migrate_validate(
             if check_drift:
                 try:
                     drift_result = validate_git_drift(
-                        env="local",
+                        env=git_env,
                         base_ref=effective_base_ref,
                         target_ref=target_ref,
                         console=console,
@@ -708,7 +715,7 @@ def migrate_validate(
             if require_migration or require_migration_bodies:
                 try:
                     acc_result = validate_migration_accompaniment(
-                        env="local",
+                        env=git_env,
                         base_ref=effective_base_ref,
                         target_ref=target_ref,
                         console=console,

--- a/python/confiture/core/differ.py
+++ b/python/confiture/core/differ.py
@@ -6,6 +6,7 @@ This module provides functionality to:
 - Generate migrations from schema diffs
 """
 
+import logging
 import re
 from typing import Any
 
@@ -139,6 +140,18 @@ _INDEX_RE = re.compile(
 # before passing individual statements to sqlparse (avoids MAX_GROUPING_TOKENS crash).
 _DDL_PREFIXES = ("CREATE", "ALTER", "DROP", "TRUNCATE", "COMMENT")
 
+logger = logging.getLogger(__name__)
+
+# ``COPY … FROM stdin;`` + inline rows + ``\.`` terminator is psql client
+# protocol, not SQL — pglast rejects the data lines, and one such block
+# anywhere in a concatenated schema used to kill the whole pglast pass (#194).
+# The data lines are free-form text (semicolons, quotes, SQL-looking noise),
+# so the block is stripped wholesale, COPY statement through terminator.
+_COPY_STDIN_RE = re.compile(
+    r"^COPY\s.*?\bFROM\s+stdin\b.*?;.*?^\\\.[ \t]*$\n?",
+    re.IGNORECASE | re.MULTILINE | re.DOTALL,
+)
+
 # pglast reports internal type aliases rather than the SQL keyword the user wrote.
 # Map them back to the canonical names in _COLUMN_TYPE_MAP.
 _PGLAST_TYPE_ALIASES: dict[str, str] = {
@@ -224,6 +237,11 @@ class SchemaDiffer:
         if not sql or not sql.strip():
             return ParsedSchema()
 
+        # Strip inline-COPY data blocks before ANY parser or regex pass sees
+        # the text: pglast rejects them outright (#194), and the free-form data
+        # lines could false-match the regex passes below.
+        sql = _COPY_STDIN_RE.sub("", sql)
+
         result = ParsedSchema()
 
         # Primary path: pglast — uses PostgreSQL's actual C parser, no token limits.
@@ -291,8 +309,15 @@ class SchemaDiffer:
         """
         try:
             tree = pglast.parse_sql(sql)
-        except Exception:
-            # pglast parse error (e.g. non-PostgreSQL syntax) — fall back to sqlparse
+        except Exception as exc:
+            # pglast parse error (e.g. non-PostgreSQL syntax) — fall back to
+            # sqlparse. Never silently: sqlparse has token limits and can miss
+            # DDL, which turned a blocking accompaniment gate into a no-op (#194).
+            logger.warning(
+                "pglast failed to parse schema (%s) — falling back to sqlparse, "
+                "which may miss DDL beyond its token limits",
+                exc,
+            )
             self._parse_create_tables_sqlparse(sql, result)
             return
 

--- a/tests/unit/test_differ_copy_stdin.py
+++ b/tests/unit/test_differ_copy_stdin.py
@@ -1,0 +1,71 @@
+"""#194: ``SchemaDiffer.parse_schema`` must survive ``COPY … FROM stdin`` blocks.
+
+``COPY table FROM stdin;`` followed by inline tab-separated rows and a ``\\.``
+terminator is psql client protocol, not parseable SQL — pglast (PostgreSQL's
+own grammar) rejects the data lines. Before this fix, one seed file using
+inline COPY anywhere in a concatenated schema killed the entire pglast pass;
+the sqlparse fallback then silently missed DDL (token limits), so
+``migrate validate --require-migration`` reported "No DDL changes detected"
+while blind. Observed in the wild: printoptim_backend's ``local`` env build
+(18 MB, one ``COPY prep_seed.tb_generic_item FROM stdin`` block) made the
+ship gate a permanent no-op.
+
+The data lines are free-form text: they can contain semicolons, quotes, and
+SQL-looking fragments, so they must be stripped as a block (COPY statement
+through the ``\\.`` terminator), not statement-split.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from confiture.core.differ import SchemaDiffer
+
+COPY_BLOCK = """\
+COPY prep_seed.tb_generic_item (id, identifier, fk_product_id) FROM stdin;
+bd1ac132-8309-4f9b-961e-bd0be0de9e2d\t<generic|1b.cabinet><leasing|1-month>\t2a7ee336
+deadbeef-0000-4f9b-961e-bd0be0de9e2e\tsemicolons; 'quotes' and CREATE TABLE noise\t2a7ee337
+\\.
+"""
+
+
+def test_parse_schema_survives_copy_stdin_block() -> None:
+    sql = (
+        "CREATE TABLE before_copy (id INT PRIMARY KEY);\n"
+        + COPY_BLOCK
+        + "CREATE TABLE after_copy (id INT PRIMARY KEY, name TEXT);\n"
+    )
+    parsed = SchemaDiffer().parse_schema(sql)
+    names = {t.name for t in parsed.tables}
+    assert names == {"before_copy", "after_copy"}
+
+
+def test_diff_detects_add_table_after_copy_stdin_block() -> None:
+    base = "CREATE TABLE before_copy (id INT PRIMARY KEY);\n" + COPY_BLOCK
+    target = base + "CREATE TABLE added_later (id INT PRIMARY KEY);\n"
+    differ = SchemaDiffer()
+    diff = differ.compare(base, target)
+    assert any(c.type == "ADD_TABLE" and c.table == "added_later" for c in diff.changes)
+
+
+def test_copy_without_inline_data_is_untouched() -> None:
+    # COPY ... FROM '/path/file' is a normal statement pglast accepts; only
+    # FROM stdin blocks carry inline data that needs stripping.
+    sql = (
+        "CREATE TABLE t1 (id INT);\n"
+        "COPY t1 FROM '/tmp/data.csv' WITH (FORMAT csv);\n"
+        "CREATE TABLE t2 (id INT);\n"
+    )
+    parsed = SchemaDiffer().parse_schema(sql)
+    assert {t.name for t in parsed.tables} == {"t1", "t2"}
+
+
+def test_pglast_fallback_warns_instead_of_degrading_silently(
+    caplog,
+) -> None:
+    # Genuinely unparseable SQL still falls back to sqlparse, but must say so:
+    # the silent fallback is what turned a blocking gate into a no-op.
+    sql = "CREATE TABLE ok (id INT);\nTHIS IS NOT SQL AT ALL;\n"
+    with caplog.at_level(logging.WARNING, logger="confiture.core.differ"):
+        SchemaDiffer().parse_schema(sql)
+    assert any("pglast" in rec.message and "sqlparse" in rec.message for rec in caplog.records)

--- a/tests/unit/test_validate_env_plumbing.py
+++ b/tests/unit/test_validate_env_plumbing.py
@@ -1,0 +1,96 @@
+"""#194: ``migrate validate`` git checks must honor ``--env``.
+
+The drift / migration-accompaniment / unmigrated-bodies checks all build the
+expected schema via ``GitSchemaBuilder(env)`` — but the CLI hardcoded
+``env="local"`` at every call site, silently ignoring ``--env``. On projects
+whose *local* environment includes seed data (e.g. ``COPY … FROM stdin``
+blocks that no SQL parser accepts), that made ``--require-migration`` a
+silent no-op: the pglast pass failed on the seed data, the sqlparse fallback
+missed the DDL, and the gate reported "No DDL changes detected" forever.
+Pointing the check at a DDL-only environment (``--env production``) is the
+documented escape hatch — so the flag has to actually reach the checker.
+
+Patch style mirrors ``test_validate_staged_routing.py``: the git-validation
+functions are patched on their source module because ``migrate_validate``
+imports them lazily.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured_git_calls(monkeypatch: pytest.MonkeyPatch) -> dict[str, dict[str, Any]]:
+    calls: dict[str, dict[str, Any]] = {}
+
+    def fake_flags() -> object:
+        return object()
+
+    def fake_drift(**kwargs: Any) -> dict[str, Any]:
+        calls["drift"] = kwargs
+        return {"passed": True}
+
+    def fake_accompaniment(**kwargs: Any) -> dict[str, Any]:
+        calls["accompaniment"] = kwargs
+        return {"is_valid": True}
+
+    def fake_bodies(**kwargs: Any) -> dict[str, Any]:
+        calls["bodies"] = kwargs
+        return {"violations": []}
+
+    monkeypatch.setattr("confiture.cli.git_validation.validate_git_flags_in_repo", fake_flags)
+    monkeypatch.setattr("confiture.cli.git_validation.validate_git_drift", fake_drift)
+    monkeypatch.setattr(
+        "confiture.cli.git_validation.validate_migration_accompaniment", fake_accompaniment
+    )
+    monkeypatch.setattr("confiture.cli.git_validation.report_unmigrated_bodies", fake_bodies)
+    return calls
+
+
+def test_require_migration_passes_env_through(
+    captured_git_calls: dict[str, dict[str, Any]],
+) -> None:
+    result = runner.invoke(
+        app,
+        ["migrate", "validate", "--require-migration", "--env", "production"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured_git_calls["accompaniment"]["env"] == "production"
+
+
+def test_require_migration_defaults_to_local_env(
+    captured_git_calls: dict[str, dict[str, Any]],
+) -> None:
+    result = runner.invoke(app, ["migrate", "validate", "--require-migration"])
+    assert result.exit_code == 0, result.output
+    assert captured_git_calls["accompaniment"]["env"] == "local"
+
+
+def test_check_drift_passes_env_through(
+    captured_git_calls: dict[str, dict[str, Any]],
+) -> None:
+    result = runner.invoke(
+        app,
+        ["migrate", "validate", "--check-drift", "--env", "production"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured_git_calls["drift"]["env"] == "production"
+
+
+def test_list_unmigrated_bodies_passes_env_through(
+    captured_git_calls: dict[str, dict[str, Any]],
+) -> None:
+    result = runner.invoke(
+        app,
+        ["migrate", "validate", "--list-unmigrated-bodies", "--env", "production"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured_git_calls["bodies"]["env"] == "production"


### PR DESCRIPTION
Closes #194.

Two compounding bugs made `migrate validate --require-migration` a silent no-op on projects whose `local` env embeds seed data (observed on printoptim_backend: probe `CREATE TABLE` vs `origin/dev` → "✅ No DDL changes detected", exit 0).

## Changes

- **CLI env plumbing**: `--check-drift` / `--require-migration[-bodies]` / `--list-unmigrated-bodies` now pass the resolved `--env` to the git-validation layer instead of a hardcoded `"local"`. `--config`-only callers keep the historical `local` default.
- **`SchemaDiffer.parse_schema`**: strips `COPY … FROM stdin; … \.` inline-data blocks (psql client protocol, not SQL) before any parser or regex pass. The data lines are free-form text (semicolons, quotes, SQL-looking noise), so the block is removed wholesale.
- **No more silent degradation**: the pglast→sqlparse fallback now logs a warning — sqlparse's token limits were dropping 81 of 637 tables on the observed schema, which is what blinded the gate.

## Verification

- 8 new tests: `tests/unit/test_validate_env_plumbing.py` (4), `tests/unit/test_differ_copy_stdin.py` (4)
- Full unit suite: 8281 passed, 41 skipped
- ruff check + format clean
- End-to-end on printoptim_backend: unmigrated `CREATE TABLE` probe now exits 1 (both default env and `--env production`); probe + accompanying migration exits 0; local schema parses 637/637 tables via pglast (was 556 via the silent sqlparse fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)