### PR TITLE
0.40.0 — validate composes (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned for 0.41.0
+
+- **Retire the `--idempotent` conflict guard.** `migrate validate --idempotent`
+  still refuses `--check-drift` / `--require-migration` /
+  `--require-migration-bodies` / `--require-grant-migration` (exit 5), even
+  though 0.40.0's composition refactor makes the combination work. The guard is
+  held one release deliberately: it is the only loud-failure net over exactly
+  the flags #181 fixed, and removing it in the same release as a 940-line
+  dispatch refactor would turn a loud error back into a silent skip if the
+  refactor has a bug. Ships with phase 05 (#188).
+
+## [0.40.0] - 2026-08-05
+
+`migrate validate` composes: every check you ask for runs (#187). Ships alone —
+it is the riskiest change in the open backlog, and coupling it to anything means
+a rollback takes the other work with it.
+
+### ⚠️ BREAKING
+
+- **`migrate validate` runs every requested check instead of the first one**
+  (#187). The command was a flat chain of `if <flag>: … return` blocks evaluated
+  in source order, so `--check-acls --check-imports` ran **only** the ACL check
+  and exited 0 — a green gate for a check that never ran. In a pre-commit hook
+  or a CI gate that is a silent false pass, the same failure class as 0.39.0's
+  `window_safe: true`. Ten-plus flag pairs were affected; 0.37.0's `--idempotent`
+  guard had closed four of them by rejecting, which was the right stopgap and
+  the wrong destination.
+
+  **What changes for you:** a script that ran two invocations to work around
+  this now gets both checks from one, and **the exit code is the worst outcome
+  across the checks that ran** — a passing check can no longer mask a failing
+  one. Exit-code handling that assumed single-check semantics is the thing to
+  re-read. Single-flag invocations are unchanged, deliberately: the registry
+  preserves the historical execution order so their text and JSON output is
+  byte-for-byte what 0.39.0 produced.
+
+- **`--format json` emits one document per run.** One check still emits its own
+  documented payload verbatim — every existing `migrate-validate-*.schema.json`
+  holds. Two or more are wrapped in the new
+  `migrate-validate-composed.schema.json`, keyed by check name, with each value
+  the payload that check would have emitted alone.
+
+- **`--list-patterns` and `--list-unmigrated-bodies` reject composition**
+  (exit 5, naming both flags). They are report modes that always exit 0, so
+  they have no gate result to compose. Previously they silently swallowed
+  whatever else you asked for.
+
+- **`migrate introspect --format json` no longer emits `tb_confiture_present`**
+  (#186). Added in 0.39.0 as a one-release deprecated alias and removed here on
+  schedule. It hardcoded the default table name, so it reported the wrong thing
+  for any project that configured `tracking_table`. Read `ledger_present`.
+
+### Fixed
+
+- **JSON mode short-circuited the git-accompaniment group.** Text mode
+  aggregated `drift` / `accompaniment` / `grant` and returned once; JSON mode
+  raised on the first failure, so a failing drift check meant accompaniment and
+  grant never ran. Both modes now run all three and report once. This block was
+  the closest thing the codebase had to a model for composition, and it did not
+  compose in the mode machine consumers use.
+- **`--check-live-drift` now honours `--ssh`.** Its help text has always
+  advertised the tunnel, but the check used `create_connection`, which has no
+  tunnel support. It now takes the run's shared connection, which does.
+- **`--check-body` / `--show-diff` dependency guards fire before any check
+  runs.** They sat halfway down the dispatch, so a git flag returned before they
+  were evaluated and an illegal combination passed silently.
+
+### Changed
+
+- **One config parse and at most one database connection per run.** Five
+  `core/validation` handlers each called `load_config` and opened their own
+  connection; over `--ssh` that meant a tunnel subprocess each. A new
+  `ValidationContext` owns both, lazily — a run of purely static checks still
+  never touches the database. The scratch databases used by `--check-body-views`
+  and `--check-body-replay` are necessarily their own connections.
+- **Internal:** the 940-line dispatch is now a registry of check descriptors
+  (`core/validation/registry.py`, `core/validation/context.py`,
+  `cli/commands/validate_checks.py`). `validate_formatter.render_*` return their
+  JSON payload instead of writing it, and `_validate_idempotency` returns
+  `(passed, payload)` instead of exiting from inside a renderer. The Typer
+  signature of `migrate validate` is untouched.
+- The nine `core/validation` handlers take an optional `ctx`. Called without
+  one they behave exactly as before, so the library API is additive.
+
+### Adapter contract
+
+**No minimum-version bump.** The fraisier adapter surface is `migrate current` /
+`up` / `down-to` / `verify` / `preflight` / `--version`; neither
+`migrate validate` nor `migrate introspect` is in it, so nothing the adapter
+reads changed. (Checked rather than assumed — the release checklist's standing
+floor-bump item was wrong for 0.39.0 too.)
+
 ## [0.39.0] - 2026-08-05
 
 Reproducible CI, pglast 8 support, and tracking-table honesty (#191, #192, #190, #186, #189).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.39.0
+**Version**: 0.40.0
 **Last Updated**: 2026-08-05
 **Current Status**: Production-Ready
 
@@ -959,7 +959,7 @@ When stuck, ask:
 ---
 
 **Last Updated**: 2026-08-05
-**Version**: 0.39.0
+**Version**: 0.40.0
 
 ---
 

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -24,9 +24,50 @@ confiture migrate fix --idempotent
 
 # Verify changed grants are carried by an accompanying migration
 confiture migrate validate --require-grant-migration --staged
+
+# Compose: every check you pass runs, and all of them report
+confiture migrate validate --check-acls --check-imports --check-ownership-coverage
 ```
 
 JSON output is available with `--format json` for every variant.
+
+## Checks compose (0.40.0)
+
+Pass as many checks as you like — **all of them run** and the exit code is the
+worst outcome across them.
+
+Until 0.40.0 this was not true. The command was a flat chain of
+`if <flag>: … return` blocks evaluated in source order, so
+`--check-acls --check-imports` ran only the ACL check and exited 0. In a
+pre-commit hook or a CI gate that is a silent false pass: a green result for a
+check that never executed. #187 replaced the chain with a registry of check
+descriptors that the runner executes in full.
+
+What this means in practice:
+
+- **One invocation, one connection.** Checks that need a database share it (and
+  share one SSH tunnel), and the config is parsed once. Splitting a gate across
+  two invocations to work around the old behaviour is no longer necessary — and
+  costs you a second connection.
+- **One JSON document.** A single check emits exactly the payload it always did.
+  Two or more are wrapped in a small envelope keyed by check name — see
+  [migrate-validate-composed.schema.json](../reference/json-schemas/migrate-validate-composed.schema.json).
+- **Order is unchanged.** Checks run in the order the old dispatch listed them,
+  so single-flag output is byte-for-byte what 0.39.0 produced.
+
+Two combinations are rejected loudly instead of composed:
+
+| Combination | Exit | Why |
+|---|---|---|
+| `--list-patterns` or `--list-unmigrated-bodies` with anything else | 5 | Report modes. Both always exit 0, so there is no result to compose into a gate decision. |
+| `--idempotent` with `--check-drift` / `--require-migration` / `--require-migration-bodies` / `--require-grant-migration` | 5 | Retained from 0.37.0 for one more release. **Retires in 0.41.0.** |
+
+That last row is a deliberate inconsistency, not an oversight. The guard is
+currently the only loud-failure net over exactly the flag combinations #181
+fixed. Removing it in the same release as a 940-line dispatch refactor would
+convert a loud error straight back into a silent skip if the refactor has a bug
+— the regression #181 exists to prevent. It comes off in 0.41.0, after a
+release of production exposure.
 
 ## `--idempotent`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1219,7 +1219,34 @@ confiture migrate validate --fix-naming --format json
 
 # Verify changed grants are carried by an accompanying migration (pre-commit)
 confiture migrate validate --require-grant-migration --staged
+
+# Compose checks: both run, one config parse, one DB connection
+confiture migrate validate --check-acls --check-imports
+confiture migrate validate --check-signatures --check-live-drift --env production
 ```
+
+#### Composing checks (0.40.0)
+
+Pass as many checks as you like: **all of them run**. Before 0.40.0 the command
+evaluated a chain of `if <flag>: … return` blocks in source order, so
+`--check-acls --check-imports` ran only the ACL check and exited 0 — a green
+gate for a check that never ran (#187).
+
+- The exit code is the worst outcome across the checks that ran, so a passing
+  check cannot mask a failing one.
+- Checks needing a database share one connection (and one SSH tunnel), and the
+  config is parsed once for the whole run.
+- `--format json` emits **one** document. A single check keeps its own
+  documented payload byte-for-byte; two or more are wrapped in
+  [`migrate-validate-composed.schema.json`](./json-schemas/migrate-validate-composed.schema.json),
+  keyed by check name.
+
+Two combinations are rejected loudly rather than composed:
+
+| Combination | Exit | Why |
+|---|---|---|
+| `--list-patterns` or `--list-unmigrated-bodies` with anything else | 5 | Report modes: they always exit 0, so there is no result to compose. |
+| `--idempotent` with `--check-drift` / `--require-migration` / `--require-migration-bodies` / `--require-grant-migration` | 5 | Retained from 0.37.0 (#181) for one release; **retires in 0.41.0**, once composition has had production exposure. |
 
 #### Recognized Migration File Patterns
 

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -120,6 +120,30 @@ Note that "no ledger" and "ledger present but empty" stay distinct: a database
 with an empty `tb_confiture` is initialized, so it succeeds normally and
 reports `ledger_present: true` with `total_applied: 0`.
 
+### `migrate validate` with several checks — the exit code aggregates (0.40.0)
+
+Since 0.40.0 (#187) `migrate validate` runs **every** check the invocation asks
+for. Its exit code is the worst outcome across the checks that ran:
+
+- **0** — every check passed.
+- **1** — at least one check reported a finding. Every validation check signals
+  1 for findings, so this is the only non-zero *finding* code today. A check
+  introducing a second distinct code must revisit
+  `confiture.core.validation.registry.aggregate_exit_code`, which resolves ties
+  by execution order rather than by an invented severity ladder — 3
+  (`db_unreachable`) and 7 (`git_error`) are siblings, not degrees.
+- **anything else** — a genuine failure (bad config → 5, unreachable database →
+  3, missing git ref → 7). These are *not* aggregated: they propagate
+  immediately through the `fail()` boundary and produce the error envelope
+  alone, exactly as before composition existed. An infrastructure failure is
+  not a finding, and emitting an error envelope beside unrelated check output
+  would give consumers two documents on one stdout.
+
+This is the behaviour change to check wrapper scripts against. A script that
+ran two invocations because composition did not work will now get both checks
+in one — generally what it wanted, but its exit-code handling may have assumed
+single-check semantics.
+
 ## How the convention was decided (issue #146)
 
 Confiture 0.18.0 shipped **three incompatible** exit-code conventions: the CLI's

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -72,9 +72,9 @@ change without a top-level version bump.
 
 ### `confiture migrate introspect --format json`
 
-[migrate-introspect.schema.json](./json-schemas/migrate-introspect.schema.json) — `{ledger_present, tb_confiture_present, detected_version, …}` for recovering which migration level a database is at by matching its live schema against `db/schema_history/`.
+[migrate-introspect.schema.json](./json-schemas/migrate-introspect.schema.json) — `{ledger_present, detected_version, …}` for recovering which migration level a database is at by matching its live schema against `db/schema_history/`.
 
-⚠️ **`tb_confiture_present` is deprecated as of 0.39.0 and removed in 0.40.0.** It hardcodes the default table name, which is wrong for any project that configured `tracking_table` (#186). Both keys are emitted with the same value during the deprecation window; migrate to **`ledger_present`**, the table-name-agnostic spelling `migrate verify` adopted in 0.37.0.
+⚠️ **`tb_confiture_present` was removed in 0.40.0**, after the one-release deprecation window opened in 0.39.0. It hardcoded the default table name, which is wrong for any project that configured `tracking_table` (#186). Use **`ledger_present`**, the table-name-agnostic spelling `migrate verify` adopted in 0.37.0.
 
 ### `confiture verify-checksums --format json`
 
@@ -223,6 +223,54 @@ Static check that every `CREATE FUNCTION` / `CREATE PROCEDURE` across the config
   ]
 }
 ```
+
+### `confiture migrate validate` with two or more checks — the composed envelope
+
+[migrate-validate-composed.schema.json](./json-schemas/migrate-validate-composed.schema.json)
+
+Since 0.40.0 (#187), `migrate validate` runs **every** check the invocation asks
+for instead of whichever appeared first in the source. One invocation therefore
+produces several payloads, and they go out as one document.
+
+**A single check is unaffected**: it still emits its own payload verbatim — every
+schema above holds byte-for-byte. The wrapper appears only for two or more, keyed
+by the check's stable machine name, with each value exactly the payload that check
+would have emitted alone.
+
+```json
+{
+  "version": "1",
+  "status": "failed",
+  "checks": {
+    "acl_coverage": { "check": "acl_coverage", "violations": [], "hints": [] },
+    "ownership_coverage": {
+      "check": "ownership_coverage",
+      "violations": [
+        {
+          "rule_id": "own_001",
+          "severity": "error",
+          "object_name": "public.orders",
+          "message": "…",
+          "file_path": "db/migrations/20260527000000_init.up.sql",
+          "line_number": 1
+        }
+      ]
+    }
+  },
+  "hints": []
+}
+```
+
+`status` is `failed` when any check that ran reported a finding, and the process
+exits 1 — the worst outcome across the checks that ran, so a passing check can no
+longer mask a failing one. Check names: `list_patterns`, `unmigrated_bodies`,
+`git_accompaniment`, `acl_coverage`, `ownership_coverage`, `function_uniqueness`,
+`security_definer`, `imports`, `live_drift`, `function_signature_drift`,
+`view_body_drift`, `replay_body_drift`, `idempotent`, `naming`.
+
+`--list-patterns` and `--list-unmigrated-bodies` are report modes and refuse to
+compose (exit 5, both flags named) — they always exit 0, so they have no result
+to combine.
 
 ### `confiture migrate status --format json`
 

--- a/docs/reference/json-schemas/migrate-introspect.schema.json
+++ b/docs/reference/json-schemas/migrate-introspect.schema.json
@@ -4,16 +4,12 @@
   "title": "confiture migrate introspect --format json",
   "description": "Detects which migration level a database is at by matching its live schema against the stored snapshots in db/schema_history/. Used to recover a baseline for a database whose ledger was lost. Three payload variants share this shape, distinguished by `confidence`: \"exact\" (a snapshot matched), \"none\" (no match; `closest_version`/`closest_similarity` describe the nearest miss), or absent with `error` set (the snapshots directory does not exist). additionalProperties is false, so a new key is a schema edit. A crash emits the error envelope (error-envelope.schema.json) instead.",
   "type": "object",
-  "required": ["ledger_present", "tb_confiture_present", "detected_version"],
+  "required": ["ledger_present", "detected_version"],
   "additionalProperties": false,
   "properties": {
     "ledger_present": {
       "type": "boolean",
-      "description": "Whether the configured migration ledger (tracking_table) exists. Added in 0.39.0 (#186) as the forward-correct, table-name-agnostic spelling — matching the key `migrate verify` adopted in 0.37.0. Prefer this key."
-    },
-    "tb_confiture_present": {
-      "type": "boolean",
-      "description": "DEPRECATED — identical value to `ledger_present`. Hardcodes the default table name and is misleading for any project that configured `tracking_table`. Retained for one release so existing consumers have an upgrade path; REMOVED IN 0.40.0. Migrate to `ledger_present`."
+      "description": "Whether the configured migration ledger (tracking_table) exists. Added in 0.39.0 (#186) as the forward-correct, table-name-agnostic spelling — matching the key `migrate verify` adopted in 0.37.0. It replaced `tb_confiture_present`, which hardcoded the default table name and was removed in 0.40.0 after its one-release deprecation window."
     },
     "detected_version": {
       "type": ["string", "null"],

--- a/docs/reference/json-schemas/migrate-validate-composed.schema.json
+++ b/docs/reference/json-schemas/migrate-validate-composed.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/migrate-validate-composed.schema.json",
+  "title": "confiture migrate validate --format json (two or more checks)",
+  "description": "Wrapper emitted when one `migrate validate` invocation runs more than one check (0.40.0, #187). A single-check invocation keeps emitting that check's own documented payload verbatim and never matches this schema — the wrapper exists precisely so the single-check shapes stay byte-for-byte stable. Each value under `checks` is the payload the same check would have emitted on its own, keyed by the check's stable machine name.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "status", "checks", "hints"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1",
+      "description": "Envelope version. Bumped only if the wrapper's own shape changes; the nested per-check payloads carry their own contracts."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["passed", "failed"],
+      "description": "`failed` when any check that ran reported a finding. The process exit code is 1 in that case, 0 otherwise."
+    },
+    "checks": {
+      "type": "object",
+      "description": "One entry per check that produced output, keyed by stable check name. Keys are exactly the names below; the set present depends on which flags were passed.",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "propertyNames": {
+        "enum": [
+          "list_patterns",
+          "unmigrated_bodies",
+          "git_accompaniment",
+          "acl_coverage",
+          "ownership_coverage",
+          "function_uniqueness",
+          "security_definer",
+          "imports",
+          "live_drift",
+          "function_signature_drift",
+          "view_body_drift",
+          "replay_body_drift",
+          "idempotent",
+          "naming"
+        ]
+      },
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "type": "object",
+          "description": "The check's single-check payload, unchanged. See the per-check schema files for the documented ones (migrate-validate-check-acl-coverage, -check-function-uniqueness, -idempotent, -grant, -list-patterns)."
+        }
+      }
+    },
+    "hints": { "$ref": "_common.schema.json#/$defs/HintsArray" }
+  }
+}

--- a/docs/reference/tracking-table.md
+++ b/docs/reference/tracking-table.md
@@ -65,7 +65,7 @@ A set of messages and one query hardcoded the `tb_confiture` default rather than
 | `migrate rebuild` backup file | `tb_confiture_backup_<ts>.json` | named after the configured table |
 | `MigrationRunner` test fixture | queried the literal, and swallowed *every* error into `[]` | takes `tracking_table=`; only an absent ledger yields `[]`, everything else raises |
 
-**`migrate introspect --format json` key deprecation.** `tb_confiture_present` is deprecated and **removed in 0.40.0**. Both it and the replacement `ledger_present` are emitted with the same value during the window — switch consumers to `ledger_present`, which does not assume a table name (#186).
+**`migrate introspect --format json` key deprecation — completed.** `tb_confiture_present` was deprecated in 0.39.0 and **removed in 0.40.0**. Consumers read `ledger_present`, which does not assume a table name (#186).
 
 The advisory-lock namespace in `core/locking.py` is deliberately *not* affected: it is derived from `SHA256("tb_confiture")` and frozen, because changing it would change the lock key and break coordination with older clients.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.39.0"
+version = "0.40.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -7,6 +7,11 @@ from typing import Any
 
 import typer
 
+from confiture.cli.commands.validate_checks import (
+    ValidateOptions,
+    build_registry,
+    validate_flag_dependencies,
+)
 from confiture.cli.error_json import fail
 from confiture.cli.helpers import (
     DATABASE_URL_OPTION_HELP,
@@ -16,7 +21,6 @@ from confiture.cli.helpers import (
     _fix_ownership,
     _output_json,
     _resolve_config,
-    _validate_idempotency,
     console,
     error_console,
     is_json,
@@ -27,7 +31,14 @@ from confiture.core.connection import create_connection, load_config, open_conne
 from confiture.core.differ import SchemaDiffer
 from confiture.core.migration_generator import MigrationGenerator
 from confiture.core.migrator import Migrator
-from confiture.exceptions import ConfigurationError, ConfiturError, GitError
+from confiture.core.validation.context import ValidationContext
+from confiture.core.validation.registry import (
+    ValidationCheck,
+    aggregate_exit_code,
+    compose_payload,
+    run_checks,
+)
+from confiture.exceptions import ConfigurationError, ConfiturError
 
 
 def migrate_diff(
@@ -153,32 +164,28 @@ def migrate_diff(
         raise typer.Exit(1) from e
 
 
-def _emit_pattern_catalog(format_output: str, output_file: Path | None) -> None:
+def _pattern_catalog_payload(opts: Any) -> dict[str, Any] | None:  # noqa: ANN401
     """Render the idempotency pattern catalog.
 
     Read-only: no DB, no config, no migrations directory.
 
     Args:
-        format_output: ``"text"`` for a Rich table, ``"json"`` for the
-            machine-readable catalog envelope.
-        output_file: Optional path to write JSON output; ignored for text.
+        opts: The parsed ``migrate validate`` options; only ``json_mode`` is read.
+
+    Returns:
+        The JSON catalog envelope, or ``None`` after printing the text table.
     """
     from confiture.core.idempotency.patterns import list_patterns
 
     entries = list_patterns()
 
-    if format_output == "json":
+    if opts.json_mode:
         # `hints` is pre-allocated per the documented JSON-schema contract
         # (docs/reference/json-schemas/migrate-validate-list-patterns.schema.json).
         # `--list-patterns` is a read-only catalog query with no ambiguous
         # success state, so the list is always empty; the key still
         # appears so consumers can code against a stable shape.
-        _output_json(
-            {"version": "1", "patterns": entries, "hints": []},
-            output_file,
-            console,
-        )
-        return
+        return {"version": "1", "patterns": entries, "hints": []}
 
     # Text mode: compact table for human eyes.
     from rich.table import Table
@@ -198,6 +205,7 @@ def _emit_pattern_catalog(format_output: str, output_file: Path | None) -> None:
             entry["description"],
         )
     console.print(table)
+    return None
 
 
 def migrate_validate(
@@ -589,21 +597,14 @@ def migrate_validate(
                 f"Invalid format: {format_output}. Use 'text', 'json', or 'csv'."
             )
 
-        # --list-patterns is a read-only catalog query. Short-circuit before
-        # touching config / migrations directory / DB. Must run before
-        # _resolve_config so projects without a confiture.yaml can still
-        # introspect the pattern catalog.
-        if list_patterns:
-            if idempotent:
-                raise ConfigurationError("--list-patterns is mutually exclusive with --idempotent")
-            _emit_pattern_catalog(format_output, output_file)
-            return
-
-        # Every branch below ends in a bare `return` and they are evaluated in
-        # source order, so a git-accompaniment flag combined with --idempotent
-        # would run only the former and silently skip idempotency. #181 fixed
-        # the --staged case by dispatch; fail loud on the rest rather than
-        # leave another silently-lying combination behind.
+        # #187/D2: the 0.37.0 conflict guard is RETAINED for 0.40.0 and retires
+        # in 0.41.0, one release after the composition refactor. Composition
+        # makes the combination safe in principle, but this guard is the only
+        # loud-failure net over exactly the flags #181 fixed; dropping it in the
+        # same release as the refactor would convert a loud error straight back
+        # into a silent skip if the refactor has a bug. Recorded here and in the
+        # 0.41.0 CHANGELOG so the temporary inconsistency does not become
+        # permanent by inattention.
         if idempotent:
             _conflicting = [
                 name
@@ -626,510 +627,85 @@ def migrate_validate(
                     ),
                 )
 
-        # Resolve --env / --config to a single config path (raises
-        # ConfigurationError, funneled through the fail() boundary below).
-        config = _resolve_config(config, env)
+        # --list-patterns is a read-only catalog query with no config or
+        # migrations directory behind it, so its options are assembled without
+        # resolving either — projects with no confiture.yaml can still
+        # introspect the pattern catalog.
+        if not list_patterns:
+            config = _resolve_config(config, env)
 
         # The git checks build the expected schema via GitSchemaBuilder(env),
         # so --env must reach them: on projects whose `local` env includes
         # seed data, pointing at a DDL-only env is the difference between a
         # working gate and a silent no-op (#194). --config-only callers keep
         # the historical "local" default.
-        git_env = env or "local"
-
-        # Handle git validation flags
-        # Report-only backlog listing (#178) — never fails, exits 0.
-        if list_unmigrated_bodies:
-            from confiture.cli.git_validation import report_unmigrated_bodies
-
-            body_result = report_unmigrated_bodies(
-                env=git_env,
-                base_ref=since or base_ref,
-                target_ref="HEAD",
-                console=console,
-                format_output=format_output,
-            )
-            if json_mode:
-                _output_json({"check": "unmigrated_bodies", **body_result}, output_file, console)
-            return
-
-        if (
-            check_drift
-            or require_migration
-            or require_migration_bodies
-            or require_grant_migration
-            # #181/D4: --staged used to enter this block and return, so
-            # `--idempotent --staged` silently never ran idempotency. When
-            # --idempotent is set and no git-accompaniment check was asked
-            # for, fall through to the idempotency branch, which now scopes
-            # to the staging index itself.
-            or (staged and not idempotent)
-        ):
-            from confiture.cli.git_validation import (
-                validate_git_drift,
-                validate_git_flags_in_repo,
-                validate_grant_accompaniment,
-                validate_migration_accompaniment,
-            )
-
-            # Override base_ref with since if provided
-            effective_base_ref = since or base_ref
-
-            # Validate we're in a git repo. NotAGitRepositoryError (GIT_002 →
-            # exit 7) propagates to the fail() boundary below.
-            validate_git_flags_in_repo()
-
-            # ARCH-L1: --staged is only meaningful for the grant-accompaniment
-            # check (staged_only=staged, below). Drift and migration
-            # accompaniment compare committed refs (base_ref → HEAD); diffing the
-            # staged index for them is not implemented, so target_ref is the
-            # constant "HEAD" rather than a dead `"HEAD" if not staged else "HEAD"`
-            # ternary. See tests/.../test_validate_staged_routing.
-            target_ref = "HEAD"
-
-            # Run git drift check
-            drift_passed = True
-            if check_drift:
-                try:
-                    drift_result = validate_git_drift(
-                        env=git_env,
-                        base_ref=effective_base_ref,
-                        target_ref=target_ref,
-                        console=console,
-                        format_output=format_output,
-                    )
-                except Exception as e:
-                    raise GitError(f"Drift check failed: {e}") from e
-                if not drift_result.get("passed"):
-                    drift_passed = False
-                    if json_mode:
-                        _output_json(
-                            {"status": "failed", "check": "drift", **drift_result},
-                            output_file,
-                            console,
-                        )
-                        raise typer.Exit(1)  # success-signal: drift found
-
-            # Run migration accompaniment check (--require-migration-bodies implies it)
-            accompaniment_passed = True
-            if require_migration or require_migration_bodies:
-                try:
-                    acc_result = validate_migration_accompaniment(
-                        env=git_env,
-                        base_ref=effective_base_ref,
-                        target_ref=target_ref,
-                        console=console,
-                        format_output=format_output,
-                        check_bodies=require_migration_bodies,
-                    )
-                except Exception as e:
-                    raise GitError(f"Accompaniment check failed: {e}") from e
-                if not acc_result.get("is_valid"):
-                    accompaniment_passed = False
-                    if json_mode:
-                        _output_json(
-                            {"status": "failed", "check": "accompaniment", **acc_result},
-                            output_file,
-                            console,
-                        )
-                        raise typer.Exit(1)  # success-signal: accompaniment missing
-
-            # Run grant accompaniment check
-            grant_passed = True
-            if require_grant_migration and not allow_grant_only:
-                # Honor a non-default grant directory from the config — a
-                # "broad coverage" gate that ignored it would be a trap.
-                grant_dir = "db/7_grant"
-                if config and Path(config).exists():
-                    try:
-                        cfg_data = load_config(Path(config))
-                        configured = (
-                            cfg_data.get("migration", {}).get("grant_dir")
-                            if isinstance(cfg_data, dict)
-                            else None
-                        )
-                        if configured:
-                            grant_dir = configured
-                    except Exception:  # noqa: BLE001 — fall back to the default
-                        pass
-                try:
-                    grant_result = validate_grant_accompaniment(
-                        base_ref=effective_base_ref,
-                        target_ref="HEAD",
-                        staged_only=staged,
-                        console=console,
-                        format_output=format_output,
-                        grant_dir=grant_dir,
-                        migrations_dir=str(migrations_dir),
-                    )
-                except Exception as e:
-                    raise GitError(f"Grant accompaniment check failed: {e}") from e
-                if not grant_result.get("is_valid"):
-                    grant_passed = False
-                    if json_mode:
-                        _output_json(
-                            {
-                                "status": "failed",
-                                "check": "grant_accompaniment",
-                                **grant_result,
-                            },
-                            output_file,
-                            console,
-                        )
-                        raise typer.Exit(1)  # success-signal: grant migration missing
-
-            # Check if all checks passed (for text output)
-            if drift_passed and accompaniment_passed and grant_passed:
-                if format_output == "json":
-                    result = {
-                        "status": "passed",
-                        "checks": [
-                            c
-                            for c, flag in [
-                                ("drift", check_drift),
-                                ("accompaniment", require_migration or require_migration_bodies),
-                                ("grant_accompaniment", require_grant_migration),
-                            ]
-                            if flag
-                        ],
-                    }
-                    _output_json(result, output_file, console)
-                else:
-                    console.print("[green]✅ All git validation checks passed[/green]")
-                return
-            else:
-                # At least one check failed in text mode
-                raise typer.Exit(1)
-
-        # Guard: --check-body requires --check-signatures
-        if check_body and not check_signatures:
-            raise ConfigurationError("--check-body requires --check-signatures")
-
-        # Guard: --show-diff requires one of the body-drift checks
-        if show_diff and not (check_body or check_body_views or check_body_replay):
-            raise ConfigurationError(
-                "--show-diff requires --check-body, --check-body-views, or --check-body-replay"
-            )
-
-        # Run ACL coverage check on migration files (static, no DB).
-        if check_acls:
-            from confiture.cli.formatters.validate_formatter import render_acl_coverage
-            from confiture.core.validation.acl_coverage import check_acl_coverage
-
-            acl_report = check_acl_coverage(migrations_dir, config)
-            render_acl_coverage(acl_report, json_mode=json_mode, output_file=output_file)
-            if acl_report.has_errors:
-                raise typer.Exit(1)  # success-signal: violations found
-            return
-
-        # Run ownership coverage check on migration files (static, no DB).
-        if check_ownership_coverage:
-            from confiture.cli.formatters.validate_formatter import (
-                render_ownership_coverage,
-            )
-            from confiture.core.validation.ownership_coverage import (
-                check_ownership_coverage,
-            )
-
-            ownership_report = check_ownership_coverage(migrations_dir, config)
-            render_ownership_coverage(
-                ownership_report, json_mode=json_mode, output_file=output_file
-            )
-            if ownership_report.has_errors:
-                raise typer.Exit(1)  # success-signal: ERROR-severity violations found
-            return
-
-        # Run function-uniqueness check on DDL files (static, no DB).
-        if check_function_uniqueness:
-            from confiture.cli.formatters.validate_formatter import (
-                render_function_uniqueness,
-            )
-            from confiture.core.validation.function_uniqueness import (
-                check_function_uniqueness,
-            )
-
-            scan_paths = list(ddl_dir) if ddl_dir else [Path("db/schema")]
-            func_report = check_function_uniqueness(scan_paths, config)
-            render_function_uniqueness(func_report, json_mode=json_mode, output_file=output_file)
-            if func_report.has_violations:
-                raise typer.Exit(1)  # success-signal: duplicate signatures found
-            return
-
-        # Run security-definer lint — static (DDL) or live (pg_proc).
-        if check_security_definer:
-            from confiture.cli.formatters.validate_formatter import (
-                render_security_definer,
-            )
-
-            if secdef_against_db:
-                from confiture.core.validation.security_definer import (
-                    check_security_definer_live,
-                )
-
-                sd_report = check_security_definer_live(
-                    config_path=config,
-                    schemas=check_signature_schemas,
-                    ssh_via=ssh_via,
-                )
-            else:
-                from confiture.core.validation.security_definer import (
-                    check_security_definer,
-                )
-
-                scan_paths = list(ddl_dir) if ddl_dir else [Path("db/schema")]
-                sd_report = check_security_definer(scan_paths, config)
-
-            render_security_definer(sd_report, json_mode=json_mode, output_file=output_file)
-            if emit_remediation is not None and sd_report.has_violations:
-                from confiture.core.validation.security_definer import emit_remediation as _emit
-
-                count = _emit(sd_report, emit_remediation)
-                console.print(
-                    f"[dim]Remediation script ({count} statement(s)) written to "
-                    f"{emit_remediation}[/dim]"
-                )
-            if sd_report.has_errors:
-                raise typer.Exit(1)  # success-signal: ERROR-severity violations found
-            return
-
-        # Run import check on Python migration modules
-        if check_imports:
-            from confiture.cli.formatters.validate_formatter import render_import_check
-            from confiture.core.import_checker import ImportChecker
-
-            import_result = ImportChecker(migrations_dir).check()
-            render_import_check(import_result, json_mode=json_mode, output_file=output_file)
-            if not import_result.success:
-                raise typer.Exit(1)  # success-signal: import failures found
-            return
-
-        # Run live drift check
-        if check_live_drift:
-            from confiture.cli.formatters.validate_formatter import render_live_drift
-            from confiture.core.validation.live_drift import check_live_drift as run_live_drift
-
-            drift_report = run_live_drift(config, schema_file)
-            render_live_drift(drift_report, json_mode=json_mode, output_file=output_file)
-            if drift_report.has_critical_drift:
-                raise typer.Exit(1)  # success-signal: critical drift found
-            return
-
-        # Run live function signature drift check
-        if check_signatures:
-            from confiture.cli.formatters.validate_formatter import render_signature_drift
-            from confiture.core.validation.signature_drift import check_signature_drift
-
-            sig_result = check_signature_drift(
-                config_path=config,
-                schema_file=schema_file,
-                schemas=check_signature_schemas,
-                check_body=check_body,
-                ssh_via=ssh_via,
-            )
-            if not json_mode:
-                if sig_result.auto_built:
-                    console.print("[dim]  (schema auto-built from DDL files)[/dim]")
-                if sig_result.ssh_target:
-                    console.print(
-                        f"[dim]  (connecting via SSH tunnel to {sig_result.ssh_target})[/dim]"
-                    )
-            render_signature_drift(
-                sig_result.drift_report,
-                sig_result.body_report,
-                json_mode=json_mode,
-                output_file=output_file,
-                show_diff=show_diff,
-            )
-            if sig_result.has_any_drift:
-                raise typer.Exit(1)  # success-signal: drift found
-            return
-
-        # Run live view / materialized-view body-drift check
-        if check_body_views:
-            from confiture.cli.formatters.validate_formatter import render_view_drift
-            from confiture.core.validation.view_drift import check_view_drift
-
-            view_result = check_view_drift(
-                config_path=config,
-                schema_file=schema_file,
-                schemas=check_signature_schemas,
-                ssh_via=ssh_via,
-                scratch_url=scratch_url,
-            )
-            if not json_mode:
-                if view_result.auto_built:
-                    console.print("[dim]  (schema auto-built from DDL files)[/dim]")
-                if view_result.ssh_target:
-                    console.print(
-                        f"[dim]  (connecting via SSH tunnel to {view_result.ssh_target})[/dim]"
-                    )
-            render_view_drift(
-                view_result.view_report,
-                json_mode=json_mode,
-                output_file=output_file,
-                show_diff=show_diff,
-            )
-            if view_result.has_drift:
-                raise typer.Exit(1)  # success-signal: view drift found
-            return
-
-        # Run replay-based function-body drift check (clean hot-patch signal)
-        if check_body_replay:
-            from confiture.cli.formatters.validate_formatter import render_replay_drift
-            from confiture.core.validation.replay_drift import check_replay_drift
-
-            replay_result = check_replay_drift(
-                config_path=config,
-                migrations_dir=migrations_dir,
-                schemas=check_signature_schemas,
-                ssh_via=ssh_via,
-                scratch_url=scratch_url,
-            )
-            if not json_mode and replay_result.ssh_target:
-                console.print(
-                    f"[dim]  (connecting via SSH tunnel to {replay_result.ssh_target})[/dim]"
-                )
-            render_replay_drift(
-                replay_result.body_report,
-                json_mode=json_mode,
-                output_file=output_file,
-                show_diff=show_diff,
-            )
-            if replay_result.has_drift:
-                raise typer.Exit(1)  # success-signal: hot-patch drift found
-            return
-
-        if not migrations_dir.exists():
-            raise ConfigurationError(
-                f"Migrations directory not found: {migrations_dir.absolute()}",
-                error_code="CONFIG_004",
-            )
-
-        # Handle idempotency validation
-        if idempotent:
+        opts = ValidateOptions(
+            format_output=format_output,
+            json_mode=json_mode,
+            migrations_dir=migrations_dir,
+            config=config,
+            git_env=env or "local",
+            schema_file=schema_file,
+            scratch_url=scratch_url,
+            schemas=check_signature_schemas,
+            ssh_via=ssh_via,
+            ddl_dir=list(ddl_dir) if ddl_dir else [],
+            list_patterns=list_patterns,
+            list_unmigrated_bodies=list_unmigrated_bodies,
+            check_drift=check_drift,
+            require_migration=require_migration,
+            require_migration_bodies=require_migration_bodies,
+            require_grant_migration=require_grant_migration,
+            check_acls=check_acls,
+            check_ownership_coverage=check_ownership_coverage,
+            check_function_uniqueness=check_function_uniqueness,
+            check_security_definer=check_security_definer,
+            check_imports=check_imports,
+            check_live_drift=check_live_drift,
+            check_signatures=check_signatures,
+            check_body_views=check_body_views,
+            check_body_replay=check_body_replay,
+            idempotent=idempotent,
+            allow_grant_only=allow_grant_only,
+            staged=staged,
+            check_body=check_body,
+            show_diff=show_diff,
+            strict_cor=strict_cor,
+            secdef_against_db=secdef_against_db,
+            emit_remediation=emit_remediation,
+            fix_naming=fix_naming,
+            dry_run=dry_run,
             # #181: --base-ref carries a truthy default ("origin/main"), so the
             # value alone cannot say whether the operator asked for scoping.
             # Gate on the parameter source; without this every unscoped run
             # would silently scope, and a plain --idempotent in a non-git tree
             # would exit 7.
-            scoping_requested = staged or param_is_explicit(ctx, "base_ref", "since")
-            _validate_idempotency(
-                migrations_dir,
-                format_output,
-                output_file,
-                strict_cor=strict_cor,
-                base_ref=(since or base_ref) if scoping_requested and not staged else None,
-                staged=staged,
-            )
-            return
+            idempotent_base_ref=(
+                (since or base_ref)
+                if (param_is_explicit(ctx, "base_ref", "since") and not staged)
+                else None
+            ),
+        )
 
-        # Use Migrator to find orphaned files (needs instance for method)
-        from unittest.mock import Mock
+        validate_flag_dependencies(opts)
+        checks = build_registry(opts)
+        _reject_exclusive_composition(checks)
 
-        from confiture.core.migrator import Migrator, find_duplicate_migration_versions
+        with ValidationContext(
+            config_path=config,
+            ssh_via=ssh_via,
+            effective_base_ref=since or base_ref,
+            staged=staged,
+        ) as run_ctx:
+            outcomes = run_checks(checks, run_ctx)
 
-        mock_conn = Mock()
-        migrator = Migrator(connection=mock_conn)
+        payload = compose_payload(outcomes)
+        if payload is not None:
+            _output_json(payload, output_file, console)
 
-        # Check for duplicate migration versions (hard error)
-        duplicate_versions = find_duplicate_migration_versions(migrations_dir)
-
-        # Find orphaned files
-        orphaned_files = migrator.find_orphaned_sql_files(migrations_dir)
-
-        if duplicate_versions:
-            if format_output == "json":
-                result: dict[str, Any] = {
-                    "status": "issues_found",
-                    "duplicate_versions": {
-                        v: [f.name for f in files] for v, files in duplicate_versions.items()
-                    },
-                }
-                if orphaned_files:
-                    result["orphaned_files"] = [f.name for f in orphaned_files]
-                _output_json(result, output_file, console)
-            else:
-                console.print("[red]❌ Duplicate migration versions detected[/red]")
-                console.print(
-                    "[red]Multiple migration files share the same version number:[/red]\n"
-                )
-                for version, files in sorted(duplicate_versions.items()):
-                    console.print(f"  Version {version}:")
-                    for f in files:
-                        console.print(f"    • {f.name}")
-                console.print("\n[yellow]💡 Rename files to use unique version prefixes.[/yellow]")
-                console.print(
-                    "[yellow]   Use 'confiture migrate generate' to auto-assign the next version.[/yellow]"
-                )
-            raise typer.Exit(1)
-
-        if not orphaned_files:
-            if format_output == "json":
-                result = {
-                    "status": "ok",
-                    "message": "No orphaned migration files found",
-                    "fixed": [],
-                    "errors": [],
-                }
-                _output_json(result, output_file, console)
-            else:
-                console.print("[green]✅ No orphaned migration files found[/green]")
-            return
-
-        # If fix_naming is requested, fix the files
-        if fix_naming:
-            # --dry-run takes precedence
-            is_dry_run = dry_run
-            result = migrator.fix_orphaned_sql_files(migrations_dir, dry_run=is_dry_run)
-
-            if format_output == "json":
-                output_dict: dict[str, Any] = {
-                    "status": "fixed" if not is_dry_run else "preview",
-                    "fixed": result.get("renamed", []),
-                    "errors": result.get("errors", []),
-                }
-                _output_json(output_dict, output_file, console)
-            else:
-                # Text output
-                if is_dry_run:
-                    console.print(
-                        "[cyan]📋 DRY-RUN: Would fix the following orphaned files:[/cyan]"
-                    )
-                else:
-                    console.print("[green]✅ Fixed orphaned migration files:[/green]")
-
-                for old_name, new_name in result.get("renamed", []):
-                    console.print(f"  • {old_name} → {new_name}")
-
-                if result.get("errors"):
-                    console.print("[red]Errors:[/red]")
-                    for filename, error_msg in result.get("errors", []):
-                        console.print(f"  ❌ {filename}: {error_msg}")
-
-        else:
-            # Just report the orphaned files (don't fix)
-            if format_output == "json":
-                output_dict = {
-                    "status": "issues_found",
-                    "orphaned_files": [f.name for f in orphaned_files],
-                }
-                _output_json(output_dict, output_file, console)
-            else:
-                console.print("[yellow]⚠️  WARNING: Orphaned migration files detected[/yellow]")
-                console.print(
-                    "[yellow]These SQL files exist but won't be applied by Confiture:[/yellow]"
-                )
-
-                for orphaned_file in orphaned_files:
-                    suggested_name = f"{orphaned_file.stem}.up.sql"
-                    console.print(f"  • {orphaned_file.name} → rename to: {suggested_name}")
-
-                console.print()
-                console.print("[cyan]To automatically fix these files, run:[/cyan]")
-                console.print("[cyan]  confiture migrate validate --fix-naming[/cyan]")
-                console.print()
-                console.print("[cyan]Or preview the changes first with:[/cyan]")
-                console.print("[cyan]  confiture migrate validate --fix-naming --dry-run[/cyan]")
+        exit_code = aggregate_exit_code(outcomes)
+        if exit_code:
+            raise typer.Exit(exit_code)  # success-signal: a check found something
 
     except typer.Exit:
         raise
@@ -1140,6 +716,32 @@ def migrate_validate(
         # exit 1), preserving the legacy catch-all exit code while emitting the
         # #145 envelope in JSON mode.
         fail(e, json_mode=json_mode, output_file=output_file)
+
+
+def _reject_exclusive_composition(checks: list[ValidationCheck]) -> None:
+    """Reject report modes combined with anything else.
+
+    ``--list-patterns`` and ``--list-unmigrated-bodies`` are *report* modes, not
+    validation modes: they dump a catalog or size a backlog and always exit 0,
+    so there is no exit code for them to compose into. Silently running one and
+    dropping the other is the very defect #187 is about, so this fails loudly
+    and names both flags.
+
+    Raises:
+        ConfigurationError: an exclusive check was requested alongside another.
+    """
+    on = [c for c in checks if c.enabled]
+    if len(on) < 2:
+        return
+    for check in on:
+        if not check.exclusive:
+            continue
+        others = ", ".join(c.flag for c in on if c is not check)
+        raise ConfigurationError(
+            f"{check.flag} cannot be combined with {others}: it is a report mode, "
+            "not a validation check, so there is no result to combine.",
+            resolution_hint=f"Run `{check.flag}` on its own, then run the other checks.",
+        )
 
 
 def migrate_fix(

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -635,8 +635,10 @@ def migrate_validate(
             ]
             if _conflicting:
                 raise ConfigurationError(
-                    f"--idempotent cannot be combined with {', '.join(_conflicting)}: "
-                    "only one check would run.",
+                    f"--idempotent cannot be combined with {', '.join(_conflicting)} "
+                    "in 0.40.0. This combination is held back one release while the "
+                    "check-composition refactor gets production exposure; it is "
+                    "allowed from 0.41.0.",
                     resolution_hint=(
                         "Run the checks as separate invocations, e.g. "
                         "`confiture migrate validate --idempotent` then "

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -230,7 +230,8 @@ def migrate_validate(
         "--list-patterns",
         help=(
             "Print machine-readable catalog of detection patterns "
-            "(read-only, no DB needed). Use with `--format json` for tooling."
+            "(read-only, no DB needed). Use with `--format json` for tooling. "
+            "Report mode: cannot be combined with any other check."
         ),
     ),
     strict_cor: bool = typer.Option(
@@ -273,7 +274,8 @@ def migrate_validate(
         help=(
             "Report-only: list function body changes (between --base-ref and HEAD) not "
             "carried by a migration, WITHOUT failing (exit 0). Use to size and drain the "
-            "backlog before enabling --require-migration-bodies."
+            "backlog before enabling --require-migration-bodies. Report mode: cannot be "
+            "combined with any other check."
         ),
     ),
     base_ref: str = typer.Option(
@@ -535,6 +537,9 @@ def migrate_validate(
       optionally verifies idempotency, checks for schema drift, and ensures DDL
       changes have corresponding migration files.
 
+      Every check you ask for runs (0.40.0). The exit code is the worst outcome
+      across them, so a passing check cannot mask a failing one.
+
     EXAMPLES:
       confiture migrate validate
         ↳ Check for orphaned files not matching naming pattern
@@ -578,11 +583,23 @@ def migrate_validate(
         They're different things — file path vs. DB schema names — and both flags can
         appear in the same invocation.
 
+      Checks compose: pass as many as you like and all of them run, sharing one
+      config parse and one database connection. Two exceptions, both loud:
+        --list-patterns / --list-unmigrated-bodies  report modes; they always exit
+                            0, so there is no result to compose. Combining either
+                            with anything else is rejected (exit 5).
+        --idempotent        still refuses --check-drift / --require-migration /
+                            --require-migration-bodies / --require-grant-migration.
+                            Deliberate for 0.40.0 only; the guard retires in 0.41.0
+                            once the composition refactor has production exposure.
+
     JSON SCHEMA:
       See docs/reference/json-schemas.md for the JSON output schemas:
         - --idempotent: migrate-validate-idempotent.schema.json
         - --list-patterns: migrate-validate-list-patterns.schema.json
         - --check-acls: migrate-validate-check-acl-coverage.schema.json
+        - two or more checks: migrate-validate-composed.schema.json (a wrapper
+          keyed by check name; one check still emits its own payload verbatim)
 
     RELATED:
       confiture migrate generate - Create new migration file
@@ -1654,18 +1671,15 @@ def _preflight_version_from_filename(filename: str) -> str:
 def _introspect_payload(ledger_present: bool, **extra: Any) -> dict[str, Any]:
     """Build ``migrate introspect``'s JSON payload (#186).
 
-    Emits **both** spellings during the deprecation window:
+    ``ledger_present`` is the table-name-agnostic spelling ``migrate verify``
+    adopted in 0.37.0. The 0.39.0 deprecated alias ``tb_confiture_present`` —
+    which hardcoded the default table name and was therefore wrong for any
+    project that configured ``tracking_table`` — was removed in 0.40.0 as
+    announced.
 
-    * ``ledger_present`` — forward-correct and table-name-agnostic, the
-      spelling ``migrate verify`` adopted in 0.37.0;
-    * ``tb_confiture_present`` — **deprecated**, hardcodes the default table
-      name and is wrong for any project that configured ``tracking_table``.
-
-    One builder for all three emit sites, because the point of a deprecation
-    window is that the two keys agree throughout it. ``tb_confiture_present``
-    is removed in 0.40.0.
+    One builder for all three emit sites, so the shape cannot drift between them.
     """
-    return {"ledger_present": ledger_present, "tb_confiture_present": ledger_present, **extra}
+    return {"ledger_present": ledger_present, **extra}
 
 
 def _preflight_tracking_table(config: Path | None) -> str:

--- a/python/confiture/cli/commands/validate_checks.py
+++ b/python/confiture/cli/commands/validate_checks.py
@@ -1,0 +1,615 @@
+"""Check adapters and registry construction for ``migrate validate`` (#187).
+
+:func:`build_registry` turns one parsed invocation into the ordered list of
+:class:`~confiture.core.validation.registry.ValidationCheck` descriptors the
+runner executes. Each adapter here is the seam between a ``core/validation``
+handler (which computes) and a ``formatters/validate_formatter`` renderer
+(which prints or returns a payload); the adapter itself only decides whether
+the check passed.
+
+The registry order reproduces the pre-0.40.0 dispatch order exactly, so a
+single-flag invocation behaves — and prints — as it always did. That is
+deliberate: reordering for elegance would change which error a user sees first
+for no benefit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from confiture.cli.helpers import _validate_idempotency, console
+from confiture.core.validation.registry import CheckOutcome, ValidationCheck
+from confiture.exceptions import ConfigurationError, GitError
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from confiture.core.validation.context import ValidationContext
+
+
+# Flags that are modifiers rather than checks, and the checks they modify. Each
+# entry is (flag, "at least one of these must also be on"). Replaces the ad-hoc
+# `if check_body and not check_signatures` guards that used to sit halfway down
+# the dispatch — halfway down meant a git flag returned before they were ever
+# evaluated, so an illegal combination could pass silently.
+_FLAG_DEPENDENCIES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("--check-body", ("--check-signatures",)),
+    ("--show-diff", ("--check-body", "--check-body-views", "--check-body-replay")),
+)
+
+
+@dataclass(frozen=True)
+class ValidateOptions:
+    """One parsed ``migrate validate`` invocation.
+
+    Carries the Typer options verbatim, plus the two values the command
+    resolves before building the registry: ``git_env`` and
+    ``idempotent_base_ref`` (which encodes #181's "was scoping actually asked
+    for?" decision, since ``--base-ref``'s default is truthy).
+    """
+
+    # Output
+    format_output: str
+    json_mode: bool
+    # Paths and connection
+    migrations_dir: Path
+    config: Path
+    git_env: str
+    schema_file: Path | None
+    scratch_url: str | None
+    schemas: str
+    ssh_via: str | None
+    ddl_dir: list[Path] = field(default_factory=list)
+    # Enabling flags, in dispatch order
+    list_patterns: bool = False
+    list_unmigrated_bodies: bool = False
+    check_drift: bool = False
+    require_migration: bool = False
+    require_migration_bodies: bool = False
+    require_grant_migration: bool = False
+    check_acls: bool = False
+    check_ownership_coverage: bool = False
+    check_function_uniqueness: bool = False
+    check_security_definer: bool = False
+    check_imports: bool = False
+    check_live_drift: bool = False
+    check_signatures: bool = False
+    check_body_views: bool = False
+    check_body_replay: bool = False
+    idempotent: bool = False
+    # Modifiers
+    allow_grant_only: bool = False
+    staged: bool = False
+    check_body: bool = False
+    show_diff: bool = False
+    strict_cor: bool = False
+    secdef_against_db: bool = False
+    emit_remediation: Path | None = None
+    fix_naming: bool = False
+    dry_run: bool = False
+    idempotent_base_ref: str | None = None
+
+    @property
+    def scan_paths(self) -> list[Path]:
+        """DDL directories for the source-scanning checks."""
+        return list(self.ddl_dir) if self.ddl_dir else [Path("db/schema")]
+
+    @property
+    def git_group_enabled(self) -> bool:
+        """Whether the git-accompaniment group runs at all.
+
+        ``--staged`` on its own still enters the group (and passes trivially),
+        which is the pre-0.40.0 behaviour — except when ``--idempotent`` is also
+        set, where #181 routes ``--staged`` to the idempotency scope instead.
+        """
+        return bool(
+            self.check_drift
+            or self.require_migration
+            or self.require_migration_bodies
+            or self.require_grant_migration
+            or (self.staged and not self.idempotent)
+        )
+
+
+def validate_flag_dependencies(opts: ValidateOptions) -> None:
+    """Reject modifier flags whose check was not requested.
+
+    Raises:
+        ConfigurationError: a modifier is on with none of its checks.
+    """
+    on = {
+        "--check-body": opts.check_body,
+        "--check-signatures": opts.check_signatures,
+        "--check-body-views": opts.check_body_views,
+        "--check-body-replay": opts.check_body_replay,
+        "--show-diff": opts.show_diff,
+    }
+    for modifier, required in _FLAG_DEPENDENCIES:
+        if not on[modifier]:
+            continue
+        if any(on[req] for req in required):
+            continue
+        if len(required) == 1:
+            raise ConfigurationError(f"{modifier} requires {required[0]}")
+        raise ConfigurationError(
+            f"{modifier} requires {', '.join(required[:-1])}, or {required[-1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Git-accompaniment group
+# ---------------------------------------------------------------------------
+
+
+def _run_git_group(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    """Run every requested git sub-check and report them together.
+
+    Before 0.40.0 this block aggregated correctly in text mode but raised
+    ``typer.Exit(1)`` on the first failure in JSON mode, so a failing drift
+    check meant accompaniment and grant never ran. Both modes now run all
+    three and report once.
+    """
+    from confiture.cli.git_validation import (
+        validate_git_drift,
+        validate_git_flags_in_repo,
+        validate_grant_accompaniment,
+        validate_migration_accompaniment,
+    )
+
+    # NotAGitRepositoryError (GIT_002 → exit 7) propagates to fail().
+    validate_git_flags_in_repo()
+
+    # ARCH-L1: --staged is only meaningful for the grant-accompaniment check.
+    # Drift and migration accompaniment compare committed refs (base_ref →
+    # HEAD); diffing the staged index for them is not implemented.
+    target_ref = "HEAD"
+
+    requested: list[str] = []
+    results: dict[str, dict[str, Any]] = {}
+    failed: list[str] = []
+
+    if opts.check_drift:
+        requested.append("drift")
+        try:
+            drift_result = validate_git_drift(
+                env=opts.git_env,
+                base_ref=ctx.effective_base_ref,
+                target_ref=target_ref,
+                console=console,
+                format_output=opts.format_output,
+            )
+        except Exception as e:
+            raise GitError(f"Drift check failed: {e}") from e
+        results["drift"] = drift_result
+        if not drift_result.get("passed"):
+            failed.append("drift")
+
+    if opts.require_migration or opts.require_migration_bodies:
+        requested.append("accompaniment")
+        try:
+            acc_result = validate_migration_accompaniment(
+                env=opts.git_env,
+                base_ref=ctx.effective_base_ref,
+                target_ref=target_ref,
+                console=console,
+                format_output=opts.format_output,
+                check_bodies=opts.require_migration_bodies,
+            )
+        except Exception as e:
+            raise GitError(f"Accompaniment check failed: {e}") from e
+        results["accompaniment"] = acc_result
+        if not acc_result.get("is_valid"):
+            failed.append("accompaniment")
+
+    if opts.require_grant_migration:
+        # Historically the envelope lists grant_accompaniment whenever it was
+        # *requested*, including when --allow-grant-only suppresses the run.
+        # Kept verbatim: the list means "asked for", and --allow-grant-only is
+        # documented as suppressing the failure, not the request.
+        requested.append("grant_accompaniment")
+        if not opts.allow_grant_only:
+            try:
+                grant_result = validate_grant_accompaniment(
+                    base_ref=ctx.effective_base_ref,
+                    target_ref=target_ref,
+                    staged_only=opts.staged,
+                    console=console,
+                    format_output=opts.format_output,
+                    grant_dir=_resolve_grant_dir(opts, ctx),
+                    migrations_dir=str(opts.migrations_dir),
+                )
+            except Exception as e:
+                raise GitError(f"Grant accompaniment check failed: {e}") from e
+            results["grant_accompaniment"] = grant_result
+            if not grant_result.get("is_valid"):
+                failed.append("grant_accompaniment")
+
+    passed = not failed
+    if not opts.json_mode:
+        if passed:
+            console.print("[green]✅ All git validation checks passed[/green]")
+        return CheckOutcome("git_accompaniment", passed=passed)
+
+    if passed:
+        payload: dict[str, Any] = {"status": "passed", "checks": requested}
+    elif len(requested) == 1:
+        # Byte-identical to the 0.39.0 single-check failure envelope.
+        payload = {"status": "failed", "check": requested[0], **results[requested[0]]}
+    else:
+        payload = {
+            "status": "failed",
+            "checks": requested,
+            "failed": failed,
+            "results": results,
+        }
+    return CheckOutcome("git_accompaniment", passed=passed, payload=payload)
+
+
+def _resolve_grant_dir(opts: ValidateOptions, ctx: ValidationContext) -> str:
+    """The configured grant sweep directory, or the documented default.
+
+    A "broad coverage" gate that ignored a non-default ``migration.grant_dir``
+    would be a trap, so the config wins when it names one.
+    """
+    if not (opts.config and Path(opts.config).exists()):
+        return "db/7_grant"
+    try:
+        cfg_data = ctx.config_data
+        configured = (
+            cfg_data.get("migration", {}).get("grant_dir") if isinstance(cfg_data, dict) else None
+        )
+    except Exception:  # noqa: BLE001 — fall back to the default
+        return "db/7_grant"
+    return str(configured) if configured else "db/7_grant"
+
+
+# ---------------------------------------------------------------------------
+# Report modes
+# ---------------------------------------------------------------------------
+
+
+def _run_list_patterns(opts: ValidateOptions, _ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.commands.migrate_analysis import _pattern_catalog_payload
+
+    return CheckOutcome("list_patterns", passed=True, payload=_pattern_catalog_payload(opts))
+
+
+def _run_list_unmigrated_bodies(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.git_validation import report_unmigrated_bodies
+
+    body_result = report_unmigrated_bodies(
+        env=opts.git_env,
+        base_ref=ctx.effective_base_ref,
+        target_ref="HEAD",
+        console=console,
+        format_output=opts.format_output,
+    )
+    payload = {"check": "unmigrated_bodies", **body_result} if opts.json_mode else None
+    # Report-only by contract (#178): sizes the backlog, never fails.
+    return CheckOutcome("unmigrated_bodies", passed=True, payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# Static checks
+# ---------------------------------------------------------------------------
+
+
+def _run_acls(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_acl_coverage
+    from confiture.core.validation.acl_coverage import check_acl_coverage
+
+    report = check_acl_coverage(opts.migrations_dir, opts.config, ctx)
+    payload = render_acl_coverage(report, json_mode=opts.json_mode)
+    return CheckOutcome("acl_coverage", passed=not report.has_errors, payload=payload)
+
+
+def _run_ownership_coverage(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_ownership_coverage
+    from confiture.core.validation.ownership_coverage import check_ownership_coverage
+
+    report = check_ownership_coverage(opts.migrations_dir, opts.config, ctx)
+    payload = render_ownership_coverage(report, json_mode=opts.json_mode)
+    return CheckOutcome("ownership_coverage", passed=not report.has_errors, payload=payload)
+
+
+def _run_function_uniqueness(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_function_uniqueness
+    from confiture.core.validation.function_uniqueness import check_function_uniqueness
+
+    report = check_function_uniqueness(opts.scan_paths, opts.config, ctx)
+    payload = render_function_uniqueness(report, json_mode=opts.json_mode)
+    return CheckOutcome("function_uniqueness", passed=not report.has_violations, payload=payload)
+
+
+def _run_security_definer(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_security_definer
+
+    if opts.secdef_against_db:
+        from confiture.core.validation.security_definer import check_security_definer_live
+
+        report = check_security_definer_live(
+            config_path=opts.config,
+            schemas=opts.schemas,
+            ssh_via=opts.ssh_via,
+            ctx=ctx,
+        )
+    else:
+        from confiture.core.validation.security_definer import check_security_definer
+
+        report = check_security_definer(opts.scan_paths, opts.config, ctx)
+
+    payload = render_security_definer(report, json_mode=opts.json_mode)
+    if opts.emit_remediation is not None and report.has_violations:
+        from confiture.core.validation.security_definer import emit_remediation as _emit
+
+        count = _emit(report, opts.emit_remediation)
+        console.print(
+            f"[dim]Remediation script ({count} statement(s)) written to "
+            f"{opts.emit_remediation}[/dim]"
+        )
+    return CheckOutcome("security_definer", passed=not report.has_errors, payload=payload)
+
+
+def _run_imports(opts: ValidateOptions, _ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_import_check
+    from confiture.core.import_checker import ImportChecker
+
+    result = ImportChecker(opts.migrations_dir).check()
+    payload = render_import_check(result, json_mode=opts.json_mode)
+    return CheckOutcome("imports", passed=result.success, payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# Database-backed checks
+# ---------------------------------------------------------------------------
+
+
+def _run_live_drift(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_live_drift
+    from confiture.core.validation.live_drift import check_live_drift
+
+    report = check_live_drift(opts.config, opts.schema_file, ctx)
+    payload = render_live_drift(report, json_mode=opts.json_mode)
+    return CheckOutcome("live_drift", passed=not report.has_critical_drift, payload=payload)
+
+
+def _run_signatures(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_signature_drift
+    from confiture.core.validation.signature_drift import check_signature_drift
+
+    result = check_signature_drift(
+        config_path=opts.config,
+        schema_file=opts.schema_file,
+        schemas=opts.schemas,
+        check_body=opts.check_body,
+        ssh_via=opts.ssh_via,
+        ctx=ctx,
+    )
+    if not opts.json_mode:
+        if result.auto_built:
+            console.print("[dim]  (schema auto-built from DDL files)[/dim]")
+        if result.ssh_target:
+            console.print(f"[dim]  (connecting via SSH tunnel to {result.ssh_target})[/dim]")
+    payload = render_signature_drift(
+        result.drift_report,
+        result.body_report,
+        json_mode=opts.json_mode,
+        show_diff=opts.show_diff,
+    )
+    return CheckOutcome(
+        "function_signature_drift", passed=not result.has_any_drift, payload=payload
+    )
+
+
+def _run_body_views(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_view_drift
+    from confiture.core.validation.view_drift import check_view_drift
+
+    result = check_view_drift(
+        config_path=opts.config,
+        schema_file=opts.schema_file,
+        schemas=opts.schemas,
+        ssh_via=opts.ssh_via,
+        scratch_url=opts.scratch_url,
+        ctx=ctx,
+    )
+    if not opts.json_mode:
+        if result.auto_built:
+            console.print("[dim]  (schema auto-built from DDL files)[/dim]")
+        if result.ssh_target:
+            console.print(f"[dim]  (connecting via SSH tunnel to {result.ssh_target})[/dim]")
+    payload = render_view_drift(
+        result.view_report, json_mode=opts.json_mode, show_diff=opts.show_diff
+    )
+    return CheckOutcome("view_body_drift", passed=not result.has_drift, payload=payload)
+
+
+def _run_body_replay(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcome:
+    from confiture.cli.formatters.validate_formatter import render_replay_drift
+    from confiture.core.validation.replay_drift import check_replay_drift
+
+    result = check_replay_drift(
+        config_path=opts.config,
+        migrations_dir=opts.migrations_dir,
+        schemas=opts.schemas,
+        ssh_via=opts.ssh_via,
+        scratch_url=opts.scratch_url,
+        ctx=ctx,
+    )
+    if not opts.json_mode and result.ssh_target:
+        console.print(f"[dim]  (connecting via SSH tunnel to {result.ssh_target})[/dim]")
+    payload = render_replay_drift(
+        result.body_report, json_mode=opts.json_mode, show_diff=opts.show_diff
+    )
+    return CheckOutcome("replay_body_drift", passed=not result.has_drift, payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# Migrations-directory checks (idempotency + naming)
+# ---------------------------------------------------------------------------
+
+
+def _require_migrations_dir(opts: ValidateOptions) -> None:
+    if not opts.migrations_dir.exists():
+        raise ConfigurationError(
+            f"Migrations directory not found: {opts.migrations_dir.absolute()}",
+            error_code="CONFIG_004",
+        )
+
+
+def _run_idempotent(opts: ValidateOptions, _ctx: ValidationContext) -> CheckOutcome:
+    _require_migrations_dir(opts)
+    passed, payload = _validate_idempotency(
+        opts.migrations_dir,
+        opts.format_output,
+        strict_cor=opts.strict_cor,
+        base_ref=opts.idempotent_base_ref,
+        staged=opts.staged,
+    )
+    return CheckOutcome("idempotent", passed=passed, payload=payload)
+
+
+def _run_naming(opts: ValidateOptions, _ctx: ValidationContext) -> CheckOutcome:
+    """The default mode: orphaned-file detection, optionally fixing names."""
+    from confiture.cli.formatters.validate_formatter import render_naming
+    from confiture.core.migrator import Migrator, find_duplicate_migration_versions
+
+    _require_migrations_dir(opts)
+
+    # Migrator needs a connection object for construction only — every method
+    # used here reads the filesystem.
+    from unittest.mock import Mock
+
+    migrator = Migrator(connection=Mock())
+    duplicate_versions = find_duplicate_migration_versions(opts.migrations_dir)
+    orphaned_files = migrator.find_orphaned_sql_files(opts.migrations_dir)
+
+    fixed: dict[str, Any] | None = None
+    if orphaned_files and opts.fix_naming and not duplicate_versions:
+        fixed = migrator.fix_orphaned_sql_files(opts.migrations_dir, dry_run=opts.dry_run)
+
+    payload = render_naming(
+        duplicate_versions=duplicate_versions,
+        orphaned_files=orphaned_files,
+        fixed=fixed,
+        json_mode=opts.json_mode,
+        dry_run=opts.dry_run,
+    )
+    return CheckOutcome("naming", passed=not duplicate_versions, payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def build_registry(opts: ValidateOptions) -> list[ValidationCheck]:
+    """The ordered descriptor list for one invocation.
+
+    Order is the pre-0.40.0 source order of the ``if <flag>: … return`` chain.
+    The naming check is last and enabled only when nothing else is — it is the
+    command's default mode, not a composable check, and that is exactly how it
+    behaved when every other branch returned before reaching it.
+    """
+    checks: list[ValidationCheck] = [
+        ValidationCheck(
+            flag="--list-patterns",
+            name="list_patterns",
+            enabled=opts.list_patterns,
+            run=lambda ctx: _run_list_patterns(opts, ctx),
+            report_only=True,
+            exclusive=True,
+        ),
+        ValidationCheck(
+            flag="--list-unmigrated-bodies",
+            name="unmigrated_bodies",
+            enabled=opts.list_unmigrated_bodies,
+            run=lambda ctx: _run_list_unmigrated_bodies(opts, ctx),
+            needs_git=True,
+            report_only=True,
+            exclusive=True,
+        ),
+        ValidationCheck(
+            flag="--check-drift/--require-migration/--require-grant-migration",
+            name="git_accompaniment",
+            enabled=opts.git_group_enabled,
+            run=lambda ctx: _run_git_group(opts, ctx),
+            needs_git=True,
+        ),
+        ValidationCheck(
+            flag="--check-acls",
+            name="acl_coverage",
+            enabled=opts.check_acls,
+            run=lambda ctx: _run_acls(opts, ctx),
+        ),
+        ValidationCheck(
+            flag="--check-ownership-coverage",
+            name="ownership_coverage",
+            enabled=opts.check_ownership_coverage,
+            run=lambda ctx: _run_ownership_coverage(opts, ctx),
+        ),
+        ValidationCheck(
+            flag="--check-function-uniqueness",
+            name="function_uniqueness",
+            enabled=opts.check_function_uniqueness,
+            run=lambda ctx: _run_function_uniqueness(opts, ctx),
+        ),
+        ValidationCheck(
+            flag="--check-security-definer",
+            name="security_definer",
+            enabled=opts.check_security_definer,
+            run=lambda ctx: _run_security_definer(opts, ctx),
+            needs_db=opts.secdef_against_db,
+        ),
+        ValidationCheck(
+            flag="--check-imports",
+            name="imports",
+            enabled=opts.check_imports,
+            run=lambda ctx: _run_imports(opts, ctx),
+        ),
+        ValidationCheck(
+            flag="--check-live-drift",
+            name="live_drift",
+            enabled=opts.check_live_drift,
+            run=lambda ctx: _run_live_drift(opts, ctx),
+            needs_db=True,
+        ),
+        ValidationCheck(
+            flag="--check-signatures",
+            name="function_signature_drift",
+            enabled=opts.check_signatures,
+            run=lambda ctx: _run_signatures(opts, ctx),
+            needs_db=True,
+        ),
+        ValidationCheck(
+            flag="--check-body-views",
+            name="view_body_drift",
+            enabled=opts.check_body_views,
+            run=lambda ctx: _run_body_views(opts, ctx),
+            needs_db=True,
+        ),
+        ValidationCheck(
+            flag="--check-body-replay",
+            name="replay_body_drift",
+            enabled=opts.check_body_replay,
+            run=lambda ctx: _run_body_replay(opts, ctx),
+            needs_db=True,
+        ),
+        ValidationCheck(
+            flag="--idempotent",
+            name="idempotent",
+            enabled=opts.idempotent,
+            run=lambda ctx: _run_idempotent(opts, ctx),
+        ),
+    ]
+    checks.append(
+        ValidationCheck(
+            flag="(default)",
+            name="naming",
+            enabled=not any(c.enabled for c in checks),
+            run=lambda ctx: _run_naming(opts, ctx),
+        )
+    )
+    return checks

--- a/python/confiture/cli/formatters/validate_formatter.py
+++ b/python/confiture/cli/formatters/validate_formatter.py
@@ -1,25 +1,27 @@
 """Rendering for ``confiture migrate validate`` modes.
 
 Each ``render_*`` function takes a typed result (produced by a
-``confiture.core.validation`` handler) and writes the human-readable or JSON
-form. Collapsing the per-mode ``if format_output == "json"`` branches here keeps
-the ``migrate_validate`` dispatcher thin and the output shapes in one place.
+``confiture.core.validation`` handler) and either prints the human-readable form
+or **returns** the JSON payload. Collapsing the per-mode ``if format_output ==
+"json"`` branches here keeps the ``migrate_validate`` dispatcher thin and the
+output shapes in one place.
 
-These functions never decide exit codes — the dispatcher raises the
-success-signal ``typer.Exit(1)`` on findings; genuine failures travel as
-``ConfiturError`` to the ``fail()`` boundary.
+Renderers return their payload rather than writing it (0.40.0, #187): checks
+compose now, so a run can produce several payloads and only the runner knows
+whether they go out verbatim or wrapped. Emitting from here would produce two
+JSON documents on one stdout.
+
+These functions never decide exit codes — the runner aggregates outcomes;
+genuine failures travel as ``ConfiturError`` to the ``fail()`` boundary.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from rich.markup import escape
 
-from confiture.cli.helpers import _output_json, console
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from confiture.cli.helpers import console
 
 
 def _violation_dict(
@@ -43,43 +45,36 @@ def _violation_dict(
     return payload
 
 
-def render_acl_coverage(report: Any, *, json_mode: bool, output_file: Path | None) -> None:
+def render_acl_coverage(report: Any, *, json_mode: bool) -> dict[str, Any] | None:
     """Render the ``--check-acls`` LintReport."""
     if json_mode:
-        _output_json(
-            {
-                "check": "acl_coverage",
-                "violations": [
-                    _violation_dict(v) for v in (report.errors + report.warnings + report.info)
-                ],
-                "hints": [],
-            },
-            output_file,
-            console,
-        )
-    elif report.has_errors:
+        return {
+            "check": "acl_coverage",
+            "violations": [
+                _violation_dict(v) for v in (report.errors + report.warnings + report.info)
+            ],
+            "hints": [],
+        }
+    if report.has_errors:
         console.print(f"[red]❌ ACL coverage check failed: {len(report.errors)} violation(s)[/red]")
         for v in report.errors:
             # Escape the rule_id brackets so Rich doesn't read them as markup.
             console.print(f"  [red]✗[/red] \\[{v.rule_id}] {v.object_name}: {v.message}")
     else:
         console.print("[green]✅ All migrations have ACL coverage[/green]")
+    return None
 
 
-def render_ownership_coverage(report: Any, *, json_mode: bool, output_file: Path | None) -> None:
+def render_ownership_coverage(report: Any, *, json_mode: bool) -> dict[str, Any] | None:
     """Render the ``--check-ownership-coverage`` result."""
     from confiture.core.linting.schema_linter import RuleSeverity
 
     if json_mode:
-        _output_json(
-            {
-                "check": "ownership_coverage",
-                "violations": [_violation_dict(v, include_line=True) for v in report.violations],
-            },
-            output_file,
-            console,
-        )
-    elif report.violations:
+        return {
+            "check": "ownership_coverage",
+            "violations": [_violation_dict(v, include_line=True) for v in report.violations],
+        }
+    if report.violations:
         console.print(
             f"[red]❌ Ownership coverage check failed: {len(report.violations)} violation(s)[/red]"
         )
@@ -91,23 +86,20 @@ def render_ownership_coverage(report: Any, *, json_mode: bool, output_file: Path
             )
     else:
         console.print("[green]✅ All migrations have ownership coverage[/green]")
+    return None
 
 
-def render_function_uniqueness(report: Any, *, json_mode: bool, output_file: Path | None) -> None:
+def render_function_uniqueness(report: Any, *, json_mode: bool) -> dict[str, Any] | None:
     """Render the ``--check-function-uniqueness`` result."""
     if json_mode:
-        _output_json(
-            {
-                "check": "function_uniqueness",
-                "violations": [
-                    _violation_dict(v, include_object_type=True, include_line=True)
-                    for v in report.violations
-                ],
-            },
-            output_file,
-            console,
-        )
-    elif report.violations:
+        return {
+            "check": "function_uniqueness",
+            "violations": [
+                _violation_dict(v, include_object_type=True, include_line=True)
+                for v in report.violations
+            ],
+        }
+    if report.violations:
         console.print(
             f"[red]❌ Function uniqueness check failed: {len(report.violations)} violation(s)[/red]"
         )
@@ -115,25 +107,22 @@ def render_function_uniqueness(report: Any, *, json_mode: bool, output_file: Pat
             console.print(f"  [red]✗[/red] \\[{v.rule_id}] {v.object_name}: {v.message}")
     else:
         console.print("[green]✅ All callables have unique signatures[/green]")
+    return None
 
 
-def render_security_definer(report: Any, *, json_mode: bool, output_file: Path | None) -> None:
+def render_security_definer(report: Any, *, json_mode: bool) -> dict[str, Any] | None:
     """Render the ``--check-security-definer`` result."""
     from confiture.core.linting.schema_linter import RuleSeverity
 
     if json_mode:
-        _output_json(
-            {
-                "check": "security_definer",
-                "violations": [
-                    _violation_dict(v, include_object_type=True, include_line=True)
-                    for v in report.violations
-                ],
-            },
-            output_file,
-            console,
-        )
-    elif report.violations:
+        return {
+            "check": "security_definer",
+            "violations": [
+                _violation_dict(v, include_object_type=True, include_line=True)
+                for v in report.violations
+            ],
+        }
+    if report.violations:
         console.print(
             f"[yellow]⚠[/yellow] Security-definer check: {len(report.violations)} violation(s)"
         )
@@ -146,15 +135,16 @@ def render_security_definer(report: Any, *, json_mode: bool, output_file: Path |
             )
     else:
         console.print("[green]✅ No unpinned SECURITY DEFINER functions found[/green]")
+    return None
 
 
-def render_import_check(result: Any, *, json_mode: bool, output_file: Path | None) -> None:
+def render_import_check(result: Any, *, json_mode: bool) -> dict[str, Any] | None:
     """Render the ``--check-imports`` ImportCheckResult."""
     from pathlib import Path as _Path
 
     if json_mode:
-        _output_json({"check": "imports", **result.to_dict()}, output_file, console)
-    elif result.success:
+        return {"check": "imports", **result.to_dict()}
+    if result.success:
         console.print(
             f"[green]✅ All {result.checked} Python migration(s) passed import check[/green]"
         )
@@ -167,16 +157,102 @@ def render_import_check(result: Any, *, json_mode: bool, output_file: Path | Non
         )
         for v in result.violations:
             console.print(f"  [red]✗[/red] [{v.rule}] {_Path(v.file_path).name}: {v.message}")
+    return None
 
 
-def render_live_drift(report: Any, *, json_mode: bool, output_file: Path | None) -> None:
+def render_naming(
+    *,
+    duplicate_versions: dict[str, list[Any]],
+    orphaned_files: list[Any],
+    fixed: dict[str, Any] | None,
+    json_mode: bool,
+    dry_run: bool,
+) -> dict[str, Any] | None:
+    """Render ``migrate validate``'s default mode: duplicate versions + orphans.
+
+    ``fixed`` is the ``fix_orphaned_sql_files`` result when ``--fix-naming`` ran,
+    else ``None``. Duplicate versions are a hard error and pre-empt fixing;
+    orphans alone are a warning that still exits 0.
+    """
+    if duplicate_versions:
+        if json_mode:
+            payload: dict[str, Any] = {
+                "status": "issues_found",
+                "duplicate_versions": {
+                    v: [f.name for f in files] for v, files in duplicate_versions.items()
+                },
+            }
+            if orphaned_files:
+                payload["orphaned_files"] = [f.name for f in orphaned_files]
+            return payload
+        console.print("[red]❌ Duplicate migration versions detected[/red]")
+        console.print("[red]Multiple migration files share the same version number:[/red]\n")
+        for version, files in sorted(duplicate_versions.items()):
+            console.print(f"  Version {version}:")
+            for f in files:
+                console.print(f"    • {f.name}")
+        console.print("\n[yellow]💡 Rename files to use unique version prefixes.[/yellow]")
+        console.print(
+            "[yellow]   Use 'confiture migrate generate' to auto-assign the next version.[/yellow]"
+        )
+        return None
+
+    if not orphaned_files:
+        if json_mode:
+            return {
+                "status": "ok",
+                "message": "No orphaned migration files found",
+                "fixed": [],
+                "errors": [],
+            }
+        console.print("[green]✅ No orphaned migration files found[/green]")
+        return None
+
+    if fixed is not None:
+        if json_mode:
+            return {
+                "status": "preview" if dry_run else "fixed",
+                "fixed": fixed.get("renamed", []),
+                "errors": fixed.get("errors", []),
+            }
+        if dry_run:
+            console.print("[cyan]📋 DRY-RUN: Would fix the following orphaned files:[/cyan]")
+        else:
+            console.print("[green]✅ Fixed orphaned migration files:[/green]")
+        for old_name, new_name in fixed.get("renamed", []):
+            console.print(f"  • {old_name} → {new_name}")
+        if fixed.get("errors"):
+            console.print("[red]Errors:[/red]")
+            for filename, error_msg in fixed.get("errors", []):
+                console.print(f"  ❌ {filename}: {error_msg}")
+        return None
+
+    if json_mode:
+        return {
+            "status": "issues_found",
+            "orphaned_files": [f.name for f in orphaned_files],
+        }
+    console.print("[yellow]⚠️  WARNING: Orphaned migration files detected[/yellow]")
+    console.print("[yellow]These SQL files exist but won't be applied by Confiture:[/yellow]")
+    for orphaned_file in orphaned_files:
+        console.print(f"  • {orphaned_file.name} → rename to: {orphaned_file.stem}.up.sql")
+    console.print()
+    console.print("[cyan]To automatically fix these files, run:[/cyan]")
+    console.print("[cyan]  confiture migrate validate --fix-naming[/cyan]")
+    console.print()
+    console.print("[cyan]Or preview the changes first with:[/cyan]")
+    console.print("[cyan]  confiture migrate validate --fix-naming --dry-run[/cyan]")
+    return None
+
+
+def render_live_drift(report: Any, *, json_mode: bool) -> dict[str, Any] | None:
     """Render the ``--check-live-drift`` DriftReport."""
     from confiture.cli.formatters.common import display_drift_report
 
     if json_mode:
-        _output_json({"check": "live_drift", **report.to_dict()}, output_file, console)
-    else:
-        display_drift_report(report, console)
+        return {"check": "live_drift", **report.to_dict()}
+    display_drift_report(report, console)
+    return None
 
 
 def _print_unified_diff(unified_diff: str) -> None:
@@ -226,9 +302,8 @@ def render_signature_drift(
     body_report: Any,
     *,
     json_mode: bool,
-    output_file: Path | None,
     show_diff: bool = False,
-) -> None:
+) -> dict[str, Any] | None:
     """Render the ``--check-signatures`` (+ ``--check-body``) result.
 
     ``show_diff`` (from ``--show-diff``) surfaces each drifted function's bodies
@@ -244,20 +319,20 @@ def render_signature_drift(
         }
         if body_report is not None:
             payload["body_drift"] = body_report.to_dict(include_bodies=show_diff)
-        _output_json(payload, output_file, console)
-    else:
-        display_signature_drift_report(drift_report, console)
-        if body_report is not None:
-            _display_body_drift_report(body_report, show_diff=show_diff)
+        return payload
+
+    display_signature_drift_report(drift_report, console)
+    if body_report is not None:
+        _display_body_drift_report(body_report, show_diff=show_diff)
+    return None
 
 
 def render_replay_drift(
     body_report: Any,
     *,
     json_mode: bool,
-    output_file: Path | None,
     show_diff: bool = False,
-) -> None:
+) -> dict[str, Any] | None:
     """Render the ``--check-body-replay`` FunctionBodyDriftReport.
 
     Reuses the function-body report shape (Phase 3) but frames drifts as
@@ -265,19 +340,14 @@ def render_replay_drift(
     does not produce. ``show_diff`` surfaces the expected/live bodies + diff.
     """
     if json_mode:
-        _output_json(
-            {"check": "replay_body_drift", **body_report.to_dict(include_bodies=show_diff)},
-            output_file,
-            console,
-        )
-        return
+        return {"check": "replay_body_drift", **body_report.to_dict(include_bodies=show_diff)}
 
     if not body_report.has_drift:
         console.print(
             f"[green]✓[/green] 0 out-of-band hot-patch(es) detected "
             f"({body_report.functions_checked} checked, {body_report.detection_time_ms:.1f}ms)"
         )
-        return
+        return None
 
     console.print(
         f"[yellow]⚠[/yellow]  {len(body_report.body_drifts)} out-of-band hot-patch(es) "
@@ -295,6 +365,7 @@ def render_replay_drift(
             "    Hint: no migration produced this body — capture the live change in a "
             "migration, or re-apply the migration-produced definition"
         )
+    return None
 
 
 _RELKIND_LABEL = {"v": "view", "m": "materialized view"}
@@ -304,28 +375,22 @@ def render_view_drift(
     view_report: Any,
     *,
     json_mode: bool,
-    output_file: Path | None,
     show_diff: bool = False,
-) -> None:
+) -> dict[str, Any] | None:
     """Render the ``--check-body-views`` ViewBodyDriftReport.
 
     ``show_diff`` (from ``--show-diff``) surfaces each drifted view's expected
     and live definitions plus a unified diff; otherwise output stays hash-only.
     """
     if json_mode:
-        _output_json(
-            {"check": "view_body_drift", **view_report.to_dict(include_defs=show_diff)},
-            output_file,
-            console,
-        )
-        return
+        return {"check": "view_body_drift", **view_report.to_dict(include_defs=show_diff)}
 
     if not view_report.has_drift:
         console.print(
             f"[green]✓[/green] 0 view definition drift(s) detected "
             f"({view_report.views_checked} checked, {view_report.detection_time_ms:.1f}ms)"
         )
-        return
+        return None
 
     console.print(
         f"[yellow]⚠[/yellow]  {len(view_report.body_drifts)} view definition "
@@ -343,3 +408,4 @@ def render_view_drift(
             "    Hint: view definition differs from source — re-apply the committed "
             "DDL or capture the live change in a migration"
         )
+    return None

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -788,8 +788,7 @@ def _report_empty_scope(
     migrations_dir: Path,
     meta: dict[str, Any],
     format_output: str,
-    output_file: Path | None,
-) -> None:
+) -> dict[str, Any] | None:
     """Report "nothing in scope changed" — a real success, distinct from "no files".
 
     Deliberately *not* the empty-directory message: the remedies differ. An
@@ -813,36 +812,30 @@ def _report_empty_scope(
     _emit_hint(message, hints_list=hints, format_=format_output)
 
     if format_output == "json":
-        _output_json(
-            {
-                "status": "ok",
-                "message": message,
-                "violations": [],
-                "meta": meta,
-                "hints": hints,
-            },
-            output_file,
-            console,
-        )
-    else:
-        console.print(f"[green]✅ {message}[/green]")
+        return {
+            "status": "ok",
+            "message": message,
+            "violations": [],
+            "meta": meta,
+            "hints": hints,
+        }
+    console.print(f"[green]✅ {message}[/green]")
+    return None
 
 
 def _validate_idempotency(
     migrations_dir: Path,
     format_output: str,
-    output_file: Path | None,
     *,
     strict_cor: bool = False,
     base_ref: str | None = None,
     staged: bool = False,
-) -> None:
+) -> tuple[bool, dict[str, Any] | None]:
     """Validate idempotency of SQL and Python migration files.
 
     Args:
         migrations_dir: Directory containing migration files
         format_output: Output format (text or json)
-        output_file: Optional file to save output to
         strict_cor: If True, info-severity CREATE OR REPLACE findings flip
             the exit code to 1 (default False — info findings render but
             don't fail the gate).
@@ -853,9 +846,12 @@ def _validate_idempotency(
             otherwise scope every run (#181).
         staged: Scope to staged migrations, reading the index blob rather than
             the working tree. Takes precedence over ``base_ref``.
-    """
-    import typer
 
+    Returns:
+        ``(passed, payload)``. Text-mode output is printed here; the JSON
+        payload is returned rather than written, because ``migrate validate``
+        composes checks and emits one document for the whole run (#187).
+    """
     from confiture.core.idempotency import IdempotencyValidator
 
     validator = IdempotencyValidator()
@@ -883,8 +879,7 @@ def _validate_idempotency(
             staged_content = _read_staged_content(selected)
 
         if not sql_files and not py_files:
-            _report_empty_scope(scope_meta, migrations_dir, meta, format_output, output_file)
-            return
+            return True, _report_empty_scope(scope_meta, migrations_dir, meta, format_output)
 
         if format_output == "text":
             where = (
@@ -917,10 +912,9 @@ def _validate_idempotency(
                 "meta": meta,
                 "hints": zero_files_hints,
             }
-            _output_json(result, output_file, console)
-        else:
-            console.print("[green]✅ No migration files found to validate[/green]")
-        return
+            return True, result
+        console.print("[green]✅ No migration files found to validate[/green]")
+        return True, None
 
     combined_report = _collect_idempotency_report(
         sql_files, py_files, validator, staged_content=staged_content
@@ -932,10 +926,7 @@ def _validate_idempotency(
         result["status"] = "issues_found" if fail else "ok"
         result["meta"] = meta
         result["hints"] = []
-        _output_json(result, output_file, console)
-        if fail:
-            raise typer.Exit(1)
-        return
+        return not fail, result
 
     blocking = [v for v in combined_report.violations if v.severity == "error"]
     info = [v for v in combined_report.violations if v.severity == "info"]
@@ -944,7 +935,7 @@ def _validate_idempotency(
         console.print("[green]✅ All migrations are idempotent[/green]")
         console.print(f"   Scanned {combined_report.files_scanned} file(s)")
         _render_extractor_warnings(combined_report)
-        return
+        return True, None
 
     if blocking:
         console.print(f"[red]❌ Found {len(blocking)} idempotency violation(s)[/red]\n")
@@ -971,8 +962,7 @@ def _validate_idempotency(
         )
         console.print("[cyan]For .py migrations, edit them manually.[/cyan]")
 
-    if fail:
-        raise typer.Exit(1)
+    return not fail, None
 
 
 def _render_violations_by_file(violations: list[Any]) -> None:

--- a/python/confiture/core/validation/acl_coverage.py
+++ b/python/confiture/core/validation/acl_coverage.py
@@ -7,13 +7,27 @@ the configured global grant-sweep directory.
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from confiture.exceptions import ConfigurationError
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def check_acl_coverage(migrations_dir: Path, config_path: Path):  # noqa: ANN201
+    from confiture.core.validation.context import ValidationContext
+
+
+def check_acl_coverage(  # noqa: ANN201
+    migrations_dir: Path,
+    config_path: Path,
+    ctx: ValidationContext | None = None,
+):
     """Lint *migrations_dir* for ACL coverage against the config's ``acls:`` block.
+
+    Args:
+        migrations_dir: Directory of migration files to lint.
+        config_path: Config file carrying the optional ``acls:`` block.
+        ctx: Shared per-run resources; supplies the already-parsed config.
 
     Returns:
         The :class:`~confiture.models.lint.LintReport` from the schema linter.
@@ -30,7 +44,7 @@ def check_acl_coverage(migrations_dir: Path, config_path: Path):  # noqa: ANN201
     if not config_path.exists():
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
 
-    config_data = load_config(config_path)
+    config_data = ctx.config_data if ctx is not None else load_config(config_path)
     # No-op when the project hasn't adopted the `acls:` block yet.
     expectations = load_acl_expectations(config_data, config_path, require=False)
 

--- a/python/confiture/core/validation/context.py
+++ b/python/confiture/core/validation/context.py
@@ -1,0 +1,105 @@
+"""Shared per-run resources for ``migrate validate`` (#187).
+
+Before 0.40.0 each validation mode returned as soon as it finished, so nothing
+was ever shared: five ``core/validation`` handlers each called ``load_config``
+and opened their own connection. Once the modes *compose*, running
+``--check-signatures --check-live-drift`` would parse the config twice and open
+two connections — and over ``--ssh``, spin up two tunnel subprocesses.
+
+:class:`ValidationContext` owns those resources for the whole run. It is lazy:
+a run of purely static checks never touches the database, and a config that is
+never needed is never read. ``open_connection`` and ``load_config`` are imported
+at module scope so tests can patch them here — this module is the single place
+the live connection is opened.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import TYPE_CHECKING, Any
+
+from confiture.core.connection import load_config, open_connection
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from types import TracebackType
+
+    import psycopg
+
+
+class ValidationContext:
+    """Config and database connection shared by every check in one run.
+
+    Use as a context manager so the connection — and any SSH tunnel behind it —
+    is closed once, after the last check has run::
+
+        with ValidationContext(config_path=cfg, ssh_via=None) as ctx:
+            outcomes = run_checks(checks, ctx)
+
+    Attributes:
+        config_path: The resolved config file. Not read until something asks.
+        ssh_via: ``user@host`` tunnel target overriding the config's own
+            ``ssh_tunnel`` block, or ``None``.
+        effective_base_ref: ``--since or --base-ref``, resolved once for every
+            git-backed check rather than per check.
+        staged: Whether ``--staged`` was passed.
+    """
+
+    def __init__(
+        self,
+        *,
+        config_path: Path,
+        ssh_via: str | None = None,
+        effective_base_ref: str = "origin/main",
+        staged: bool = False,
+    ) -> None:
+        self.config_path = config_path
+        self.ssh_via = ssh_via
+        self.effective_base_ref = effective_base_ref
+        self.staged = staged
+        self._config_data: Any = None
+        self._config_loaded = False
+        self._connection: psycopg.Connection[Any] | None = None
+        self._stack = ExitStack()
+
+    def __enter__(self) -> ValidationContext:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    @property
+    def config_data(self) -> Any:  # noqa: ANN401 — dict or Environment, per load_config
+        """The parsed config, read at most once per run."""
+        if not self._config_loaded:
+            self._config_data = load_config(self.config_path)
+            self._config_loaded = True
+        return self._config_data
+
+    def connection(self) -> psycopg.Connection[Any]:
+        """The live database connection, opened at most once per run.
+
+        Honours ``ssh_via`` by layering an ``ssh_tunnel`` block onto the config,
+        the same override ``--check-signatures`` has always applied — which is
+        how ``--check-live-drift`` finally gains the ``--ssh`` support its help
+        text has always claimed.
+        """
+        if self._connection is None:
+            from confiture.core.validation.signature_drift import _ssh_override
+
+            config = self.config_data
+            if self.ssh_via:
+                config = _ssh_override(config, self.ssh_via)
+            self._connection = self._stack.enter_context(open_connection(config))
+        return self._connection
+
+    def close(self) -> None:
+        """Release the connection and any tunnel behind it. Idempotent."""
+        self._connection = None
+        self._stack.close()
+        self._stack = ExitStack()

--- a/python/confiture/core/validation/function_uniqueness.py
+++ b/python/confiture/core/validation/function_uniqueness.py
@@ -9,10 +9,15 @@ shadowed by ``confiture build``, so func_001 catches the duplicate first.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from confiture.core.linting.schema_linter import LintViolation
 from confiture.exceptions import ConfigurationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from confiture.core.validation.context import ValidationContext
 
 
 @dataclass(frozen=True)
@@ -27,9 +32,16 @@ class FunctionUniquenessReport:
 
 
 def check_function_uniqueness(
-    scan_paths: list[Path], config_path: Path
+    scan_paths: list[Path],
+    config_path: Path,
+    ctx: ValidationContext | None = None,
 ) -> FunctionUniquenessReport:
     """Run func_001 across *scan_paths*.
+
+    Args:
+        scan_paths: DDL directories to scan.
+        config_path: Config file carrying the optional ``function_coverage:`` block.
+        ctx: Shared per-run resources; supplies the already-parsed config.
 
     Returns:
         A :class:`FunctionUniquenessReport`. No-op (empty) when the config has no
@@ -46,7 +58,7 @@ def check_function_uniqueness(
     if not config_path.exists():
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
 
-    config_data = load_config(config_path)
+    config_data = ctx.config_data if ctx is not None else load_config(config_path)
     coverage = load_function_coverage(config_data, config_path, require=False)
 
     violations: list[LintViolation] = []

--- a/python/confiture/core/validation/live_drift.py
+++ b/python/confiture/core/validation/live_drift.py
@@ -9,15 +9,32 @@ at module scope so tests can patch them on this module.
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from confiture.core.connection import create_connection, load_config
 from confiture.core.drift import SchemaDriftDetector
 from confiture.exceptions import ConfigurationError
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def check_live_drift(config_path: Path, schema_file: Path | None):  # noqa: ANN201
+    from confiture.core.validation.context import ValidationContext
+
+
+def check_live_drift(  # noqa: ANN201
+    config_path: Path,
+    schema_file: Path | None,
+    ctx: ValidationContext | None = None,
+):
     """Compare the live schema against *schema_file*.
+
+    Args:
+        config_path: Config file resolving the database connection.
+        schema_file: The DDL schema file to compare against (required).
+        ctx: Shared per-run resources. When given, the connection comes from
+            there — which is also how this check finally honours ``--ssh``, a
+            tunnel its help text has always advertised but ``create_connection``
+            never opened.
 
     Returns:
         The :class:`~confiture.core.drift.DriftReport`.
@@ -30,6 +47,17 @@ def check_live_drift(config_path: Path, schema_file: Path | None):  # noqa: ANN2
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
     if schema_file is None:
         raise ConfigurationError("--schema is required with --check-live-drift")
+
+    if ctx is not None:
+        try:
+            shared = ctx.connection()
+        except ConfigurationError:
+            raise
+        except Exception as exc:
+            raise ConfigurationError(
+                f"Database connection failed: {exc}", error_code="CONFIG_006"
+            ) from exc
+        return SchemaDriftDetector(shared).compare_with_schema_file(str(schema_file))
 
     config_data = load_config(config_path)
     try:

--- a/python/confiture/core/validation/ownership_coverage.py
+++ b/python/confiture/core/validation/ownership_coverage.py
@@ -8,10 +8,15 @@ TO`` on objects the migration didn't create (own_002).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from confiture.core.linting.schema_linter import LintViolation, RuleSeverity
 from confiture.exceptions import ConfigurationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from confiture.core.validation.context import ValidationContext
 
 
 @dataclass(frozen=True)
@@ -29,8 +34,17 @@ class OwnershipCoverageReport:
         return any(v.severity == RuleSeverity.ERROR for v in self.violations)
 
 
-def check_ownership_coverage(migrations_dir: Path, config_path: Path) -> OwnershipCoverageReport:
+def check_ownership_coverage(
+    migrations_dir: Path,
+    config_path: Path,
+    ctx: ValidationContext | None = None,
+) -> OwnershipCoverageReport:
     """Run own_001 + own_002 against *migrations_dir*.
+
+    Args:
+        migrations_dir: Directory of migration files to lint.
+        config_path: Config file carrying the optional ``ownership:`` block.
+        ctx: Shared per-run resources; supplies the already-parsed config.
 
     Returns:
         An :class:`OwnershipCoverageReport`. No-op (empty) when the config has no
@@ -50,7 +64,7 @@ def check_ownership_coverage(migrations_dir: Path, config_path: Path) -> Ownersh
     if not config_path.exists():
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
 
-    config_data = load_config(config_path)
+    config_data = ctx.config_data if ctx is not None else load_config(config_path)
     # No-op when the project hasn't adopted the `ownership:` block yet.
     ownership_exp = load_ownership_expectation(config_data, config_path, require=False)
 

--- a/python/confiture/core/validation/registry.py
+++ b/python/confiture/core/validation/registry.py
@@ -1,0 +1,141 @@
+"""Check registry and composition runner for ``migrate validate`` (#187).
+
+``migrate validate`` used to be a flat chain of ``if <flag>: … return`` blocks
+evaluated in source order, so any two validation flags meant the second one was
+silently skipped and the gate still exited 0. This module replaces the chain
+with an ordered registry of descriptors: the command builds the enabled list,
+the runner executes all of them, and the outcomes aggregate into one exit code
+and one JSON document.
+
+The registry's order deliberately reproduces the old source order, so a
+single-flag invocation is byte-identical to 0.39.0 — that is what keeps the
+blast radius of a 940-line refactor survivable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from confiture.core.error_codes import EXIT_CODE_SEMANTIC_CLASS
+
+if TYPE_CHECKING:
+    from confiture.core.validation.context import ValidationContext
+
+
+@dataclass(frozen=True)
+class CheckOutcome:
+    """What one check reported.
+
+    Attributes:
+        check: Stable machine name, and the key this check's payload takes in a
+            composed JSON envelope (``"acl_coverage"``, ``"imports"``, …).
+        passed: False when the check found something the gate should fail on.
+            Advisory findings that never failed the gate (an unpinned
+            SECURITY DEFINER at warning severity, say) stay ``passed=True``.
+        exit_code: The process exit code this check signals when it does not
+            pass. Every check signals ``1`` today; the field exists so a check
+            with a different semantic class composes rather than being coerced.
+        payload: The JSON-mode document for this check, or ``None`` in text
+            mode. Checks never write output themselves — the runner emits once.
+    """
+
+    check: str
+    passed: bool
+    exit_code: int = 1
+    payload: dict[str, Any] | None = None
+
+    @property
+    def semantic_class(self) -> str:
+        """This outcome's exit-code class per the 0.38.0 contract (#193)."""
+        return EXIT_CODE_SEMANTIC_CLASS[0 if self.passed else self.exit_code]
+
+
+@dataclass(frozen=True)
+class ValidationCheck:
+    """One registered check: what turns it on, and what it needs to run.
+
+    Attributes:
+        flag: The CLI flag that enables it, for error messages.
+        name: Stable machine name, matching the :class:`CheckOutcome` it emits.
+        enabled: Whether this run asked for it.
+        run: Executes the check against the shared context.
+        needs_db: Declares the shared live connection. Checks that declare it
+            get one connection between them, not one each.
+        needs_git: Declares a git working tree (validated once, before any
+            git-backed check runs).
+        report_only: A catalog/report mode with no gate semantics. These do not
+            compose — see ``exclusive``.
+        exclusive: Reject any other check alongside this one.
+        requires: Flags that must also be enabled for this check to be legal.
+    """
+
+    flag: str
+    name: str
+    enabled: bool
+    run: Callable[[ValidationContext], CheckOutcome]
+    needs_db: bool = False
+    needs_git: bool = False
+    report_only: bool = False
+    exclusive: bool = False
+    requires: tuple[str, ...] = ()
+
+
+def enabled_checks(checks: Sequence[ValidationCheck]) -> list[ValidationCheck]:
+    """The subset this run asked for, in registry (= historical source) order."""
+    return [c for c in checks if c.enabled]
+
+
+def run_checks(checks: Sequence[ValidationCheck], ctx: ValidationContext) -> list[CheckOutcome]:
+    """Run every enabled check in order and collect what each reported.
+
+    Findings compose; genuine failures do not. A check that raises
+    ``ConfiturError`` (bad config, unreachable database, missing git ref)
+    propagates immediately to the command's ``fail()`` boundary, exactly as it
+    did before composition existed — an infrastructure failure is not a finding
+    to be aggregated, and continuing would emit an error envelope alongside
+    unrelated check output.
+    """
+    return [check.run(ctx) for check in enabled_checks(checks)]
+
+
+def aggregate_exit_code(outcomes: Sequence[CheckOutcome]) -> int:
+    """The exit code for a whole run: the first failing check's, in order.
+
+    Every check signals exit 1 today, so "first failing" and "worst" are the
+    same integer and the ordering question does not arise. It is resolved this
+    way rather than by a severity ladder because the exit-code taxonomy is not
+    ordered by severity — 3 (``db_unreachable``) and 7 (``git_error``) are
+    siblings, not degrees. A check introducing a second distinct code must
+    revisit this function rather than inherit an accident.
+    """
+    for outcome in outcomes:
+        if not outcome.passed:
+            return outcome.exit_code
+    return 0
+
+
+def compose_payload(outcomes: Sequence[CheckOutcome]) -> dict[str, Any] | None:
+    """Merge per-check JSON payloads into the one document the run emits.
+
+    A single check emits its payload **verbatim**, so every documented
+    single-check schema keeps its exact shape. Two or more emit a wrapper keyed
+    by check name — a new shape for a combination that previously could not
+    happen at all.
+
+    Returns:
+        The document to emit, or ``None`` when no check produced one (text mode).
+    """
+    with_payload = [o for o in outcomes if o.payload is not None]
+    if not with_payload:
+        return None
+    if len(with_payload) == 1:
+        return with_payload[0].payload
+
+    return {
+        "version": "1",
+        "status": "passed" if all(o.passed for o in outcomes) else "failed",
+        "checks": {o.check: o.payload for o in with_payload},
+        "hints": [],
+    }

--- a/python/confiture/core/validation/replay_drift.py
+++ b/python/confiture/core/validation/replay_drift.py
@@ -15,6 +15,7 @@ signature pairing is exact — this sidesteps the text-parse asymmetry class of 
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from confiture.core.function_body_drift import FunctionBodyDriftReport
+    from confiture.core.validation.context import ValidationContext
 
 
 @dataclass
@@ -52,6 +54,7 @@ def check_replay_drift(
     schemas: str,
     ssh_via: str | None,
     scratch_url: str | None = None,
+    ctx: ValidationContext | None = None,
 ) -> ReplayDriftResult:
     """Detect function-body drift between live and a fresh migration replay.
 
@@ -66,6 +69,8 @@ def check_replay_drift(
         ssh_via: Optional ``user@host`` SSH tunnel for the *live* connection.
         scratch_url: Writable server on which to replay the migrations. Required
             when ``ssh_via`` is set.
+        ctx: Shared per-run resources supplying the config and the *live*
+            connection. The scratch database is necessarily its own connection.
 
     Raises:
         ConfigurationError: config missing, or ``--ssh`` without ``--scratch-url``.
@@ -79,7 +84,7 @@ def check_replay_drift(
     if not config_path.exists():
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
 
-    config_data = load_config(config_path)
+    config_data = ctx.config_data if ctx is not None else load_config(config_path)
     schema_list = [s.strip() for s in schemas.split(",") if s.strip()]
 
     effective_config: Any = config_data
@@ -100,7 +105,10 @@ def check_replay_drift(
             resolution_hint="Set database_url in the config or pass --scratch-url.",
         )
 
-    with open_connection(effective_config) as live_conn:
+    conn_cm = (
+        nullcontext(ctx.connection()) if ctx is not None else open_connection(effective_config)
+    )
+    with conn_cm as live_conn:
         live_bodies = LiveFunctionCatalog(live_conn).get_bodies(schemas=schema_list)
         with ExpectedSchemaDB(
             scratch, migrations_dir=migrations_dir

--- a/python/confiture/core/validation/security_definer.py
+++ b/python/confiture/core/validation/security_definer.py
@@ -18,9 +18,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from confiture.core.linting.schema_linter import LintViolation, RuleSeverity
 from confiture.exceptions import ConfigurationError
+
+if TYPE_CHECKING:
+    from confiture.core.validation.context import ValidationContext
 
 
 @dataclass(frozen=True)
@@ -42,8 +46,17 @@ class SecurityDefinerReport:
         return any(v.severity == RuleSeverity.ERROR for v in self.violations)
 
 
-def check_security_definer(scan_paths: list[Path], config_path: Path) -> SecurityDefinerReport:
+def check_security_definer(
+    scan_paths: list[Path],
+    config_path: Path,
+    ctx: ValidationContext | None = None,
+) -> SecurityDefinerReport:
     """Run sec_002 across *scan_paths*.
+
+    Args:
+        scan_paths: DDL directories to scan.
+        config_path: Config file carrying the optional ``security_lint:`` block.
+        ctx: Shared per-run resources; supplies the already-parsed config.
 
     Returns:
         A :class:`SecurityDefinerReport`. No-op (empty) when the config has
@@ -62,7 +75,7 @@ def check_security_definer(scan_paths: list[Path], config_path: Path) -> Securit
     if not config_path.exists():
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
 
-    config_data = load_config(config_path)
+    config_data = ctx.config_data if ctx is not None else load_config(config_path)
     sec_lint = load_security_lint(config_data, config_path, require=False)
 
     if sec_lint is None or not sec_lint.enabled:
@@ -83,6 +96,7 @@ def check_security_definer_live(
     schemas: str,
     ssh_via: str | None,
     exclude_extensions: bool = True,
+    ctx: ValidationContext | None = None,
 ) -> SecurityDefinerReport:
     """Query ``pg_proc`` for unpinned SECURITY DEFINER callables.
 
@@ -94,6 +108,8 @@ def check_security_definer_live(
         schemas: Comma-separated schema names to scan (e.g. ``"public,auth"``).
         ssh_via: Optional ``user@host`` SSH tunnel target overriding the config.
         exclude_extensions: Skip extension-owned functions (default ``True``).
+        ctx: Shared per-run resources supplying the config and the live
+            connection, so this check does not open a second one.
 
     Returns:
         A :class:`SecurityDefinerReport`. No-op (empty) when the config has
@@ -103,6 +119,8 @@ def check_security_definer_live(
         ConfigurationError: config missing, connection failed, or
             ``security_lint:`` malformed.
     """
+    from contextlib import nullcontext
+
     from confiture.core.connection import load_config, open_connection
     from confiture.core.linting.libraries.security_definer import (
         Sec002SecurityDefinerSearchPath,
@@ -113,7 +131,7 @@ def check_security_definer_live(
     if not config_path.exists():
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
 
-    config_data = load_config(config_path)
+    config_data = ctx.config_data if ctx is not None else load_config(config_path)
     sec_lint = load_security_lint(config_data, config_path, require=False)
 
     if sec_lint is None or not sec_lint.enabled:
@@ -128,7 +146,10 @@ def check_security_definer_live(
     schema_list = [s.strip() for s in schemas.split(",") if s.strip()]
 
     effective_config = _ssh_override(config_data, ssh_via) if ssh_via else config_data
-    with open_connection(effective_config) as conn:
+    conn_cm = (
+        nullcontext(ctx.connection()) if ctx is not None else open_connection(effective_config)
+    )
+    with conn_cm as conn:
         violations = rule.check_live(
             conn,
             schemas=schema_list,

--- a/python/confiture/core/validation/signature_drift.py
+++ b/python/confiture/core/validation/signature_drift.py
@@ -10,6 +10,7 @@ patch them on this module.
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -20,6 +21,7 @@ from confiture.exceptions import ConfigurationError
 if TYPE_CHECKING:
     from confiture.core.function_body_drift import FunctionBodyDriftReport
     from confiture.core.function_signature_drift import FunctionSignatureDriftReport
+    from confiture.core.validation.context import ValidationContext
 
 
 @dataclass
@@ -107,6 +109,7 @@ def check_signature_drift(
     schemas: str,
     check_body: bool,
     ssh_via: str | None,
+    ctx: ValidationContext | None = None,
 ) -> SignatureDriftResult:
     """Detect signature (and optional body) drift against the live database.
 
@@ -116,6 +119,10 @@ def check_signature_drift(
         schemas: Comma-separated DB schema names to scan (e.g. ``"public,auth"``).
         check_body: Also compare function bodies (heavier).
         ssh_via: Optional ``user@host`` SSH tunnel target overriding the config.
+        ctx: Shared per-run resources. When given, the config and the live
+            connection come from there, so several checks in one
+            ``migrate validate`` run connect once between them. When ``None``
+            this function is fully standalone, exactly as before 0.40.0.
 
     Raises:
         ConfigurationError: config missing, auto-build failed, or connection failed.
@@ -127,7 +134,7 @@ def check_signature_drift(
     if not config_path.exists():
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
 
-    config_data = load_config(config_path)
+    config_data = ctx.config_data if ctx is not None else load_config(config_path)
     schema_list = [s.strip() for s in schemas.split(",") if s.strip()]
 
     source_sql, auto_built = _resolve_source_sql(config_data, schema_file)
@@ -137,7 +144,10 @@ def check_signature_drift(
     if ssh_via:
         effective_config = _ssh_override(config_data, ssh_via)
 
-    with open_connection(effective_config) as conn:
+    conn_cm = (
+        nullcontext(ctx.connection()) if ctx is not None else open_connection(effective_config)
+    )
+    with conn_cm as conn:
         live_catalog = LiveFunctionCatalog(conn)
         live_sigs = live_catalog.get_signatures(schemas=schema_list)
         drift_report = FunctionSignatureDriftDetector().compare(

--- a/python/confiture/core/validation/view_drift.py
+++ b/python/confiture/core/validation/view_drift.py
@@ -13,6 +13,7 @@ so the source-resolution and SSH-tunnel behaviour matches ``--check-signatures``
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -23,6 +24,7 @@ from confiture.exceptions import ConfigurationError
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from confiture.core.validation.context import ValidationContext
     from confiture.core.view_body_drift import ViewBodyDriftReport
 
 
@@ -58,6 +60,7 @@ def check_view_drift(
     schemas: str,
     ssh_via: str | None,
     scratch_url: str | None = None,
+    ctx: ValidationContext | None = None,
 ) -> ViewDriftResult:
     """Detect view definition drift against the live database.
 
@@ -73,6 +76,8 @@ def check_view_drift(
         scratch_url: Writable server on which to build the expected scratch DB.
             Required when ``ssh_via`` is set (the scratch DB cannot be built on a
             remote read-only live server through the tunnel).
+        ctx: Shared per-run resources supplying the config and the *live*
+            connection. The scratch database is necessarily its own connection.
 
     Raises:
         ConfigurationError: config missing, auto-build failed, or ``--ssh`` was
@@ -85,7 +90,7 @@ def check_view_drift(
     if not config_path.exists():
         raise ConfigurationError(f"Config file not found: {config_path}", error_code="CONFIG_004")
 
-    config_data = load_config(config_path)
+    config_data = ctx.config_data if ctx is not None else load_config(config_path)
     schema_list = [s.strip() for s in schemas.split(",") if s.strip()]
 
     source_sql, auto_built = _resolve_source_sql(config_data, schema_file)
@@ -108,7 +113,10 @@ def check_view_drift(
             resolution_hint="Set database_url in the config or pass --scratch-url.",
         )
 
-    with open_connection(effective_config) as live_conn:
+    conn_cm = (
+        nullcontext(ctx.connection()) if ctx is not None else open_connection(effective_config)
+    )
+    with conn_cm as live_conn:
         live_defs = LiveViewCatalog(live_conn).get_view_definitions(schema_list)
         with ExpectedSchemaDB(scratch).from_source(schema_sql=source_sql) as scratch_conn:
             src_defs = LiveViewCatalog(scratch_conn).get_view_definitions(schema_list)

--- a/tests/unit/json_schemas/test_introspect_schema.py
+++ b/tests/unit/json_schemas/test_introspect_schema.py
@@ -1,10 +1,13 @@
 """Schema conformance for ``migrate introspect --format json`` (#186).
 
 Introspect emits three different payloads from three separate ``json.dumps``
-call sites. The interesting property is that all three carry **both**
-``ledger_present`` and the deprecated ``tb_confiture_present``, with the same
-value — a deprecation window is only useful if the two keys agree throughout
-it, and three independent emit sites is how they would silently stop agreeing.
+call sites. The interesting property is that all three carry ``ledger_present``
+and match the schema — three independent emit sites is how a shape silently
+stops agreeing.
+
+The deprecated ``tb_confiture_present`` alias was added in 0.39.0 and removed in
+0.40.0 as announced; ``test_deprecated_alias_is_gone`` pins the removal so it
+cannot creep back in.
 """
 
 from __future__ import annotations
@@ -63,13 +66,6 @@ def _invoke(cfg: Path, snapshots: Path):
     )
 
 
-def _assert_keys_agree(payload: dict) -> None:
-    assert payload["ledger_present"] == payload["tb_confiture_present"], (
-        "the deprecated alias must carry the same value as ledger_present for "
-        "the whole deprecation window"
-    )
-
-
 @patch("confiture.core.connection.create_connection")
 @patch("confiture.core.migrator.Migrator")
 def test_missing_snapshots_dir_matches_schema(
@@ -81,7 +77,6 @@ def test_missing_snapshots_dir_matches_schema(
 
     payload = json.loads(result.stdout)
     _validator().validate(payload)
-    _assert_keys_agree(payload)
     assert payload["error"] == "snapshots_dir not found"
     assert payload["detected_version"] is None
 
@@ -105,7 +100,6 @@ def test_exact_match_matches_schema(
 
     payload = json.loads(result.stdout)
     _validator().validate(payload)
-    _assert_keys_agree(payload)
     assert payload["confidence"] == "exact"
     assert payload["detected_version"] == "20260101000000"
 
@@ -130,7 +124,6 @@ def test_no_match_with_closest_matches_schema(
 
     payload = json.loads(result.stdout)
     _validator().validate(payload)
-    _assert_keys_agree(payload)
     assert payload["confidence"] == "none"
     assert payload["closest_version"] == "20260101000000"
     assert payload["closest_similarity"] == pytest.approx(0.4213)
@@ -138,22 +131,25 @@ def test_no_match_with_closest_matches_schema(
 
 @patch("confiture.core.connection.create_connection")
 @patch("confiture.core.migrator.Migrator")
-def test_deprecated_alias_is_still_emitted(migrator_cls, _conn, cfg: Path, tmp_path: Path) -> None:
-    """Removing it early would break consumers with no upgrade path.
+def test_deprecated_alias_is_gone(migrator_cls, _conn, cfg: Path, tmp_path: Path) -> None:
+    """``tb_confiture_present`` was removed in 0.40.0 as announced (#186).
 
-    Delete this test — and the key — in 0.40.0, not before.
+    It hardcoded the default table name, so it lied to every project that had
+    configured ``tracking_table`` — which is why it only ever existed as a
+    one-release upgrade path.
     """
     migrator_cls.return_value.tracking_table_exists.return_value = True
 
     payload = json.loads(_invoke(cfg, tmp_path / "nope").stdout)
 
-    assert "tb_confiture_present" in payload
+    assert "tb_confiture_present" not in payload
     assert "ledger_present" in payload
 
 
-def test_schema_records_the_removal_release() -> None:
-    """The deprecated key's description must say when it goes away."""
+def test_schema_no_longer_declares_the_removed_key() -> None:
+    """The schema sets additionalProperties: false, so a re-added key would fail
+    validation — but the property declaration itself must go too, or the schema
+    would keep advertising a key nothing emits."""
     schema = json.loads((SCHEMAS_DIR / "migrate-introspect.schema.json").read_text())
-    description = schema["properties"]["tb_confiture_present"]["description"]
-    assert "DEPRECATED" in description
-    assert "0.40.0" in description
+    assert "tb_confiture_present" not in schema["properties"]
+    assert "tb_confiture_present" not in schema["required"]

--- a/tests/unit/json_schemas/test_validate_composed_schema.py
+++ b/tests/unit/json_schemas/test_validate_composed_schema.py
@@ -1,0 +1,115 @@
+"""Validate the composed ``migrate validate --format json`` envelope (#187).
+
+Pins both halves of the contract: two-or-more checks emit the wrapper, and a
+single check still emits its own payload — the wrapper must *not* appear then,
+or every documented single-check schema breaks at once.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+SCHEMA_FILE = "migrate-validate-composed.schema.json"
+
+runner = CliRunner()
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real project the static checks can run against, chdir-ed into."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    (tmp_path / "db" / "environments").mkdir(parents=True)
+    (tmp_path / "db" / "environments" / "local.yaml").write_text(
+        "database_url: postgresql://localhost/test\ninclude_dirs:\n  - path: db/schema\n"
+    )
+    (migs / "20260527000000_init.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS public.orders (id INT PRIMARY KEY);\n"
+        "GRANT SELECT ON public.orders TO app_reader;\n"
+    )
+    (tmp_path / "confiture.yaml").write_text(
+        dedent(
+            """\
+            name: test
+            database_url: postgresql://localhost/test
+            include_dirs:
+              - path: db/schema
+            acls:
+              - schema: public
+                apply_to: ALL_TABLES
+                grants:
+                  - role: app_reader
+                    privileges: [SELECT]
+            """
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_schema_is_valid_draft_2020_12(schemas_dir: Path) -> None:
+    Draft202012Validator.check_schema(_load(schemas_dir, SCHEMA_FILE))
+
+
+def test_two_checks_emit_the_composed_envelope(
+    project: Path,  # noqa: ARG001
+    schemas_dir: Path,
+    schema_registry: object,
+) -> None:
+    result = runner.invoke(
+        app,
+        ["migrate", "validate", "--check-acls", "--check-imports", "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    Draft202012Validator(_load(schemas_dir, SCHEMA_FILE), registry=schema_registry).validate(
+        payload
+    )
+    assert set(payload["checks"]) == {"acl_coverage", "imports"}
+
+
+def test_nested_payloads_still_match_their_own_schema(
+    project: Path,  # noqa: ARG001
+    schemas_dir: Path,
+    schema_registry: object,
+) -> None:
+    """The wrapper nests each check's payload unchanged, not a reduced form."""
+    result = runner.invoke(
+        app,
+        ["migrate", "validate", "--check-acls", "--check-imports", "--format", "json"],
+    )
+    nested = json.loads(result.stdout)["checks"]["acl_coverage"]
+    Draft202012Validator(
+        _load(schemas_dir, "migrate-validate-check-acl-coverage.schema.json"),
+        registry=schema_registry,
+    ).validate(nested)
+
+
+def test_single_check_does_not_emit_the_wrapper(
+    project: Path,  # noqa: ARG001
+    schemas_dir: Path,
+    schema_registry: object,
+) -> None:
+    result = runner.invoke(app, ["migrate", "validate", "--check-acls", "--format", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+
+    validator = Draft202012Validator(_load(schemas_dir, SCHEMA_FILE), registry=schema_registry)
+    assert not validator.is_valid(payload), "single-check output must not be the composed wrapper"
+    Draft202012Validator(
+        _load(schemas_dir, "migrate-validate-check-acl-coverage.schema.json"),
+        registry=schema_registry,
+    ).validate(payload)

--- a/tests/unit/test_drift_cli.py
+++ b/tests/unit/test_drift_cli.py
@@ -349,12 +349,17 @@ class TestMigrateValidateCheckLiveDrift:
     """Tests for --check-live-drift flag on migrate validate."""
 
     @patch("confiture.core.validation.live_drift.SchemaDriftDetector")
-    @patch("confiture.core.validation.live_drift.create_connection")
-    @patch("confiture.core.validation.live_drift.load_config")
+    @patch("confiture.core.validation.context.open_connection")
+    @patch("confiture.core.validation.context.load_config")
     def test_validate_check_live_drift_flag(
-        self, mock_load_config, mock_create_connection, mock_detector_class, tmp_path
+        self, mock_load_config, mock_open_connection, mock_detector_class, tmp_path
     ):
-        """SchemaDriftDetector should be called when --check-live-drift is used."""
+        """SchemaDriftDetector should be called when --check-live-drift is used.
+
+        Patched on ``core.validation.context`` since 0.40.0: the CLI opens one
+        connection per run there and hands it to every database-backed check,
+        instead of each handler calling its own ``create_connection``.
+        """
         config_file = tmp_path / "confiture.yaml"
         config_file.write_text("database_url: postgresql://localhost/test\n")
         schema_file = tmp_path / "schema.sql"
@@ -362,7 +367,8 @@ class TestMigrateValidateCheckLiveDrift:
 
         mock_load_config.return_value = MagicMock()
         mock_conn = MagicMock()
-        mock_create_connection.return_value = mock_conn
+        mock_open_connection.return_value.__enter__.return_value = mock_conn
+        mock_open_connection.return_value.__exit__.return_value = False
 
         from confiture.core.drift import DriftReport
 

--- a/tests/unit/test_migrate_validate_check_signatures.py
+++ b/tests/unit/test_migrate_validate_check_signatures.py
@@ -1,4 +1,11 @@
-"""Unit tests for migrate validate --check-signatures and --check-body CLI flags."""
+"""Unit tests for migrate validate --check-signatures and --check-body CLI flags.
+
+``load_config`` / ``open_connection`` are patched on
+``confiture.core.validation.context`` since 0.40.0: the CLI opens one connection
+per run there and hands it to every database-backed check, instead of each
+handler calling its own. ``check_signature_drift`` still opens its own when
+called without a context, so the handler-level symbols remain real.
+"""
 
 import re
 from unittest.mock import MagicMock, patch
@@ -154,14 +161,10 @@ class TestCheckSignaturesFlag:
         schema = tmp_path / "schema.sql"
         schema.write_text("-- no functions")
 
+        open_conn = self._make_open_conn_mock()
         with (
-            patch(
-                "confiture.core.validation.signature_drift.load_config", return_value=MagicMock()
-            ),
-            patch(
-                "confiture.core.validation.signature_drift.open_connection",
-                self._make_open_conn_mock(),
-            ),
+            patch("confiture.core.validation.context.load_config", return_value=MagicMock()),
+            patch("confiture.core.validation.context.open_connection", open_conn),
             patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntrospector,
         ):
             MockIntrospector.return_value.introspect.return_value = MagicMock(functions=[])
@@ -183,6 +186,10 @@ class TestCheckSignaturesFlag:
                     ],
                 )
         assert result.exit_code == 0
+        # The double must actually be the thing that ran. Without this, a stale
+        # patch target passes on any box with Postgres on localhost and fails
+        # only in CI — how these tests first went red in 0.40.0.
+        assert open_conn.called, "the patched connection factory was never used"
 
     def test_check_signatures_exits_1_on_drift(self, tmp_path):
         config = tmp_path / "confiture.yaml"
@@ -191,11 +198,9 @@ class TestCheckSignaturesFlag:
         schema.write_text("-- no functions")
 
         with (
+            patch("confiture.core.validation.context.load_config", return_value=MagicMock()),
             patch(
-                "confiture.core.validation.signature_drift.load_config", return_value=MagicMock()
-            ),
-            patch(
-                "confiture.core.validation.signature_drift.open_connection",
+                "confiture.core.validation.context.open_connection",
                 self._make_open_conn_mock(),
             ),
             patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntrospector,
@@ -227,11 +232,9 @@ class TestCheckSignaturesFlag:
         schema.write_text("-- no functions")
 
         with (
+            patch("confiture.core.validation.context.load_config", return_value=MagicMock()),
             patch(
-                "confiture.core.validation.signature_drift.load_config", return_value=MagicMock()
-            ),
-            patch(
-                "confiture.core.validation.signature_drift.open_connection",
+                "confiture.core.validation.context.open_connection",
                 self._make_open_conn_mock(),
             ),
             patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntrospector,
@@ -301,11 +304,11 @@ class TestCheckBodyFlag:
 
         with (
             patch(
-                "confiture.core.validation.signature_drift.load_config",
+                "confiture.core.validation.context.load_config",
                 return_value=MagicMock(),
             ),
             patch(
-                "confiture.core.validation.signature_drift.open_connection",
+                "confiture.core.validation.context.open_connection",
                 self._make_open_conn_mock(),
             ),
             patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntr,
@@ -344,11 +347,11 @@ class TestCheckBodyFlag:
 
         with (
             patch(
-                "confiture.core.validation.signature_drift.load_config",
+                "confiture.core.validation.context.load_config",
                 return_value=MagicMock(),
             ),
             patch(
-                "confiture.core.validation.signature_drift.open_connection",
+                "confiture.core.validation.context.open_connection",
                 self._make_open_conn_mock(),
             ),
             patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntr,
@@ -396,11 +399,11 @@ class TestCheckBodyFlag:
 
         with (
             patch(
-                "confiture.core.validation.signature_drift.load_config",
+                "confiture.core.validation.context.load_config",
                 return_value=MagicMock(),
             ),
             patch(
-                "confiture.core.validation.signature_drift.open_connection",
+                "confiture.core.validation.context.open_connection",
                 self._make_open_conn_mock(),
             ),
             patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntr,
@@ -466,11 +469,11 @@ class TestCheckBodyFlag:
 
         with (
             patch(
-                "confiture.core.validation.signature_drift.load_config",
+                "confiture.core.validation.context.load_config",
                 return_value=MagicMock(),
             ),
             patch(
-                "confiture.core.validation.signature_drift.open_connection",
+                "confiture.core.validation.context.open_connection",
                 self._make_open_conn_mock(),
             ),
             patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntr,
@@ -512,11 +515,11 @@ class TestCheckBodyFlag:
 
         with (
             patch(
-                "confiture.core.validation.signature_drift.load_config",
+                "confiture.core.validation.context.load_config",
                 return_value=MagicMock(),
             ),
             patch(
-                "confiture.core.validation.signature_drift.open_connection",
+                "confiture.core.validation.context.open_connection",
                 self._make_open_conn_mock(),
             ),
             patch("confiture.core.live_function_catalog.FunctionIntrospector") as MockIntr,

--- a/tests/unit/test_no_raw_exit_convention.py
+++ b/tests/unit/test_no_raw_exit_convention.py
@@ -55,10 +55,11 @@ _ALLOWLIST: dict[str, int] = {
     # MigrateDiffResult domain formatter), migrate fix-signatures, and migrate
     # preflight (already mostly fail()-routed via computed Exit(exit_code)).
     # TODO(follow-up): finish diff / fix-signatures / preflight contract sweep.
-    # +2 (29): --check-body-views (28) and --check-body-replay (29) drift gates —
-    # both Exit(1) success-signals (CI drift signals, same kind as the
-    # --check-signatures gate), not failure paths.
-    "commands/migrate_analysis.py": 29,
+    # 0.40.0 (#187): the validate dispatch became a check registry, so its
+    # eleven per-check `Exit(1)` success-signals collapsed into the single
+    # aggregated `Exit(aggregate_exit_code(...))` — a computed value, not a
+    # literal, so it no longer appears here at all. 29 → 15.
+    "commands/migrate_analysis.py": 15,
     # ---- migrate_core: status/up/down/generate/estimate ----
     # Mix of success-signal (status→1 pending) and not-yet-converted failures;
     # already partially routed through fail(). Paid down opportunistically.
@@ -89,7 +90,9 @@ _ALLOWLIST: dict[str, int] = {
     # (Phase 03) and now raise ConfigurationError instead of typer.Exit(2) — the
     # ValidationError seam they shared with migrate_validate is reseamed through
     # the callers' fail() boundaries (drift/bootstrap/migrate validate).
-    "helpers.py": 2,  # success-signal: idempotency gate → Exit(1) on findings
+    # helpers.py: fully converted (0.40.0) — _validate_idempotency returns
+    # (passed, payload) so the caller aggregates the gate with the other checks
+    # instead of exiting from inside a renderer.
     # commands/mcp.py: fully converted (Cycle 1) — connection → CONFIG_006,
     # missing-extra → generic ConfiturError, both via fail().
     "test_db.py": 1,  # success-signal: test-db status → Exit(1) on stale/absent template (CI gate)

--- a/tests/unit/test_validate_composition_git_and_db.py
+++ b/tests/unit/test_validate_composition_git_and_db.py
@@ -250,3 +250,61 @@ def test_db_backed_checks_open_one_connection(
 
     assert result.exit_code == 0, result.output
     assert len(opened) == 1, f"opened {len(opened)} connections: {opened}"
+
+
+def test_emit_remediation_fires_exactly_once_when_composed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--emit-remediation`` is a file-writing side effect; composition must not
+    run it twice, and must not skip it because another check ran first."""
+    (tmp_path / "db" / "migrations").mkdir(parents=True)
+    ddl = tmp_path / "db" / "schema"
+    ddl.mkdir(parents=True)
+    (ddl / "10_fn.sql").write_text(
+        "CREATE FUNCTION public.f() RETURNS int AS $$ SELECT 1 $$ LANGUAGE sql SECURITY DEFINER;\n"
+    )
+    config = tmp_path / "confiture.yaml"
+    config.write_text(
+        textwrap.dedent(
+            """\
+            name: test
+            database_url: postgresql://localhost/test
+            include_dirs:
+              - path: db/schema
+            security_lint:
+              enabled: true
+            """
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+
+    calls: list[Path] = []
+    real_emit = __import__(
+        "confiture.core.validation.security_definer", fromlist=["emit_remediation"]
+    ).emit_remediation
+
+    def spy(report: Any, output_path: Path) -> int:
+        calls.append(output_path)
+        return real_emit(report, output_path)
+
+    monkeypatch.setattr("confiture.core.validation.security_definer.emit_remediation", spy)
+
+    out = tmp_path / "fix.sql"
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-security-definer",
+            "--check-imports",
+            "-c",
+            str(config),
+            "--emit-remediation",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "passed import check" in result.output
+    assert len(calls) == 1, f"emit_remediation ran {len(calls)} times"
+    assert out.exists()

--- a/tests/unit/test_validate_composition_git_and_db.py
+++ b/tests/unit/test_validate_composition_git_and_db.py
@@ -1,0 +1,252 @@
+"""Composition for the git- and database-backed ``migrate validate`` checks (#187).
+
+Split from ``test_validate_flag_composition.py`` because these need doubles: a
+git working tree for the accompaniment group, and patched connection factories
+for the live checks. The static matrix over there stays dependency-free.
+
+Two defects are pinned here beyond plain composition:
+
+* **The git group short-circuits in JSON mode.** Text mode aggregates
+  ``drift_passed`` / ``accompaniment_passed`` / ``grant_passed`` and returns
+  once; JSON mode raised ``typer.Exit(1)`` on the first failure, so a failing
+  drift check meant accompaniment never ran. The one block that looked like a
+  model for composition did not compose in the mode machine consumers use.
+* **Each DB-backed handler opened its own connection.** Five of them did, so
+  ``--check-signatures --check-live-drift`` connected twice — and over ``--ssh``
+  spun up two tunnel subprocesses.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Git-backed checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def git_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A committed git repo holding a minimal confiture project."""
+    repo = tmp_path / "repo"
+    (repo / "db" / "schema").mkdir(parents=True)
+    (repo / "db" / "migrations").mkdir(parents=True)
+    (repo / "db" / "environments").mkdir(parents=True)
+    (repo / "db" / "environments" / "local.yaml").write_text(
+        "database_url: postgresql://localhost/test\ninclude_dirs:\n  - path: db/schema\n"
+    )
+    (repo / "confiture.yaml").write_text(
+        textwrap.dedent(
+            """\
+            name: local
+            database_url: postgresql://localhost/test
+            include_dirs:
+              - path: db/schema
+            """
+        )
+    )
+    for cmd in (
+        ["git", "init"],
+        ["git", "config", "user.email", "t@t.com"],
+        ["git", "config", "user.name", "T"],
+        ["git", "add", "."],
+        ["git", "commit", "-m", "init"],
+    ):
+        subprocess.run(cmd, cwd=repo, check=True, capture_output=True)
+    monkeypatch.chdir(repo)
+    return repo
+
+
+@pytest.fixture
+def git_doubles(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch the three git sub-checks; each records that it ran.
+
+    Patched on ``confiture.cli.git_validation`` because ``migrate validate``
+    imports them lazily from there.
+    """
+    state: dict[str, Any] = {"ran": [], "drift_passes": True, "accompaniment_passes": True}
+
+    def fake_flags() -> object:
+        return object()
+
+    def fake_drift(**_: Any) -> dict[str, Any]:
+        state["ran"].append("drift")
+        return {"passed": state["drift_passes"], "changes": []}
+
+    def fake_accompaniment(**_: Any) -> dict[str, Any]:
+        state["ran"].append("accompaniment")
+        return {"is_valid": state["accompaniment_passes"], "violations": []}
+
+    def fake_grant(**_: Any) -> dict[str, Any]:
+        state["ran"].append("grant")
+        return {"is_valid": True, "violations": []}
+
+    monkeypatch.setattr("confiture.cli.git_validation.validate_git_flags_in_repo", fake_flags)
+    monkeypatch.setattr("confiture.cli.git_validation.validate_git_drift", fake_drift)
+    monkeypatch.setattr(
+        "confiture.cli.git_validation.validate_migration_accompaniment", fake_accompaniment
+    )
+    monkeypatch.setattr("confiture.cli.git_validation.validate_grant_accompaniment", fake_grant)
+    return state
+
+
+def _invoke(*flags: str) -> Any:
+    return runner.invoke(app, ["migrate", "validate", "-c", "confiture.yaml", *flags])
+
+
+def test_json_mode_runs_every_git_subcheck_despite_an_early_failure(
+    git_project: Path,  # noqa: ARG001
+    git_doubles: dict[str, Any],
+) -> None:
+    """A failing drift check must not stop accompaniment and grant from running."""
+    git_doubles["drift_passes"] = False
+
+    result = _invoke(
+        "--check-drift",
+        "--require-migration",
+        "--require-grant-migration",
+        "--format",
+        "json",
+    )
+
+    assert git_doubles["ran"] == ["drift", "accompaniment", "grant"]
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+
+
+def test_text_mode_runs_every_git_subcheck_despite_an_early_failure(
+    git_project: Path,  # noqa: ARG001
+    git_doubles: dict[str, Any],
+) -> None:
+    """Text mode already aggregated; pin it so the JSON fix keeps it that way."""
+    git_doubles["drift_passes"] = False
+
+    result = _invoke("--check-drift", "--require-migration", "--require-grant-migration")
+
+    assert git_doubles["ran"] == ["drift", "accompaniment", "grant"]
+    assert result.exit_code == 1, result.output
+
+
+def test_git_check_composes_with_a_static_check(
+    git_project: Path,  # noqa: ARG001
+    git_doubles: dict[str, Any],
+) -> None:
+    """``--check-drift --check-imports`` runs both, not whichever comes first."""
+    result = _invoke("--check-drift", "--check-imports")
+
+    assert git_doubles["ran"] == ["drift"]
+    assert "passed import check" in result.output
+    assert result.exit_code == 0, result.output
+
+
+def test_single_git_check_json_envelope_is_unchanged(
+    git_project: Path,  # noqa: ARG001
+    git_doubles: dict[str, Any],  # noqa: ARG001
+) -> None:
+    """The 0.39.0 group envelope survives verbatim for a lone git flag."""
+    result = _invoke("--check-drift", "--format", "json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload == {"status": "passed", "checks": ["drift"]}
+
+
+# ---------------------------------------------------------------------------
+# Database-backed checks share one connection
+# ---------------------------------------------------------------------------
+
+
+def _conn_cm() -> MagicMock:
+    """A context-manager double yielding a fake connection."""
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=MagicMock())
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+def test_db_backed_checks_open_one_connection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--check-signatures --check-live-drift`` must connect once, not twice.
+
+    Every place a live connection can be opened is counted, so the assertion
+    holds whether the connection comes from a handler or from the shared
+    context.
+    """
+    config = tmp_path / "confiture.yaml"
+    config.write_text("name: test\ndatabase_url: postgresql://localhost/test\n")
+    schema = tmp_path / "schema.sql"
+    schema.write_text("-- no functions\n")
+
+    opened: list[str] = []
+
+    def counting(label: str) -> Any:
+        def _factory(*_a: Any, **_k: Any) -> MagicMock:
+            opened.append(label)
+            return _conn_cm()
+
+        return _factory
+
+    def counting_raw(label: str) -> Any:
+        def _factory(*_a: Any, **_k: Any) -> MagicMock:
+            opened.append(label)
+            return MagicMock()
+
+        return _factory
+
+    monkeypatch.setattr(
+        "confiture.core.validation.context.open_connection", counting("context"), raising=False
+    )
+    monkeypatch.setattr(
+        "confiture.core.validation.signature_drift.open_connection", counting("signature_drift")
+    )
+    monkeypatch.setattr(
+        "confiture.core.validation.live_drift.create_connection", counting_raw("live_drift")
+    )
+    monkeypatch.setattr(
+        "confiture.core.validation.live_drift.SchemaDriftDetector",
+        MagicMock(
+            return_value=MagicMock(
+                compare_with_schema_file=MagicMock(
+                    return_value=MagicMock(has_critical_drift=False, to_dict=lambda: {})
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "confiture.core.live_function_catalog.FunctionIntrospector",
+        MagicMock(
+            return_value=MagicMock(introspect=MagicMock(return_value=MagicMock(functions=[])))
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-signatures",
+            "--check-live-drift",
+            "--config",
+            str(config),
+            "--schema",
+            str(schema),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(opened) == 1, f"opened {len(opened)} connections: {opened}"

--- a/tests/unit/test_validate_composition_git_and_db.py
+++ b/tests/unit/test_validate_composition_git_and_db.py
@@ -249,7 +249,11 @@ def test_db_backed_checks_open_one_connection(
     )
 
     assert result.exit_code == 0, result.output
-    assert len(opened) == 1, f"opened {len(opened)} connections: {opened}"
+    # Naming the seam, not just counting: an empty list would mean the doubles
+    # were bypassed and a *real* connection was made — which passes on a
+    # developer box with Postgres on localhost and fails in CI. That exact
+    # asymmetry is how the 0.40.0 patch-target move first reached CI red.
+    assert opened == ["context"], f"connections opened: {opened}"
 
 
 def test_emit_remediation_fires_exactly_once_when_composed(

--- a/tests/unit/test_validate_flag_composition.py
+++ b/tests/unit/test_validate_flag_composition.py
@@ -1,0 +1,238 @@
+"""``migrate validate`` runs every check the operator asked for (#187).
+
+Before 0.40.0 the command was a flat chain of ``if <flag>: … return`` blocks
+evaluated in source order, so ``--check-acls --check-imports`` ran *only* the
+ACL check and exited 0 — a green gate for a check that never ran. That is the
+same silent-false-pass class as the pglast-8 ``window_safe`` bug, and in a
+pre-commit or CI gate it is the failure mode that matters most.
+
+The matrix below is generated from :data:`STATIC_CHECKS`, so a new flag joins it
+by being registered rather than by anyone remembering to extend a list. Every
+flag here is static — no database, no git — so the matrix stays a unit test.
+
+The project fixture is a *real* one, built in ``tmp_path`` and ``chdir``-ed into:
+Typer resolves ``db/migrations`` relative to the working directory, so a test
+run from the repo root exits with "No migrations directory found" long before
+reaching the dispatch under test.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+# (flag, success marker in text output). The marker must be unique to the check,
+# so "both ran" is provable from one invocation's output.
+STATIC_CHECKS: list[tuple[str, str]] = [
+    ("--check-acls", "All migrations have ACL coverage"),
+    ("--check-ownership-coverage", "All migrations have ownership coverage"),
+    ("--check-function-uniqueness", "All callables have unique signatures"),
+    ("--check-security-definer", "No unpinned SECURITY DEFINER functions found"),
+    ("--check-imports", "passed import check"),
+    ("--idempotent", "All migrations are idempotent"),
+]
+
+STATIC_PAIRS = list(itertools.combinations(STATIC_CHECKS, 2))
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real, clean confiture project every static check passes on."""
+    (tmp_path / "db" / "migrations").mkdir(parents=True)
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    # No `ALTER TABLE … OWNER TO`: that statement is a blocking idempotency
+    # violation, and --idempotent is in the matrix. The ownership lint stays
+    # genuinely enabled instead — scoped to materialized views, which this
+    # migration does not create, so own_001 has nothing to flag.
+    (tmp_path / "db" / "migrations" / "20260101120000_t.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS public.foo (id int);\nGRANT SELECT ON public.foo TO my_app;\n"
+    )
+    (tmp_path / "db" / "schema" / "10_tables.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS public.foo (id int);\n"
+    )
+    # SchemaLinter() instantiates Environment.load("local"), which resolves
+    # db/environments/local.yaml from the *working directory* — so the file has
+    # to exist inside the fixture project, not just in the repo we ran from.
+    (tmp_path / "db" / "environments").mkdir(parents=True)
+    (tmp_path / "db" / "environments" / "local.yaml").write_text(
+        "database_url: postgresql://localhost/test\ninclude_dirs:\n  - path: db/schema\n"
+    )
+    (tmp_path / "confiture.yaml").write_text(
+        textwrap.dedent(
+            """\
+            name: test
+            database_url: postgresql://localhost/test
+            include_dirs:
+              - path: db/schema
+            acls:
+              - schema: public
+                apply_to: ALL_TABLES
+                grants:
+                  - role: my_app
+                    privileges: [SELECT]
+            ownership:
+              expected_owner: migrator
+              lint_enabled: true
+              apply_to:
+                - schema: public
+                  relkinds: [m]
+            function_coverage:
+              enabled: true
+            security_lint:
+              enabled: true
+            """
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _invoke(*flags: str) -> object:
+    return runner.invoke(app, ["migrate", "validate", "-c", "confiture.yaml", *flags])
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    STATIC_PAIRS,
+    ids=[f"{a[0]}+{b[0]}" for a, b in STATIC_PAIRS],
+)
+def test_static_flag_pairs_run_both_checks(
+    project: Path,  # noqa: ARG001 — fixture chdirs; the path itself is unused
+    first: tuple[str, str],
+    second: tuple[str, str],
+) -> None:
+    """Both requested checks must execute, whichever order the source lists them."""
+    first_flag, first_marker = first
+    second_flag, second_marker = second
+
+    result = _invoke(first_flag, second_flag)
+
+    assert result.exit_code == 0, result.output
+    assert first_marker in result.output, f"{first_flag} did not run: {result.output!r}"
+    assert second_marker in result.output, f"{second_flag} did not run: {result.output!r}"
+
+
+def test_every_static_flag_runs_alone(project: Path) -> None:  # noqa: ARG001
+    """Sanity anchor: each marker is genuinely produced by its own flag.
+
+    Without this the matrix could pass vacuously if a marker leaked from an
+    unrelated code path.
+    """
+    for flag, marker in STATIC_CHECKS:
+        result = _invoke(flag)
+        assert result.exit_code == 0, f"{flag}: {result.output}"
+        assert marker in result.output, f"{flag} did not emit its marker: {result.output!r}"
+
+
+# ---------------------------------------------------------------------------
+# Exit codes: the worst outcome across the checks that ran
+# ---------------------------------------------------------------------------
+
+
+def test_failing_second_check_still_fails_the_run(project: Path) -> None:
+    """A passing check must not mask a failing one that ran after it."""
+    # own_001: a CREATE TABLE with no matching `ALTER … OWNER TO`.
+    (project / "confiture.yaml").write_text(
+        (project / "confiture.yaml").read_text().replace("relkinds: [m]", "relkinds: [r]")
+    )
+
+    result = _invoke("--check-imports", "--check-ownership-coverage")
+
+    assert "passed import check" in result.output
+    assert "Ownership coverage check failed" in result.output
+    assert result.exit_code == 1, result.output
+
+
+def test_failing_first_check_still_runs_the_second(project: Path) -> None:
+    """A failing check must not stop the rest of the run."""
+    (project / "confiture.yaml").write_text(
+        (project / "confiture.yaml").read_text().replace("relkinds: [m]", "relkinds: [r]")
+    )
+
+    result = _invoke("--check-ownership-coverage", "--check-imports")
+
+    assert "Ownership coverage check failed" in result.output
+    assert "passed import check" in result.output
+    assert result.exit_code == 1, result.output
+
+
+# ---------------------------------------------------------------------------
+# JSON: one envelope per run, single-check shapes preserved verbatim
+# ---------------------------------------------------------------------------
+
+
+def test_single_check_json_shape_is_unchanged(project: Path) -> None:  # noqa: ARG001
+    """One check still emits its own documented payload, not a wrapper."""
+    result = _invoke("--check-acls", "--format", "json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["check"] == "acl_coverage"
+    assert "checks" not in payload
+
+
+def test_composed_json_is_one_document_keyed_by_check(project: Path) -> None:  # noqa: ARG001
+    """Two checks emit a single parseable envelope holding both payloads."""
+    result = _invoke("--check-acls", "--check-imports", "--format", "json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)  # two documents would not parse
+    assert payload["status"] == "passed"
+    assert set(payload["checks"]) == {"acl_coverage", "imports"}
+    assert payload["checks"]["acl_coverage"]["check"] == "acl_coverage"
+
+
+def test_composed_json_reports_failed_status(project: Path) -> None:
+    (project / "confiture.yaml").write_text(
+        (project / "confiture.yaml").read_text().replace("relkinds: [m]", "relkinds: [r]")
+    )
+
+    result = _invoke("--check-imports", "--check-ownership-coverage", "--format", "json")
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+    assert payload["checks"]["ownership_coverage"]["violations"]
+
+
+# ---------------------------------------------------------------------------
+# Report modes do not compose (they have no gate semantics to compose with)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("report_flag", ["--list-patterns", "--list-unmigrated-bodies"])
+def test_report_modes_reject_composition(project: Path, report_flag: str) -> None:  # noqa: ARG001
+    result = _invoke(report_flag, "--check-acls")
+
+    assert result.exit_code == 5, result.output
+    assert report_flag in result.output
+    assert "--check-acls" in result.output
+
+
+# ---------------------------------------------------------------------------
+# The 0.37.0 --idempotent conflict guard is RETAINED this release (D2)
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_git_conflict_guard_is_retained(project: Path) -> None:  # noqa: ARG001
+    """Deliberately still rejecting: retired in 0.41.0, not here.
+
+    Composition makes this combination safe in principle, but the guard is the
+    only loud-failure net over the flags #181 fixed. Removing it in the same
+    release as the refactor would trade a known-good behaviour for an unproven
+    one — so it stays one release longer, on purpose.
+    """
+    result = _invoke("--idempotent", "--check-drift")
+
+    assert result.exit_code == 5, result.output
+    assert "--idempotent cannot be combined with --check-drift" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql-confiture"
-version = "0.39.0"
+version = "0.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
`migrate validate` was a flat chain of `if <flag>: … return` blocks evaluated in
source order. `--check-acls --check-imports` ran **only** the ACL check and
exited 0 — a green gate for a check that never ran. In a pre-commit hook or a CI
gate that is a silent false pass, the same failure class as 0.39.0's
`window_safe: true`. Ten-plus flag pairs were affected.

Ships **alone** by design: a 940-line dispatch refactor plus API changes across
nine `core/validation` handlers. Coupling it to anything means a rollback takes
the other work with it.

## What changed

- **Every requested check runs**, in the historical source order. The exit code
  is the worst outcome across them, so a passing check can no longer mask a
  failing one.
- **One config parse, at most one database connection** — and one SSH tunnel
  instead of one per check. A new lazy `ValidationContext` owns both; a run of
  purely static checks still never touches the database.
- **`--format json` emits one document.** A single check keeps its own payload
  byte-for-byte (every existing `migrate-validate-*.schema.json` holds); two or
  more are wrapped in the new `migrate-validate-composed.schema.json`.
- **JSON mode no longer short-circuits the git-accompaniment group.** Text mode
  aggregated all three sub-checks; JSON mode raised on the first failure, so a
  failing drift check meant accompaniment never ran. The one block that looked
  like a model for composition did not compose in the mode machine consumers use.
- **`--check-live-drift` finally honours `--ssh`**, which its help text has
  always advertised — it used `create_connection`, which has no tunnel support.
- **Report modes reject composition** (`--list-patterns`,
  `--list-unmigrated-bodies`), exit 5, naming both flags.
- **`tb_confiture_present` removed** from `migrate introspect --format json`,
  on schedule from 0.39.0's one-release deprecation window.

## What stayed deliberately wrong

`--idempotent` still refuses `--check-drift` / `--require-migration` /
`--require-migration-bodies` / `--require-grant-migration` even though
composition makes the combination work. That guard is the only loud-failure net
over exactly the flags #181 fixed; removing it in the same release as this
refactor would turn a loud error back into a silent skip if the refactor has a
bug. It retires in 0.41.0 — recorded in the error message, the CHANGELOG's
`Planned for 0.41.0` block, the guide, and a test docstring, so it cannot become
permanent by inattention.

## Blast-radius control

Registry order reproduces the old dispatch order exactly, so single-flag output
is byte-identical to 0.39.0. The nine handlers take `ctx=None` by default and
behave exactly as before when called that way, so the library API is additive —
only the CLI-level connection *patch target* moved (3 test sites).

## Verification

- 9502 passed, 79 skipped (baseline 9383) — 29 new composition tests, written
  and verified failing before any production code, with a sanity anchor proving
  each marker is genuinely produced by its own flag
- `ruff check` + `ruff format --check` + `ty check` clean
- `cargo clippy --locked` + `cargo fmt --check` clean
- 61 JSON-schema conformance tests, including one pinning that a **single**
  check does *not* emit the composed wrapper
- Adapter floor deliberately not bumped: `migrate validate` and
  `migrate introspect` are not in the contract's subcommand surface (verified
  against the table, not assumed)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)