### PR TITLE
0.41.0 — ledger probe (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-08-05
+
+The migration-ledger probe answers the question its callers are actually asking
+(#188), and the `--idempotent` conflict guard that 0.40.0 held back one release
+comes off.
+
+### ⚠️ Behaviour change
+
+- **A bare `tracking_table` is resolved through `search_path`** instead of
+  matching the name in any schema (#188). `core/ledger.py`'s probe ran
+  `information_schema.tables WHERE table_name = %s`, which is schema-blind: a
+  ledger in `staging` reported *present* to a session that would go on to read
+  `public`. The probe now runs `to_regclass`, which resolves exactly as the
+  query it is a precondition for. A **schema-qualified** `tracking_table` is
+  deliberately unchanged — see *Why the paths differ* below.
+
+  **What changes for you.** In one configuration, and only one: a bare
+  `tracking_table` whose ledger lives in a schema off the connection's
+  `search_path` now reports **absent** where it reported present. That
+  configuration never worked — the probe said present, `initialize()` skipped
+  the `CREATE TABLE`, and the very next statement failed with
+  `relation "tb_confiture" does not exist`. Every configuration that functioned
+  before gets the same answer it always did.
+
+  Consequences worth knowing:
+
+  - **Presence is not readability.** A role that can see the ledger but cannot
+    `SELECT` from it still reports present. Readability was considered and
+    dropped: `has_table_privilege` *raises* on the missing-`USAGE` case that
+    motivates the question, which would trade a wrong answer for a crash.
+  - **Relation kind is filtered.** Tables, partitioned tables, views and
+    foreign tables count — the kinds `information_schema.tables` reported.
+    `to_regclass` resolves every kind, so a sequence or index sharing the name
+    would otherwise have started reading as a ledger.
+  - **A privilege refusal on the bare path raises a typed `SQLError`**
+    (`SQL_001`), never a raw psycopg exception — the crash class #182 closed.
+
+- **`migrate up --auto-detect-baseline` refuses a ledger it cannot see.** Since
+  "absent" got stricter, the flag's trigger got a guard: if the configured name
+  does not resolve **but a relation of that name exists in another schema**, the
+  command exits 5 naming both, instead of building a second ledger and marking
+  every migration applied in it. It is the only path in `migrate up` that
+  rewrites migration history unprompted. Unaffected when the name is genuinely
+  unused, which is the state the flag exists for.
+
 ### Changed
+
+- **`migrate status` and `verify-checksums` report the ledger they read.**
+  `migrate status --format json` gains a top-level `resolved_table`;
+  `verify-checksums --format json` gains `summary.resolved_table`. Both name the
+  schema-qualified relation the session resolved to, beside the configured
+  `tracking_table` — which no longer identifies a relation on its own. Both
+  schemas set `additionalProperties: false`, so consumers pinned to the previous
+  schema must update to accept the new key. Text output stays quiet unless the
+  resolution is worth remarking on: the configured name, and a bare name landing
+  in `public`, say nothing new.
+
+- **An absent ledger says where it actually is.** `migrate status` (via
+  `hints[]`) and `verify-checksums` now sweep for the same name in other schemas
+  and name what they find. "Not present in this database" became a half-truth the
+  moment the probe got stricter.
 
 - **The `--idempotent` conflict guard is retired.** `migrate validate
   --idempotent` now composes with `--check-drift`, `--require-migration`,
@@ -19,6 +79,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exposure before its safety net came off. Both checks now run; the exit code is
   the worse of the two. Scripts that split the flags across two invocations to
   work around the rejection can merge them, and save a config parse.
+
+### Why the paths differ
+
+Converting the schema-qualified probe too would be tidier and is wrong.
+`to_regclass('hidden.tb_secret')` **raises** `permission denied for schema
+hidden` for a role without `USAGE`, where the `information_schema` query returns
+cleanly — measured both ways on PostgreSQL 17.8. A qualified name already
+filters on schema correctly, so the conversion would buy nothing and would put
+an unhandled psycopg exception on the ledger path that `_migrator/state.py` uses
+whenever `tracking_table` is qualified. Two queries, deliberately.
+
+### Contract
+
+No fraisier adapter minimum-version bump. `migrate up` is on the adapter's
+subcommand surface, but the new refusal fires only under
+`--auto-detect-baseline`, which the adapter does not pass, and the probe change
+is a no-op for every configuration that worked before. Recorded as a behaviour
+advisory in
+[the adapter contract](docs/reference/fraisier-adapter-contract.md#subcommand-surface).
 
 ## [0.40.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Planned for 0.41.0
+### Changed
 
-- **Retire the `--idempotent` conflict guard.** `migrate validate --idempotent`
-  still refuses `--check-drift` / `--require-migration` /
-  `--require-migration-bodies` / `--require-grant-migration` (exit 5), even
-  though 0.40.0's composition refactor makes the combination work. The guard is
-  held one release deliberately: it is the only loud-failure net over exactly
-  the flags #181 fixed, and removing it in the same release as a 940-line
-  dispatch refactor would turn a loud error back into a silent skip if the
-  refactor has a bug. Ships with phase 05 (#188).
+- **The `--idempotent` conflict guard is retired.** `migrate validate
+  --idempotent` now composes with `--check-drift`, `--require-migration`,
+  `--require-migration-bodies` and `--require-grant-migration` instead of
+  rejecting them with exit 5. The guard dates to 0.37.0, when the dispatch ran
+  the git branch and silently skipped idempotency (#181) — a loud error was the
+  right answer then. 0.40.0's composition refactor made the combination work,
+  and the guard was held one release past it so the refactor got production
+  exposure before its safety net came off. Both checks now run; the exit code is
+  the worse of the two. Scripts that split the flags across two invocations to
+  work around the rejection can merge them, and save a config parse.
 
 ## [0.40.0] - 2026-08-05
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.40.0
+**Version**: 0.41.0
 **Last Updated**: 2026-08-05
 **Current Status**: Production-Ready
 
@@ -959,7 +959,7 @@ When stuck, ask:
 ---
 
 **Last Updated**: 2026-08-05
-**Version**: 0.40.0
+**Version**: 0.41.0
 
 ---
 

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -55,19 +55,20 @@ What this means in practice:
 - **Order is unchanged.** Checks run in the order the old dispatch listed them,
   so single-flag output is byte-for-byte what 0.39.0 produced.
 
-Two combinations are rejected loudly instead of composed:
+One combination is rejected loudly instead of composed:
 
 | Combination | Exit | Why |
 |---|---|---|
 | `--list-patterns` or `--list-unmigrated-bodies` with anything else | 5 | Report modes. Both always exit 0, so there is no result to compose into a gate decision. |
-| `--idempotent` with `--check-drift` / `--require-migration` / `--require-migration-bodies` / `--require-grant-migration` | 5 | Retained from 0.37.0 for one more release. **Retires in 0.41.0.** |
 
-That last row is a deliberate inconsistency, not an oversight. The guard is
-currently the only loud-failure net over exactly the flag combinations #181
-fixed. Removing it in the same release as a 940-line dispatch refactor would
-convert a loud error straight back into a silent skip if the refactor has a bug
-— the regression #181 exists to prevent. It comes off in 0.41.0, after a
-release of production exposure.
+`--idempotent` composes with the git checks **from 0.41.0**. It was rejected
+alongside `--check-drift` / `--require-migration` / `--require-migration-bodies`
+/ `--require-grant-migration` in 0.37.0 through 0.40.0: the pre-composition
+dispatch ran the git branch and silently skipped idempotency, so a loud error
+was the only honest answer (#181). Composition landed in 0.40.0 and the guard
+was held one release past it so the refactor got production exposure before its
+safety net came off. Both checks now run and the exit code is the worse of the
+two.
 
 ## `--idempotent`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1241,12 +1241,16 @@ gate for a check that never ran (#187).
   [`migrate-validate-composed.schema.json`](./json-schemas/migrate-validate-composed.schema.json),
   keyed by check name.
 
-Two combinations are rejected loudly rather than composed:
+One combination is rejected loudly rather than composed:
 
 | Combination | Exit | Why |
 |---|---|---|
 | `--list-patterns` or `--list-unmigrated-bodies` with anything else | 5 | Report modes: they always exit 0, so there is no result to compose. |
-| `--idempotent` with `--check-drift` / `--require-migration` / `--require-migration-bodies` / `--require-grant-migration` | 5 | Retained from 0.37.0 (#181) for one release; **retires in 0.41.0**, once composition has had production exposure. |
+
+`--idempotent` was also rejected alongside `--check-drift` /
+`--require-migration` / `--require-migration-bodies` /
+`--require-grant-migration` in 0.37.0 through 0.40.0 (#181). That guard is
+**retired in 0.41.0**: the combination composes like any other.
 
 #### Recognized Migration File Patterns
 
@@ -1687,9 +1691,10 @@ migrations the run succeeds with a `message` explaining that nothing changed
 since the base ref — deliberately distinct from the "directory contains no
 files" message, since the remedies differ.
 
-⚠️ `--idempotent` cannot be combined with `--check-drift`,
-`--require-migration`, `--require-migration-bodies`, or
-`--require-grant-migration`: only one check would run. Invoke them separately.
+Since 0.41.0 `--idempotent` composes with `--check-drift`,
+`--require-migration`, `--require-migration-bodies` and
+`--require-grant-migration`. Earlier versions rejected those combinations with
+exit 5, because only one of the two checks would have run.
 
 #### Examples
 

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -51,6 +51,26 @@ confiture migrate <subcommand> [<args>] --no-config --format json --output <file
 | `preflight`        | `migrate preflight`                        | [migrate-preflight](json-schemas/migrate-preflight.schema.json) |
 | `describe`         | `confiture --version` (synthesised)        | — (last whitespace token is the version) |
 
+> ℹ️ **Behaviour advisory — ledger-existence probe, 0.41.0 (#188).** Every
+> command above that distinguishes "no ledger" from "empty ledger" — `current`,
+> `up`, `verify`, `preflight` — goes through one probe, and that probe changed.
+> A **bare** `tracking_table` (the `tb_confiture` default) is now resolved
+> through `search_path` instead of matching the name in any schema; a
+> schema-qualified one is unchanged.
+>
+> **No minimum-version bump, and the adapter needs no change.** The answer moves
+> in exactly one configuration: a bare name whose ledger sits in a schema *off*
+> the connection's `search_path`. That configuration never worked — the probe
+> reported present and the next statement failed with `relation "tb_confiture"
+> does not exist` (measured on PostgreSQL 17.8). For every configuration that
+> functioned before, the probe returns what it always did. `migrate up` gained a
+> refusal on this state, but only under `--auto-detect-baseline`, which the
+> adapter does not pass.
+>
+> The adapter-consumed fields and exit codes are untouched. `migrate status` and
+> `verify-checksums` gained a `resolved_table` key naming the relation actually
+> read; neither command is on this surface.
+
 The adapter-consumed fields per command:
 
 - **current** — `revision` (the head, `null` when none applied).

--- a/docs/reference/json-schemas/migrate-status.schema.json
+++ b/docs/reference/json-schemas/migrate-status.schema.json
@@ -41,6 +41,10 @@
           "type": ["string", "null"],
           "description": "Configured tracking table name. NULL when no --config was supplied."
         },
+        "resolved_table": {
+          "type": ["string", "null"],
+          "description": "The schema-qualified relation the configured name resolved to for this session, e.g. \"public.tb_confiture\" (0.41.0, #188). A bare tracking_table resolves through search_path, so this is how a consumer learns which of several same-named tables was read. NULL when no --config was supplied, when the database was unreachable, or when the name resolves to nothing. When the ledger was absent, hints[] additionally names any schema that does hold a relation of that name."
+        },
         "applied": {
           "type": "array",
           "items": { "type": "string" },

--- a/docs/reference/json-schemas/verify-checksums.schema.json
+++ b/docs/reference/json-schemas/verify-checksums.schema.json
@@ -37,7 +37,11 @@
         },
         "tracking_table": {
           "type": "string",
-          "description": "The resolved ledger name actually queried — the configured tracking_table, not necessarily the tb_confiture default."
+          "description": "The ledger name as configured — the project's tracking_table, not necessarily the tb_confiture default. May be bare or schema-qualified; see resolved_table for what it actually resolved to."
+        },
+        "resolved_table": {
+          "type": ["string", "null"],
+          "description": "The schema-qualified relation the ledger name resolved to for this session, e.g. \"public.tb_confiture\" (0.41.0, #188). A bare tracking_table resolves through search_path, so this is how a consumer learns which of several same-named tables was actually read. Null when the ledger did not resolve — only emitted so under --allow-uninitialized, since otherwise an absent ledger raises PRECON_1001."
         }
       }
     },

--- a/docs/reference/tracking-table.md
+++ b/docs/reference/tracking-table.md
@@ -51,6 +51,51 @@ migration:
 
 If the name is schema-qualified, Confiture creates the table in that schema. Otherwise, it creates it in the connection's default `search_path`.
 
+### How Confiture decides the ledger exists (0.41.0)
+
+The answer depends on whether the configured name is schema-qualified, and the
+two paths ask deliberately different questions (#188):
+
+| Configured name | Question asked | Answers "yes" for |
+|---|---|---|
+| bare — `tb_confiture` | `to_regclass('tb_confiture')` — resolves through `search_path` | the one relation this session would actually read |
+| qualified — `audit.tb_confiture` | `information_schema.tables` filtered on schema **and** name | that exact table |
+
+Before 0.41.0 the bare form matched the name in *any* schema. A ledger in
+`staging` therefore reported present to a session whose `search_path` did not
+include `staging` — and the very next statement failed with
+`relation "tb_confiture" does not exist`. The bare probe now agrees with the
+queries it is a precondition for.
+
+Two consequences worth knowing:
+
+- **Presence is not readability.** A role that can see the table but cannot
+  `SELECT` from it still gets "present". Deriving readability was considered
+  and dropped: `has_table_privilege` *raises* on the missing-`USAGE` case that
+  motivates the question, so it would have traded a wrong answer for a crash.
+- **Relation kind matters.** A table, partitioned table, view or foreign table
+  counts — the kinds `information_schema.tables` reported. A sequence or index
+  that happens to share the name does not.
+
+### `--auto-detect-baseline` refuses a ledger it cannot see
+
+Because "absent" got stricter, `migrate up --auto-detect-baseline` gained a
+guard. If the configured name does not resolve for this session **but a
+relation of that name exists in some other schema**, the command refuses with
+exit 5 and names both:
+
+```text
+--auto-detect-baseline: 'tb_confiture' does not resolve for this session, but a
+relation of that name exists in staging.tb_confiture. Refusing to auto-baseline:
+doing so would create a second ledger and mark every migration applied in it.
+```
+
+This is the only path in `migrate up` that rewrites migration history without
+being asked to, so it stops rather than guesses. Resolve it by pointing at the
+ledger you meant — set `migration.tracking_table` to the qualified name, or put
+its schema on the connection's `search_path` — and re-run. If the other relation
+is unrelated, drop or rename it first.
+
 ### If you renamed the table before 0.39.0
 
 A set of messages and one query hardcoded the `tb_confiture` default rather than resolving the configured name (#190). If you configured `tracking_table` and are upgrading from an earlier release, note what changed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.40.0"
+version = "0.41.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/admin.py
+++ b/python/confiture/cli/commands/admin.py
@@ -45,6 +45,7 @@ def _checksum_payload(
     checked: int,
     mismatches: list,
     tracking_table: str,
+    resolved_table: str | None = None,
     fixed: int | None = None,
 ) -> dict:
     """Build ``verify-checksums --format json`` output (#189).
@@ -53,6 +54,11 @@ def _checksum_payload(
     text and JSON cannot describe different outcomes. Reuses the shared issue
     object (``issue-object.schema.json``) rather than inventing a mismatch
     shape, matching the house envelope `migrate verify` established.
+
+    ``tracking_table`` is what the operator configured; ``resolved_table`` is
+    what that name resolved to for this session (#188). They differ whenever a
+    bare name is involved, so both are always emitted rather than one
+    conditionally — a consumer should not have to guess which it is holding.
     """
     payload: dict = {
         "ok": not mismatches,
@@ -61,6 +67,7 @@ def _checksum_payload(
             "checked": checked,
             "mismatched": len(mismatches),
             "tracking_table": tracking_table,
+            "resolved_table": resolved_table,
         },
         "issues": [
             {
@@ -306,7 +313,7 @@ def verify_checksums(
         MigrationChecksumVerifier,
     )
     from confiture.core.connection import create_connection, load_config
-    from confiture.core.ledger import ledger_exists
+    from confiture.core.ledger import find_ledger_relations, notable_resolution, probe_ledger
 
     if output_format not in ("text", "json"):
         fail(
@@ -327,7 +334,19 @@ def verify_checksums(
         # "no table", that would be indistinguishable from "no mismatches" —
         # the absent-vs-empty conflation this guard exists to prevent.
         tracking_table = _get_tracking_table(config_data)
-        if not ledger_exists(conn, tracking_table):
+        ledger = probe_ledger(conn, tracking_table)
+        if not ledger.exists:
+            # Since 0.41.0 a bare name is resolved through search_path, so
+            # "absent" can mean "present, but not where this session looks".
+            # Saying which is the difference between an actionable message and
+            # a puzzle (#188).
+            _elsewhere = find_ledger_relations(conn, tracking_table)
+            _note = (
+                f" A relation of that name does exist in {', '.join(_elsewhere)}, but this "
+                "connection's search_path does not reach it."
+                if _elsewhere
+                else ""
+            )
             conn.close()
             if allow_uninitialized:
                 if json_mode:
@@ -340,6 +359,7 @@ def verify_checksums(
                             checked=0,
                             mismatches=[],
                             tracking_table=tracking_table,
+                            resolved_table=None,
                         ),
                         None,
                         console,
@@ -347,12 +367,13 @@ def verify_checksums(
                     return
                 console.print(
                     f"[yellow]ℹ️  No migration ledger found (`{tracking_table}` is not "
-                    "present in this database) — 0 migrations recorded, nothing to "
+                    f"present in this database){_note} — 0 migrations recorded, nothing to "
                     "verify.[/yellow]"
                 )
                 return
             raise DatabaseNotInitializedError(
-                f"No migration ledger found: `{tracking_table}` is not present in this database",
+                f"No migration ledger found: `{tracking_table}` is not present in "
+                f"this database.{_note}",
                 resolution_hint=_NO_LEDGER_HINT,
             )
 
@@ -376,12 +397,15 @@ def verify_checksums(
                         checked=checked,
                         mismatches=[],
                         tracking_table=tracking_table,
+                        resolved_table=ledger.resolved_name,
                     ),
                     None,
                     console,
                 )
             else:
-                console.print("[green]✅ All migration checksums verified![/green]")
+                _read = notable_resolution(tracking_table, ledger.resolved_name)
+                _suffix = f" (read `{_read}`)" if _read else ""
+                console.print(f"[green]✅ All migration checksums verified!{_suffix}[/green]")
             conn.close()
             return
 
@@ -396,6 +420,7 @@ def verify_checksums(
                     checked=checked,
                     mismatches=mismatches,
                     tracking_table=tracking_table,
+                    resolved_table=ledger.resolved_name,
                     fixed=updated,
                 ),
                 None,

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -584,14 +584,16 @@ def migrate_validate(
         appear in the same invocation.
 
       Checks compose: pass as many as you like and all of them run, sharing one
-      config parse and one database connection. Two exceptions, both loud:
+      config parse and one database connection. The exit code is the worst
+      outcome across them. One exception, and it is loud:
         --list-patterns / --list-unmigrated-bodies  report modes; they always exit
                             0, so there is no result to compose. Combining either
                             with anything else is rejected (exit 5).
-        --idempotent        still refuses --check-drift / --require-migration /
-                            --require-migration-bodies / --require-grant-migration.
-                            Deliberate for 0.40.0 only; the guard retires in 0.41.0
-                            once the composition refactor has production exposure.
+
+      --idempotent composes with the git checks from 0.41.0. It was rejected
+      alongside --check-drift / --require-migration / --require-migration-bodies /
+      --require-grant-migration in 0.37.0–0.40.0, because the pre-composition
+      dispatch ran the git branch and silently skipped idempotency (#181).
 
     JSON SCHEMA:
       See docs/reference/json-schemas.md for the JSON output schemas:
@@ -613,38 +615,6 @@ def migrate_validate(
             raise ConfigurationError(
                 f"Invalid format: {format_output}. Use 'text', 'json', or 'csv'."
             )
-
-        # #187/D2: the 0.37.0 conflict guard is RETAINED for 0.40.0 and retires
-        # in 0.41.0, one release after the composition refactor. Composition
-        # makes the combination safe in principle, but this guard is the only
-        # loud-failure net over exactly the flags #181 fixed; dropping it in the
-        # same release as the refactor would convert a loud error straight back
-        # into a silent skip if the refactor has a bug. Recorded here and in the
-        # 0.41.0 CHANGELOG so the temporary inconsistency does not become
-        # permanent by inattention.
-        if idempotent:
-            _conflicting = [
-                name
-                for name, on in (
-                    ("--check-drift", check_drift),
-                    ("--require-migration", require_migration),
-                    ("--require-migration-bodies", require_migration_bodies),
-                    ("--require-grant-migration", require_grant_migration),
-                )
-                if on
-            ]
-            if _conflicting:
-                raise ConfigurationError(
-                    f"--idempotent cannot be combined with {', '.join(_conflicting)} "
-                    "in 0.40.0. This combination is held back one release while the "
-                    "check-composition refactor gets production exposure; it is "
-                    "allowed from 0.41.0.",
-                    resolution_hint=(
-                        "Run the checks as separate invocations, e.g. "
-                        "`confiture migrate validate --idempotent` then "
-                        f"`confiture migrate validate {_conflicting[0]}`."
-                    ),
-                )
 
         # --list-patterns is a read-only catalog query with no config or
         # migrations directory behind it, so its options are assembled without

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -177,6 +177,10 @@ def migrate_status(
         db_error: str | None = None
         tracking_table_absent: bool = False
         status_tracking_table: str | None = None
+        # What the configured name actually resolved to for this session, and
+        # (when it did not) where a relation of that name does live (#188).
+        status_resolved_table: str | None = None
+        ledger_elsewhere: list[str] = []
         # status connects only on an *intentional* source: a --database-url
         # flag, --no-config, an explicit --config, or the canonical
         # CONFITURE_DATABASE_URL. A merely-ambient DATABASE_URL must NOT force a
@@ -206,10 +210,29 @@ def migrate_status(
 
                 config_data = _status_config_data
                 status_tracking_table = _get_tracking_table(config_data)
+                from confiture.core.ledger import find_ledger_relations, probe_ledger
+                from confiture.exceptions import ConfiturError
+
                 conn = create_connection(config_data)
                 migrator = Migrator(connection=conn, migration_table=status_tracking_table)
                 tracking_table_was_present = migrator.tracking_table_exists()
+                if not tracking_table_was_present:
+                    # A bare name resolves through search_path since 0.41.0, so
+                    # "absent" no longer implies "nowhere in this database".
+                    # Reporting only the first half sends the operator looking
+                    # for a table that is sitting right there (#188).
+                    ledger_elsewhere = find_ledger_relations(conn, status_tracking_table)
                 migrator.initialize()
+                # After initialize, so this names the ledger the run will read
+                # rather than the one it found (or did not) a moment earlier.
+                # Reporting metadata only: a probe refused for lack of
+                # privilege must not turn a working status into "could not
+                # connect to database". Narrow on purpose — a NameError in the
+                # probe still surfaces rather than degrading to None.
+                try:
+                    status_resolved_table = probe_ledger(conn, status_tracking_table).resolved_name
+                except ConfiturError:
+                    status_resolved_table = None
                 applied_versions = set(migrator.get_applied_versions())
                 for row in migrator.get_applied_migrations_with_timestamps():
                     applied_at_by_version[row["version"]] = row["applied_at"]
@@ -280,9 +303,22 @@ def migrate_status(
                 hints_list=status_hints,
                 format_=output_format,
             )
+            if ledger_elsewhere:
+                # The likeliest cause of a surprising "all pending", and one an
+                # operator cannot diagnose from the ledger name alone.
+                _emit_hint(
+                    f"`{status_tracking_table}` does not resolve on this "
+                    f"connection's search_path, but a relation of that name "
+                    f"exists in {', '.join(ledger_elsewhere)}. Qualify "
+                    "`migration.tracking_table` or adjust search_path if that "
+                    "is the ledger you meant.",
+                    hints_list=status_hints,
+                    format_=output_format,
+                )
         if output_format == "json":
             result: dict[str, Any] = {
                 "tracking_table": status_tracking_table,
+                "resolved_table": status_resolved_table,
                 "applied": applied_list,
                 "pending": pending_list,
                 "current": current_version,

--- a/python/confiture/cli/commands/migrate_core.py
+++ b/python/confiture/cli/commands/migrate_core.py
@@ -898,6 +898,36 @@ def migrate_up(
 
         # Auto-detect baseline pre-flight (before initialize so we can check absence)
         if auto_detect_baseline and not migrator.tracking_table_exists():
+            # #188: "absent" got stricter. It used to mean "no table of this
+            # name in any schema"; it now means "this session cannot resolve
+            # one", which is the right precondition for reading the ledger and
+            # the wrong trigger for rebuilding it. A ledger parked in a schema
+            # off `search_path` reads absent here, and auto-baseline would
+            # answer by creating a second one and marking every migration
+            # applied in it. This is the only path in the command that can
+            # rewrite migration history unprompted, so it refuses rather than
+            # guesses. `LedgerProbe.resolved_name` cannot answer this — it is
+            # None exactly when the probe says absent.
+            from confiture.core.ledger import find_ledger_relations
+
+            _elsewhere = find_ledger_relations(conn, _get_tracking_table(config_data))
+            if _elsewhere:
+                from confiture.exceptions import ConfigurationError
+
+                conn.close()
+                raise ConfigurationError(
+                    f"--auto-detect-baseline: {_get_tracking_table(config_data)!r} does not "
+                    f"resolve for this session, but a relation of that name exists in "
+                    f"{', '.join(_elsewhere)}. Refusing to auto-baseline: doing so would "
+                    f"create a second ledger and mark every migration applied in it.",
+                    resolution_hint=(
+                        "Point at the existing ledger — set `migration.tracking_table` to "
+                        f"{_elsewhere[0]!r}, or put its schema on the connection's "
+                        "search_path — then re-run. If the ledger really is meant to be "
+                        "new, drop or rename the other relation first."
+                    ),
+                )
+
             _resolved_snapshots_dir = snapshots_dir_up or Path("db/schema_history")
             if not _resolved_snapshots_dir.exists():
                 error_console.print(

--- a/python/confiture/core/_migrator/state.py
+++ b/python/confiture/core/_migrator/state.py
@@ -14,7 +14,7 @@ from psycopg import sql as pgsql
 
 from confiture.core.hooks.context import ExecutionContext
 from confiture.core.ledger import ledger_exists
-from confiture.exceptions import MigrationError, SQLError
+from confiture.exceptions import MigrationError
 
 if TYPE_CHECKING:
     from confiture.core._migrator.engine import Migrator
@@ -29,6 +29,13 @@ def _qualified_table(migrator: Migrator) -> str:
     ``Migrator`` splits the configured ``tracking_table`` into
     ``_table_schema`` / ``_table_base``; :func:`ledger_exists` takes the
     combined form.
+
+    Note:
+        The name is qualified only when the *configuration* was. With the
+        default ``tb_confiture`` this returns a bare name, so the probe takes
+        :mod:`confiture.core.ledger`'s ``search_path``-resolving path — the
+        same resolution ``migrator._table_ident`` gets, which is what keeps the
+        existence check and the DDL that follows it talking about one table.
     """
     if migrator._table_schema is not None:
         return f"{migrator._table_schema}.{migrator._table_base}"
@@ -99,16 +106,10 @@ def initialize(migrator: Migrator) -> None:
         migrator.connection.commit()
     except Exception as e:
         migrator.connection.rollback()
-        if isinstance(e, SQLError):
-            raise MigrationError(
-                f"Failed to initialize migrations table: {e}",
-                resolution_hint="Check database permissions to CREATE TABLE in the target schema",
-            ) from e
-        else:
-            raise MigrationError(
-                f"Failed to initialize migrations table: {e}",
-                resolution_hint="Check database permissions to CREATE TABLE in the target schema",
-            ) from e
+        raise MigrationError(
+            f"Failed to initialize migrations table: {e}",
+            resolution_hint="Check database permissions to CREATE TABLE in the target schema",
+        ) from e
 
 
 def is_applied(migrator: Migrator, version: str) -> bool:

--- a/python/confiture/core/ledger.py
+++ b/python/confiture/core/ledger.py
@@ -10,17 +10,33 @@ This module holds the single implementation of that check, callable with a raw
 connection so that callers which never build a :class:`Migrator` — such as
 ``verify-checksums`` — do not have to reach into ``core._migrator``.
 
-Caveat: for a bare (unqualified) table name the probe matches the table in
-*any* schema, and respects neither ``search_path`` nor schema privileges.
-``to_regclass('tb_confiture') IS NOT NULL`` would be strictly more correct, but
-switching to it changes behaviour for ``migrate status``,
-``migrate up --auto-baseline`` and ``MigratorSession.current()``, so it is
-tracked as a follow-up rather than changed here.
+**The two paths are deliberately different queries** (#188).
+
+A *bare* name resolves through ``search_path``, exactly as the query the probe
+is a precondition for will.  Before 0.41.0 it matched
+``information_schema.tables WHERE table_name = %s``, which is schema-blind: a
+ledger in ``staging`` reported present to a session that would go on to read
+``public``, and the two disagreed silently.
+
+A *qualified* name stays on ``information_schema``.  Converting it too would be
+tidier and is wrong: ``to_regclass('hidden.tb_secret')`` **raises**
+``permission denied for schema hidden`` for a role without ``USAGE``, where the
+``information_schema`` query returns cleanly (both measured on PostgreSQL 17.8).
+A qualified name already filters on schema correctly, so the conversion would
+buy nothing and would put an unhandled psycopg exception on the hot ledger path
+— the crash class #182 and 0.37.0 closed.
+
+The asymmetry is the point, not an oversight.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
+
+import psycopg
+
+from confiture.exceptions import SQLError
 
 _QUALIFIED_SQL = """
     SELECT EXISTS (
@@ -29,37 +45,155 @@ _QUALIFIED_SQL = """
     )
 """
 
+# `to_regclass` resolves *any* relation kind, so a sequence or an index named
+# `tb_confiture` would answer "the ledger exists".  The relkinds below are the
+# ones `information_schema.tables` reported — ordinary and partitioned tables,
+# views, foreign tables — so the only behaviour this conversion changes is
+# search_path awareness.
 _BARE_SQL = """
-    SELECT EXISTS (
-        SELECT FROM information_schema.tables
-        WHERE table_name = %s
-    )
+    SELECT n.nspname, c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.oid = to_regclass(%s)
+      AND c.relkind IN ('r', 'p', 'v', 'f')
 """
+
+# Schema-blind on purpose: this answers "does this name exist anywhere?", the
+# question `LedgerProbe` deliberately stopped answering.  `pg_class` rather than
+# `information_schema` so it does not depend on table privileges.
+_ANYWHERE_SQL = """
+    SELECT n.nspname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = %s
+      AND c.relkind IN ('r', 'p', 'v', 'f')
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    ORDER BY n.nspname
+"""
+
+
+@dataclass(frozen=True)
+class LedgerProbe:
+    """The answer to "is the ledger there, and which one did I find?".
+
+    Attributes:
+        exists: Whether a ledger relation resolves for this session.
+        resolved_name: The schema-qualified relation the name resolved to, or
+            ``None`` when it did not resolve.  For a bare name this is the
+            probe's real value: it lets a command report *reading
+            ``staging.tb_confiture``* instead of leaving the operator to guess
+            which of two same-named tables the session picked.
+
+    Note:
+        ``exists`` is presence, not readability.  A role that can see a table
+        in ``information_schema`` but cannot ``SELECT`` from it gets
+        ``exists=True``.  Readability was considered and dropped: the obvious
+        implementation, ``has_table_privilege``, raises on exactly the
+        missing-``USAGE`` case that motivates the question.
+    """
+
+    exists: bool
+    resolved_name: str | None = None
+
+
+def probe_ledger(connection: Any, table: str) -> LedgerProbe:
+    """Resolve the migration ledger for this session.
+
+    Args:
+        connection: An open DB-API connection (psycopg3).
+        table: Bare (``tb_confiture``) or schema-qualified
+            (``public.tb_confiture``) table name.  A bare name resolves through
+            ``search_path``; a qualified name filters on the schema it names.
+
+    Returns:
+        A :class:`LedgerProbe` carrying presence and the resolved relation.
+
+    Raises:
+        SQLError: The bare-name probe was refused for lack of privilege.  Raw
+            psycopg exceptions never escape this function.
+
+    Example:
+        >>> probe_ledger(conn, "tb_confiture")
+        LedgerProbe(exists=True, resolved_name='public.tb_confiture')
+    """
+    schema, _, base = table.partition(".")
+    if base:
+        return _probe_qualified(connection, schema, base)
+    return _probe_bare(connection, schema)
 
 
 def ledger_exists(connection: Any, table: str) -> bool:
     """Return True when the migration ledger table exists.
 
+    The boolean face of :func:`probe_ledger`, kept so callers that only need a
+    yes/no need not unpack a dataclass.
+
     Args:
         connection: An open DB-API connection (psycopg3).
-        table: Bare (``tb_confiture``) or schema-qualified
-            (``public.tb_confiture``) table name.  A qualified name filters on
-            the schema; a bare name matches the table in any schema.
+        table: Bare or schema-qualified table name.
 
     Returns:
-        True if the table is present, False otherwise.
+        True if the ledger is present, False otherwise.
 
     Example:
         >>> ledger_exists(conn, "tb_confiture")
         False
     """
-    schema, _, base = table.partition(".")
-    if base:
-        sql, params = _QUALIFIED_SQL, (schema, base)
-    else:
-        sql, params = _BARE_SQL, (schema,)
+    return probe_ledger(connection, table).exists
 
+
+def find_ledger_relations(connection: Any, table: str) -> list[str]:
+    """Every schema holding a relation of this name, qualified, sorted.
+
+    Schema-blind by design — it is the sweep that turns "the ledger did not
+    resolve" into "…but there is one in ``staging``", which is the difference
+    between ``migrate up --auto-detect-baseline`` refusing and it quietly
+    building a second ledger.  A qualified *table* is swept by its base name,
+    since the whole point is to find copies outside the named schema.
+
+    Args:
+        connection: An open DB-API connection (psycopg3).
+        table: Bare or schema-qualified table name.
+
+    Returns:
+        ``["archive.tb_confiture", "staging.tb_confiture"]``-style names, empty
+        when the name is unused.
+    """
+    base = table.rpartition(".")[2]
     with connection.cursor() as cursor:
-        cursor.execute(sql, params)
+        cursor.execute(_ANYWHERE_SQL, (base,))
+        return [f"{row[0]}.{base}" for row in cursor.fetchall()]
+
+
+def _probe_qualified(connection: Any, schema: str, base: str) -> LedgerProbe:
+    with connection.cursor() as cursor:
+        cursor.execute(_QUALIFIED_SQL, (schema, base))
         row = cursor.fetchone()
-        return bool(row[0]) if row else False
+    if not (row and row[0]):
+        return LedgerProbe(exists=False)
+    return LedgerProbe(exists=True, resolved_name=f"{schema}.{base}")
+
+
+def _probe_bare(connection: Any, name: str) -> LedgerProbe:
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(_BARE_SQL, (name,))
+            row = cursor.fetchone()
+    except psycopg.errors.InsufficientPrivilege as e:
+        # Narrow on purpose.  A bare name cannot reach the missing-USAGE case
+        # (search_path silently skips schemas the role cannot use), so this
+        # covers the residue — EXECUTE revoked on `to_regclass`, say.  Catching
+        # anything broader here would swallow real defects in this module.
+        raise SQLError(
+            _BARE_SQL,
+            (name,),
+            e,
+            resolution_hint=(
+                f"The current role may not resolve {name!r}. Grant it the "
+                "privileges the migration ledger needs, or connect as the role "
+                "that owns it."
+            ),
+        ) from e
+    if not row:
+        return LedgerProbe(exists=False)
+    return LedgerProbe(exists=True, resolved_name=f"{row[0]}.{row[1]}")

--- a/python/confiture/core/ledger.py
+++ b/python/confiture/core/ledger.py
@@ -151,6 +151,11 @@ def find_ledger_relations(connection: Any, table: str) -> list[str]:
     building a second ledger.  A qualified *table* is swept by its base name,
     since the whole point is to find copies outside the named schema.
 
+    The name is split exactly as :func:`probe_ledger` splits it — on the *first*
+    dot.  The two have to agree: this function's answer is only meaningful as a
+    follow-up to that one, and a sweep for a different relation than the one
+    probed would report look-alikes that are not look-alikes at all.
+
     Args:
         connection: An open DB-API connection (psycopg3).
         table: Bare or schema-qualified table name.
@@ -159,7 +164,8 @@ def find_ledger_relations(connection: Any, table: str) -> list[str]:
         ``["archive.tb_confiture", "staging.tb_confiture"]``-style names, empty
         when the name is unused.
     """
-    base = table.rpartition(".")[2]
+    schema, _, qualified_base = table.partition(".")
+    base = qualified_base or schema
     with connection.cursor() as cursor:
         cursor.execute(_ANYWHERE_SQL, (base,))
         return [f"{row[0]}.{base}" for row in cursor.fetchall()]

--- a/python/confiture/core/ledger.py
+++ b/python/confiture/core/ledger.py
@@ -165,6 +165,27 @@ def find_ledger_relations(connection: Any, table: str) -> list[str]:
         return [f"{row[0]}.{base}" for row in cursor.fetchall()]
 
 
+def notable_resolution(configured: str, resolved: str | None) -> str | None:
+    """The resolved name, but only when it is worth telling the operator.
+
+    Two resolutions carry no information: the one that matches what they
+    configured, and a bare name landing in ``public``, which is the documented
+    default. Printing either on every run would bury the case that *does*
+    matter — a bare name resolving somewhere unexpected — in noise.
+
+    Args:
+        configured: The ``tracking_table`` value as written in config.
+        resolved: :attr:`LedgerProbe.resolved_name`, or None.
+
+    Returns:
+        The resolved name when it is neither the configured name nor its
+        ``public`` default, else None.
+    """
+    if resolved is None or resolved in (configured, f"public.{configured}"):
+        return None
+    return resolved
+
+
 def _probe_qualified(connection: Any, schema: str, base: str) -> LedgerProbe:
     with connection.cursor() as cursor:
         cursor.execute(_QUALIFIED_SQL, (schema, base))

--- a/tests/integration/test_ledger_probe.py
+++ b/tests/integration/test_ledger_probe.py
@@ -1,0 +1,292 @@
+"""What the ledger probe answers against a real PostgreSQL (#188).
+
+``tests/unit/test_ledger.py`` pins the SQL shape. This file pins the semantics,
+which is where the bug lived: a bare ``tb_confiture`` matched the table in *any*
+schema, so the probe and the query it was a precondition for could disagree.
+
+Every scenario here is provisioned in its own schema inside the shared test
+database and torn down after, so the tests are order-independent and leave no
+residue. The two role-based scenarios skip cleanly where the connection cannot
+create a role — that is a permission of the environment, not a gap in cover.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import psycopg
+import pytest
+
+from confiture.core.ledger import find_ledger_relations, probe_ledger
+
+
+@pytest.fixture
+def conn(test_db_url: str) -> Iterator[psycopg.Connection]:
+    """An autocommit connection; each test owns its own schemas."""
+    try:
+        connection = psycopg.connect(test_db_url, autocommit=True)
+    except psycopg.OperationalError as e:  # pragma: no cover - environment gate
+        pytest.skip(f"PostgreSQL not available: {e}")
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def tag() -> str:
+    """A per-test suffix so parallel runs never collide on schema names."""
+    return uuid.uuid4().hex[:10]
+
+
+def _make_ledger(conn: psycopg.Connection, schema: str, name: str = "tb_confiture") -> None:
+    conn.execute(f'CREATE SCHEMA "{schema}"')
+    conn.execute(f'CREATE TABLE "{schema}"."{name}" (version text)')
+
+
+def _drop_schemas(conn: psycopg.Connection, *schemas: str) -> None:
+    for schema in schemas:
+        conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+
+
+class TestSearchPathResolution:
+    def test_ledger_on_search_path_resolves_to_its_real_schema(
+        self, conn: psycopg.Connection, tag: str
+    ) -> None:
+        schema = f"onpath_{tag}"
+        _make_ledger(conn, schema)
+        try:
+            conn.execute(f'SET search_path TO "{schema}", public')
+
+            probe = probe_ledger(conn, "tb_confiture")
+
+            assert probe.exists is True
+            assert probe.resolved_name == f"{schema}.tb_confiture"
+        finally:
+            conn.execute("SET search_path TO public")
+            _drop_schemas(conn, schema)
+
+    def test_ledger_off_search_path_reports_absent(
+        self, conn: psycopg.Connection, tag: str
+    ) -> None:
+        """The defect, stated positively.
+
+        Pre-0.41.0 this returned present, so `migrate status` announced a
+        ledger the session could not read and `initialize()` skipped a CREATE
+        the session needed.
+        """
+        schema = f"offpath_{tag}"
+        _make_ledger(conn, schema)
+        try:
+            conn.execute("SET search_path TO public")
+
+            probe = probe_ledger(conn, "tb_confiture")
+
+            assert probe.exists is False
+            assert probe.resolved_name is None
+            # ...but the relation is genuinely there. Without this the test
+            # would pass just as well against an empty database.
+            assert find_ledger_relations(conn, "tb_confiture") == [f"{schema}.tb_confiture"]
+        finally:
+            _drop_schemas(conn, schema)
+
+    def test_same_name_in_two_schemas_resolves_to_the_first_on_search_path(
+        self, conn: psycopg.Connection, tag: str
+    ) -> None:
+        first, second = f"first_{tag}", f"second_{tag}"
+        _make_ledger(conn, first)
+        _make_ledger(conn, second)
+        try:
+            conn.execute(f'SET search_path TO "{first}", "{second}"')
+            assert probe_ledger(conn, "tb_confiture").resolved_name == f"{first}.tb_confiture"
+
+            # Reversing the search_path reverses the answer — proof the probe
+            # reads search_path rather than, say, OID order.
+            conn.execute(f'SET search_path TO "{second}", "{first}"')
+            assert probe_ledger(conn, "tb_confiture").resolved_name == f"{second}.tb_confiture"
+        finally:
+            conn.execute("SET search_path TO public")
+            _drop_schemas(conn, first, second)
+
+    def test_a_sequence_of_the_same_name_is_not_a_ledger(
+        self, conn: psycopg.Connection, tag: str
+    ) -> None:
+        schema = f"seqonly_{tag}"
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+        conn.execute(f'CREATE SEQUENCE "{schema}".tb_confiture')
+        try:
+            conn.execute(f'SET search_path TO "{schema}"')
+
+            assert probe_ledger(conn, "tb_confiture").exists is False
+        finally:
+            conn.execute("SET search_path TO public")
+            _drop_schemas(conn, schema)
+
+    def test_a_view_of_the_same_name_still_counts(self, conn: psycopg.Connection, tag: str) -> None:
+        """`information_schema.tables` counted views, so this one must not change."""
+        schema = f"viewonly_{tag}"
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+        conn.execute(f'CREATE VIEW "{schema}".tb_confiture AS SELECT 1 AS version')
+        try:
+            conn.execute(f'SET search_path TO "{schema}"')
+
+            assert probe_ledger(conn, "tb_confiture").exists is True
+        finally:
+            conn.execute("SET search_path TO public")
+            _drop_schemas(conn, schema)
+
+
+class TestQualifiedProbeIsUnchanged:
+    def test_qualified_name_finds_a_ledger_off_search_path(
+        self, conn: psycopg.Connection, tag: str
+    ) -> None:
+        """Naming the schema is how you reach a ledger search_path cannot see."""
+        schema = f"qualified_{tag}"
+        _make_ledger(conn, schema)
+        try:
+            conn.execute("SET search_path TO public")
+
+            probe = probe_ledger(conn, f"{schema}.tb_confiture")
+
+            assert probe.exists is True
+            assert probe.resolved_name == f"{schema}.tb_confiture"
+        finally:
+            _drop_schemas(conn, schema)
+
+    def test_qualified_name_does_not_match_another_schema(
+        self, conn: psycopg.Connection, tag: str
+    ) -> None:
+        schema = f"elsewhere_{tag}"
+        _make_ledger(conn, schema)
+        try:
+            assert probe_ledger(conn, "public.tb_confiture").exists is False
+        finally:
+            _drop_schemas(conn, schema)
+
+
+@pytest.fixture
+def restricted(
+    conn: psycopg.Connection, test_db_url: str, tag: str
+) -> Iterator[tuple[str, psycopg.Connection]]:
+    """A schema plus a connection as a role with no USAGE on it.
+
+    This is the scenario #188's decision turns on: ``to_regclass('s.t')`` raises
+    `permission denied for schema s` here, while `information_schema` returns
+    cleanly. Skips where the test connection cannot create a role.
+    """
+    schema, role = f"restricted_{tag}", f"probe_role_{tag}"
+    try:
+        conn.execute(f'CREATE ROLE "{role}" LOGIN')
+    except psycopg.errors.InsufficientPrivilege:  # pragma: no cover - environment gate
+        pytest.skip("test connection cannot CREATE ROLE")
+    _make_ledger(conn, schema)
+    conn.execute(f'GRANT SELECT ON "{schema}".tb_confiture TO "{role}"')
+    # Deliberately no GRANT USAGE ON SCHEMA.
+    restricted_conn = None
+    try:
+        info = psycopg.conninfo.conninfo_to_dict(test_db_url)
+        info["user"] = role
+        info.pop("password", None)
+        try:
+            restricted_conn = psycopg.connect(psycopg.conninfo.make_conninfo(**info))
+        except psycopg.OperationalError as e:  # pragma: no cover - environment gate
+            pytest.skip(f"cannot connect as an unprivileged role: {e}")
+        yield schema, restricted_conn
+    finally:
+        if restricted_conn is not None:
+            restricted_conn.close()
+        _drop_schemas(conn, schema)
+        conn.execute(f'DROP ROLE IF EXISTS "{role}"')
+
+
+class TestPrivileges:
+    def test_qualified_probe_answers_cleanly_without_schema_usage(
+        self, restricted: tuple[str, psycopg.Connection]
+    ) -> None:
+        """The regression guard for #182: no raw psycopg exception, ever.
+
+        `information_schema` reports the row even though the role cannot read
+        the table. That is a wrong answer to "can I read this?" — and the right
+        answer to "is it there?", which is what this probe is for. #188's
+        decision keeps it rather than swap a wrong answer for a crash.
+        """
+        schema, restricted_conn = restricted
+
+        probe = probe_ledger(restricted_conn, f"{schema}.tb_confiture")
+
+        assert probe.exists is True
+
+    def test_bare_probe_skips_a_schema_the_role_cannot_use(
+        self, restricted: tuple[str, psycopg.Connection]
+    ) -> None:
+        """Even with the schema on search_path, resolution yields NULL not an error.
+
+        This is why the bare path needs no privilege special-casing: PostgreSQL
+        silently drops search_path entries the role has no USAGE on.
+        """
+        schema, restricted_conn = restricted
+        restricted_conn.execute(f'SET search_path TO "{schema}"')
+
+        probe = probe_ledger(restricted_conn, "tb_confiture")
+
+        assert probe.exists is False
+
+    def test_a_readable_ledger_is_reported_present(
+        self, conn: psycopg.Connection, restricted: tuple[str, psycopg.Connection], tag: str
+    ) -> None:
+        """Sanity anchor: the role is not simply blind to everything."""
+        _schema, restricted_conn = restricted
+        visible = f"visible_{tag}"
+        _make_ledger(conn, visible)
+        role = f"probe_role_{tag}"
+        conn.execute(f'GRANT USAGE ON SCHEMA "{visible}" TO "{role}"')
+        try:
+            restricted_conn.execute(f'SET search_path TO "{visible}"')
+
+            probe = probe_ledger(restricted_conn, "tb_confiture")
+
+            assert probe.exists is True
+            assert probe.resolved_name == f"{visible}.tb_confiture"
+        finally:
+            restricted_conn.rollback()
+            _drop_schemas(conn, visible)
+
+    def test_no_select_privilege_still_reports_present(
+        self, conn: psycopg.Connection, tag: str
+    ) -> None:
+        """Presence, not readability — #188 dropped `readable` deliberately.
+
+        ``has_table_privilege`` raises on the very USAGE-less case the field was
+        meant to describe, so deriving readability from it would have traded one
+        wrong answer for an exception.
+        """
+        schema = f"noselect_{tag}"
+        _make_ledger(conn, schema)
+        try:
+            conn.execute(f'SET search_path TO "{schema}"')
+            conn.execute(f'REVOKE ALL ON "{schema}".tb_confiture FROM PUBLIC')
+
+            assert probe_ledger(conn, "tb_confiture").exists is True
+        finally:
+            conn.execute("SET search_path TO public")
+            _drop_schemas(conn, schema)
+
+
+class TestFindLedgerRelations:
+    def test_finds_every_copy_across_schemas(self, conn: psycopg.Connection, tag: str) -> None:
+        alpha, beta = f"alpha_{tag}", f"beta_{tag}"
+        _make_ledger(conn, alpha)
+        _make_ledger(conn, beta)
+        try:
+            found = find_ledger_relations(conn, "tb_confiture")
+
+            assert f"{alpha}.tb_confiture" in found
+            assert f"{beta}.tb_confiture" in found
+        finally:
+            _drop_schemas(conn, alpha, beta)
+
+    def test_returns_empty_when_the_name_is_unused(
+        self, conn: psycopg.Connection, tag: str
+    ) -> None:
+        assert find_ledger_relations(conn, f"tb_absent_{tag}") == []

--- a/tests/integration/test_ledger_probe.py
+++ b/tests/integration/test_ledger_probe.py
@@ -290,3 +290,122 @@ class TestFindLedgerRelations:
         self, conn: psycopg.Connection, tag: str
     ) -> None:
         assert find_ledger_relations(conn, f"tb_absent_{tag}") == []
+
+
+@pytest.fixture
+def migrator_conn(test_db_url: str) -> Iterator[psycopg.Connection]:
+    """A second, transactional connection — the one a Migrator would hold."""
+    try:
+        connection = psycopg.connect(test_db_url)
+    except psycopg.OperationalError as e:  # pragma: no cover - environment gate
+        pytest.skip(f"PostgreSQL not available: {e}")
+    try:
+        yield connection
+    finally:
+        connection.rollback()
+        connection.close()
+
+
+class TestInitializeFollowsTheResolvedLedger:
+    """`initialize()` must create the ledger the session will go on to read.
+
+    It probes with `_qualified_table()`, which returns a **bare** name whenever
+    `tracking_table` is unqualified — the default. Phase 05 recorded that this
+    path "always" uses the qualified probe; it does not, and that is what puts
+    `initialize()` in the blast radius of the search_path fix rather than out
+    of it.
+    """
+
+    def test_a_reachable_ledger_is_not_recreated(
+        self, conn: psycopg.Connection, migrator_conn: psycopg.Connection, tag: str
+    ) -> None:
+        from confiture.core.migrator import Migrator
+
+        schema = f"initon_{tag}"
+        _make_ledger(conn, schema)
+        try:
+            migrator_conn.execute(f'SET search_path TO "{schema}"')
+
+            Migrator(connection=migrator_conn).initialize()
+
+            assert find_ledger_relations(conn, "tb_confiture") == [f"{schema}.tb_confiture"]
+        finally:
+            migrator_conn.rollback()
+            _drop_schemas(conn, schema)
+
+    def test_an_unreachable_ledger_does_not_suppress_creation(
+        self, conn: psycopg.Connection, migrator_conn: psycopg.Connection, tag: str
+    ) -> None:
+        """The pre-0.41.0 dead end, now navigable.
+
+        With a ledger in a schema off `search_path`, the schema-blind probe
+        reported present, `initialize()` skipped the CREATE, and the very next
+        statement — the #137 additive ALTER — failed with `relation
+        "tb_confiture" does not exist`. Nothing could recover it but hand-editing
+        the config. The session now gets a ledger where it reads.
+        """
+        from confiture.core.migrator import Migrator
+
+        hidden, session = f"initoff_{tag}", f"initsess_{tag}"
+        _make_ledger(conn, hidden)
+        conn.execute(f'CREATE SCHEMA "{session}"')
+        try:
+            migrator_conn.execute(f'SET search_path TO "{session}"')
+
+            migrator = Migrator(connection=migrator_conn)
+            migrator.initialize()
+
+            assert migrator.tracking_table_exists() is True
+            assert sorted(find_ledger_relations(conn, "tb_confiture")) == [
+                f"{hidden}.tb_confiture",
+                f"{session}.tb_confiture",
+            ]
+        finally:
+            migrator_conn.rollback()
+            _drop_schemas(conn, hidden, session)
+
+
+class TestAutoBaselineGuardCondition:
+    """The refusal's precondition, against a real PostgreSQL.
+
+    ``tests/unit/cli/test_auto_baseline_guard.py`` proves the CLI refuses when
+    the sweep returns something. This proves the sweep really does return
+    something in the state that now reads absent — so the guard is reachable
+    rather than dead code protecting a scenario PostgreSQL never produces.
+    """
+
+    def test_an_off_search_path_ledger_is_absent_but_findable(
+        self, conn: psycopg.Connection, migrator_conn: psycopg.Connection, tag: str
+    ) -> None:
+        from confiture.core.migrator import Migrator
+
+        hidden, session = f"guardoff_{tag}", f"guardsess_{tag}"
+        _make_ledger(conn, hidden)
+        conn.execute(f'CREATE SCHEMA "{session}"')
+        try:
+            migrator_conn.execute(f'SET search_path TO "{session}"')
+
+            # Both halves of the guard's condition, from one real database.
+            assert Migrator(connection=migrator_conn).tracking_table_exists() is False
+            assert find_ledger_relations(migrator_conn, "tb_confiture") == [
+                f"{hidden}.tb_confiture"
+            ]
+        finally:
+            migrator_conn.rollback()
+            _drop_schemas(conn, hidden, session)
+
+    def test_a_reachable_ledger_never_reaches_the_guard(
+        self, conn: psycopg.Connection, migrator_conn: psycopg.Connection, tag: str
+    ) -> None:
+        """Auto-baseline is skipped entirely when the ledger resolves."""
+        from confiture.core.migrator import Migrator
+
+        schema = f"guardon_{tag}"
+        _make_ledger(conn, schema)
+        try:
+            migrator_conn.execute(f'SET search_path TO "{schema}"')
+
+            assert Migrator(connection=migrator_conn).tracking_table_exists() is True
+        finally:
+            migrator_conn.rollback()
+            _drop_schemas(conn, schema)

--- a/tests/unit/cli/test_auto_baseline_guard.py
+++ b/tests/unit/cli/test_auto_baseline_guard.py
@@ -1,0 +1,158 @@
+"""``migrate up --auto-detect-baseline`` refuses a ledger it merely cannot see (#188).
+
+Auto-baseline exists to bootstrap a database that has never been migrated: no
+ledger, so create one and mark the migrations already present in the schema. It
+decides that from ``tracking_table_exists()``, which since 0.41.0 resolves a
+bare name through ``search_path`` instead of matching any schema.
+
+That is the correct answer to "can this session read the ledger?" and the wrong
+trigger for auto-baseline. A ledger sitting in a schema off ``search_path`` now
+reads absent, and without this guard the command would build a *second* ledger
+and mark every migration applied in it — on a production database, an incident.
+So absence is no longer sufficient: the name must be unused everywhere.
+
+These are unit tests on purpose. The DB-backed twin lives in
+``tests/integration/test_ledger_probe.py``, and this repo's CI cannot reach a
+database — an integration-only guard over a data-destroying path would gate
+nothing on a pull request.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real project tree — Typer resolves db/migrations from the cwd."""
+    (tmp_path / "db" / "migrations").mkdir(parents=True)
+    (tmp_path / "db" / "migrations" / "20260101120000_t.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS public.foo (id int);\n"
+    )
+    (tmp_path / "db" / "schema_history").mkdir(parents=True)
+    (tmp_path / "db" / "schema_history" / "20260101120000.sql").write_text(
+        "CREATE TABLE public.foo (id int);\n"
+    )
+    (tmp_path / "confiture.yaml").write_text(
+        textwrap.dedent(
+            """\
+            name: test
+            database_url: postgresql://localhost/test
+            include_dirs:
+              - path: db/schema
+            """
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def doubles(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stand-ins for the connection, the migrator and the schema-blind sweep.
+
+    ``elsewhere`` is what the sweep reports. ``calls`` records the two methods
+    that would rewrite the ledger, so a refusal can be shown to have refused
+    rather than merely printed something.
+    """
+    state: dict[str, Any] = {"elsewhere": [], "calls": [], "swept": []}
+
+    migrator = MagicMock()
+    migrator.tracking_table_exists.return_value = False
+    migrator.initialize.side_effect = lambda *a, **k: state["calls"].append("initialize")
+    migrator.baseline_through.side_effect = lambda *a, **k: state["calls"].append(
+        "baseline_through"
+    )
+    migrator.get_applied_versions.return_value = []
+    state["migrator"] = migrator
+
+    monkeypatch.setattr("confiture.core.connection.create_connection", lambda *a, **k: MagicMock())
+    monkeypatch.setattr("confiture.core.migrator.Migrator", lambda *a, **k: migrator)
+
+    def fake_sweep(_conn: Any, table: str) -> list[str]:
+        state["swept"].append(table)
+        return list(state["elsewhere"])
+
+    monkeypatch.setattr("confiture.core.ledger.find_ledger_relations", fake_sweep)
+    return state
+
+
+def _invoke(*flags: str) -> Any:
+    # --no-lock because the advisory-lock key is derived by hashing the real
+    # connection, which a MagicMock cannot satisfy. The guard runs well before
+    # the lock is taken, so this changes nothing under test.
+    return runner.invoke(app, ["migrate", "up", "-c", "confiture.yaml", "--no-lock", *flags])
+
+
+def test_refuses_when_the_name_exists_in_another_schema(
+    project: Path,  # noqa: ARG001 — fixture chdirs
+    doubles: dict[str, Any],
+) -> None:
+    doubles["elsewhere"] = ["staging.tb_confiture"]
+
+    result = _invoke("--auto-detect-baseline")
+
+    assert result.exit_code == 5, result.output
+    # The sweep really ran — an empty list here would mean the guard was
+    # skipped and this test passed for the wrong reason.
+    assert doubles["swept"] == ["tb_confiture"]
+    # Both halves of the message: what was searched, and what was found.
+    assert "staging.tb_confiture" in result.output
+    assert "tb_confiture" in result.output
+    # And nothing was written.
+    assert doubles["calls"] == [], f"auto-baseline still ran: {doubles['calls']}"
+
+
+def test_names_every_schema_it_found(
+    project: Path,  # noqa: ARG001
+    doubles: dict[str, Any],
+) -> None:
+    """Two copies is the case where guessing costs the most; list them all."""
+    doubles["elsewhere"] = ["archive.tb_confiture", "staging.tb_confiture"]
+
+    result = _invoke("--auto-detect-baseline")
+
+    assert result.exit_code == 5, result.output
+    assert "archive.tb_confiture" in result.output
+    assert "staging.tb_confiture" in result.output
+
+
+def test_a_genuinely_unused_name_still_auto_baselines(
+    project: Path,  # noqa: ARG001
+    doubles: dict[str, Any],
+) -> None:
+    """The guard must not become a blanket refusal.
+
+    Nothing anywhere holds the name, which is the state auto-baseline was
+    built for, so it proceeds and marks the snapshot's migrations applied.
+    """
+    doubles["elsewhere"] = []
+
+    result = _invoke("--auto-detect-baseline")
+
+    assert doubles["swept"] == ["tb_confiture"]
+    assert "initialize" in doubles["calls"], result.output
+    assert result.exit_code == 0, result.output
+
+
+def test_without_the_flag_a_ledger_elsewhere_is_not_the_command_s_business(
+    project: Path,  # noqa: ARG001
+    doubles: dict[str, Any],
+) -> None:
+    """A plain `migrate up` never self-baselines, so it never needs the sweep."""
+    doubles["elsewhere"] = ["staging.tb_confiture"]
+
+    result = _invoke()
+
+    assert doubles["swept"] == []
+    assert result.exit_code == 0, result.output

--- a/tests/unit/cli/test_idempotent_scoping.py
+++ b/tests/unit/cli/test_idempotent_scoping.py
@@ -576,21 +576,66 @@ class TestOutsideRepo:
         assert result.exit_code == 7
 
 
-class TestFlagCombinationGuard:
-    def test_idempotent_with_require_migration_fails_loud(self, bare_dir: Path) -> None:
-        """Previously ran only --require-migration and silently skipped idempotency."""
-        result = runner.invoke(
-            app,
-            [
-                "migrate",
-                "validate",
-                "--idempotent",
-                "--require-migration",
-                "--migrations-dir",
-                str(bare_dir),
-            ],
-        )
+class TestFlagCombinationComposes:
+    """`--idempotent --require-migration` runs both checks (0.41.0).
 
-        assert result.exit_code != 0
-        # Short fragment: Rich soft-wraps mid-sentence at console width.
-        assert "cannot be combined with" in result.output
+    0.37.0 rejected this combination outright, because the dispatch of the day
+    ran the git branch and silently skipped idempotency — #181's own defect. A
+    loud error was the right answer while that was true. Composition landed in
+    0.40.0 and the guard came off one release later, so what has to be pinned
+    now is not the rejection but the thing the rejection stood in for: the
+    idempotency scan really runs, over a positive selection, next to the git
+    check.
+    """
+
+    @pytest.fixture
+    def git_double(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Stand in for the accompaniment check, recording that it ran.
+
+        Patched on ``confiture.cli.git_validation`` because the git group
+        imports the sub-checks lazily from there. Without the double the check
+        would build an expected schema from real refs, which is
+        ``test_cli_git_validation.py``'s job, not this file's.
+        """
+        ran: list[str] = []
+
+        def fake_accompaniment(**_: object) -> dict[str, object]:
+            ran.append("accompaniment")
+            return {"is_valid": True, "violations": []}
+
+        monkeypatch.setattr(
+            "confiture.cli.git_validation.validate_migration_accompaniment",
+            fake_accompaniment,
+        )
+        return ran
+
+    def test_both_checks_run(self, repo: Path, git_double: list[str]) -> None:
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--require-migration", cwd=repo)
+
+        assert git_double == ["accompaniment"], "the git check did not run"
+        assert payload["checks"]["git_accompaniment"] == {
+            "status": "passed",
+            "checks": ["accompaniment"],
+        }
+        idempotent = payload["checks"]["idempotent"]
+        assert idempotent["files_scanned"] == 3
+        assert _basenames(idempotent) == {
+            "20260101000000_alpha.up.sql",
+            "20260102000000_beta.up.sql",
+            "20260103000000_gamma.up.sql",
+        }
+        assert exit_code == 0
+
+    def test_a_passing_git_check_does_not_mask_a_violation(
+        self, repo: Path, git_double: list[str]
+    ) -> None:
+        """The failure mode the guard existed to prevent, now prevented by composing."""
+        _migration(repo, "20260104000000", "delta", idempotent=False)
+
+        exit_code, payload = _run_json(repo / "db" / "migrations", "--require-migration", cwd=repo)
+
+        assert git_double == ["accompaniment"]
+        assert payload["status"] == "failed"
+        assert payload["checks"]["idempotent"]["violation_count"] >= 1
+        assert "20260104000000_delta.up.sql" in _basenames(payload["checks"]["idempotent"])
+        assert exit_code == 1

--- a/tests/unit/cli/test_verify_checksums_no_ledger.py
+++ b/tests/unit/cli/test_verify_checksums_no_ledger.py
@@ -19,6 +19,7 @@ import yaml
 from typer.testing import CliRunner
 
 from confiture.cli.main import app
+from confiture.core.ledger import LedgerProbe
 
 runner = CliRunner()
 
@@ -49,21 +50,41 @@ def migrations_dir(tmp_path: Path) -> Path:
 
 
 def _invoke(
-    cfg: Path, migrations_dir: Path, *extra: str, ledger: bool, argv0: str = "verify-checksums"
+    cfg: Path,
+    migrations_dir: Path,
+    *extra: str,
+    ledger: bool,
+    elsewhere: list[str] | None = None,
+    argv0: str = "verify-checksums",
 ):
     """Invoke the command with the ledger probe forced to `ledger`.
 
-    `verify_checksums` imports both names inside the function body, so the
-    patch targets are the source modules, not `commands.admin`.
+    `verify_checksums` imports the names inside the function body, so the patch
+    targets are the source modules, not `commands.admin`.
+
+    ``probe_ledger``, not ``ledger_exists``: 0.41.0 moved the command onto the
+    richer probe. Left on the old name the patch binds to nothing, the real
+    probe runs against the MagicMock connection, and a mock row reads as
+    *present* — so the ledger=True cases would have gone on passing while
+    testing nothing. The `assert probe.called` below is what makes that
+    impossible to repeat.
     """
+    probe = MagicMock(
+        return_value=LedgerProbe(
+            exists=ledger, resolved_name="public.tb_confiture" if ledger else None
+        )
+    )
     with (
         patch("confiture.core.connection.create_connection", return_value=MagicMock()),
-        patch("confiture.core.ledger.ledger_exists", return_value=ledger),
+        patch("confiture.core.ledger.probe_ledger", probe),
+        patch("confiture.core.ledger.find_ledger_relations", return_value=elsewhere or []),
     ):
-        return runner.invoke(
+        result = runner.invoke(
             app,
             [argv0, "-c", str(cfg), "--migrations-dir", str(migrations_dir), *extra],
         )
+    assert probe.called, "the ledger probe double was never used — patch target is stale"
+    return result
 
 
 class TestAbsentLedger:
@@ -139,3 +160,42 @@ class TestDeprecatedAliasParity:
 
         assert result.exit_code == 0
         assert "no migration ledger" in result.output.lower()
+
+
+class TestAbsentButPresentElsewhere:
+    """0.41.0 made "absent" mean "does not resolve *here*" (#188).
+
+    A bare `tracking_table` is now resolved through `search_path`, so a ledger
+    parked in another schema reports absent where it used to report present.
+    "Not present in this database" would then be a lie the operator has no way
+    to see through, so the message says where it actually is.
+    """
+
+    def test_the_message_names_the_schema_that_holds_it(
+        self, cfg: Path, migrations_dir: Path
+    ) -> None:
+        result = _invoke(cfg, migrations_dir, ledger=False, elsewhere=["staging.tb_confiture"])
+
+        assert result.exit_code == 2
+        assert "staging.tb_confiture" in result.output
+        assert "search_path" in result.output
+
+    def test_allow_uninitialized_says_it_too(self, cfg: Path, migrations_dir: Path) -> None:
+        result = _invoke(
+            cfg,
+            migrations_dir,
+            "--allow-uninitialized",
+            ledger=False,
+            elsewhere=["staging.tb_confiture"],
+        )
+
+        assert result.exit_code == 0
+        assert "staging.tb_confiture" in result.output
+
+    def test_a_genuinely_empty_database_gains_no_extra_noise(
+        self, cfg: Path, migrations_dir: Path
+    ) -> None:
+        """Nothing found elsewhere means nothing extra said."""
+        result = _invoke(cfg, migrations_dir, ledger=False, elsewhere=[])
+
+        assert "search_path" not in result.output

--- a/tests/unit/json_schemas/test_status_schema.py
+++ b/tests/unit/json_schemas/test_status_schema.py
@@ -75,3 +75,56 @@ def test_status_without_config_validates(tmp_path, schemas_dir, schema_registry)
     assert all(m["status"] == "unknown" for m in payload["migrations"])
     assert payload["summary"] == {"applied": 0, "pending": 0, "total": 1}
     assert payload["hints"] == []
+
+
+def test_resolved_table_validates(tmp_path, schemas_dir, schema_registry, monkeypatch):
+    """`resolved_table` names the relation the session actually read (0.41.0, #188).
+
+    A bare `tracking_table` resolves through `search_path`, so the configured
+    name alone no longer identifies a relation. `additionalProperties: false`
+    means the key had to be declared in the schema, not merely emitted.
+    """
+    from unittest.mock import MagicMock
+
+    from confiture.config.environment import Environment
+    from confiture.core.ledger import LedgerProbe
+
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260527000000_init.up.sql").write_text("CREATE TABLE IF NOT EXISTS u (id INT);\n")
+    cfg = tmp_path / "env.yaml"
+    cfg.write_text("name: test\ndatabase_url: postgresql://localhost/test\n")
+
+    migrator = MagicMock()
+    migrator.tracking_table_exists.return_value = True
+    migrator.get_applied_versions.return_value = []
+    migrator.get_applied_migrations_with_timestamps.return_value = []
+
+    env = Environment.model_validate(
+        {"name": "test", "database_url": "postgresql://localhost/test"}
+    )
+    monkeypatch.setattr("confiture.core.connection.load_config", lambda *a, **k: env)
+    monkeypatch.setattr("confiture.core.connection.create_connection", lambda *a, **k: MagicMock())
+    monkeypatch.setattr("confiture.core.migrator.Migrator", lambda *a, **k: migrator)
+    probe = MagicMock(return_value=LedgerProbe(exists=True, resolved_name="staging.tb_confiture"))
+    monkeypatch.setattr("confiture.core.ledger.probe_ledger", probe)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "status",
+            "--config",
+            str(cfg),
+            "--migrations-dir",
+            str(migs),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert probe.called, "ledger probe double unused — patch target is stale"
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir, schema_registry).validate(payload)
+    assert payload["resolved_table"] == "staging.tb_confiture"

--- a/tests/unit/json_schemas/test_verify_checksums_schema.py
+++ b/tests/unit/json_schemas/test_verify_checksums_schema.py
@@ -26,6 +26,7 @@ from referencing.jsonschema import DRAFT202012
 from typer.testing import CliRunner
 
 from confiture.cli.main import app
+from confiture.core.ledger import LedgerProbe
 
 runner = CliRunner()
 
@@ -96,16 +97,25 @@ def _mismatch(version: str, name: str) -> MagicMock:
 
 
 @patch("confiture.core.connection.create_connection")
-@patch("confiture.core.ledger.ledger_exists", return_value=True)
+@patch(
+    "confiture.core.ledger.probe_ledger",
+    return_value=LedgerProbe(exists=True, resolved_name="audit.tb_migrations"),
+)
 @patch("confiture.core.checksum.MigrationChecksumVerifier")
 def test_clean_run_matches_schema(
-    verifier_cls, _exists, _conn, cfg: Path, migrations_dir: Path
+    verifier_cls, probe, _conn, cfg: Path, migrations_dir: Path
 ) -> None:
     verifier_cls.return_value.verify_all.return_value = []
     verifier_cls.return_value.count_applied.return_value = 3
 
     result = _invoke(cfg, migrations_dir)
 
+    # Naming the seam, not just asserting the shape. When 0.41.0 moved this
+    # command from `ledger_exists` to `probe_ledger`, the stale patch bound to
+    # nothing and the real probe ran against the MagicMock connection — whose
+    # row is truthy, so it read as *present* and this test kept passing while
+    # testing nothing at all.
+    assert probe.called, "ledger probe double unused — patch target is stale"
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
     _validator("verify-checksums.schema.json").validate(payload)
@@ -113,13 +123,17 @@ def test_clean_run_matches_schema(
     assert payload["ledger_present"] is True
     assert payload["issues"] == []
     assert payload["summary"]["mismatched"] == 0
+    assert payload["summary"]["resolved_table"] == "audit.tb_migrations"
 
 
 @patch("confiture.core.connection.create_connection")
-@patch("confiture.core.ledger.ledger_exists", return_value=True)
+@patch(
+    "confiture.core.ledger.probe_ledger",
+    return_value=LedgerProbe(exists=True, resolved_name="audit.tb_migrations"),
+)
 @patch("confiture.core.checksum.MigrationChecksumVerifier")
 def test_mismatch_run_matches_schema(
-    verifier_cls, _exists, _conn, cfg: Path, migrations_dir: Path
+    verifier_cls, probe, _conn, cfg: Path, migrations_dir: Path
 ) -> None:
     verifier_cls.return_value.verify_all.return_value = [
         _mismatch("20260101000000", "init"),
@@ -142,28 +156,34 @@ def test_mismatch_run_matches_schema(
 
 
 @patch("confiture.core.connection.create_connection")
-@patch("confiture.core.ledger.ledger_exists", return_value=False)
+@patch("confiture.core.ledger.find_ledger_relations", return_value=[])
+@patch("confiture.core.ledger.probe_ledger", return_value=LedgerProbe(exists=False))
 def test_no_ledger_with_allow_uninitialized_matches_schema(
-    _exists, _conn, cfg: Path, migrations_dir: Path
+    probe, _elsewhere, _conn, cfg: Path, migrations_dir: Path
 ) -> None:
     """The degraded path must emit JSON, not `return` after a Rich print."""
     result = _invoke(cfg, migrations_dir, "--allow-uninitialized")
 
+    assert probe.called, "ledger probe double unused — patch target is stale"
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
     _validator("verify-checksums.schema.json").validate(payload)
     assert payload["ok"] is True
     assert payload["ledger_present"] is False
     assert payload["summary"]["checked"] == 0
+    # Nothing resolved, so nothing to name — the key is declared, not omitted.
+    assert payload["summary"]["resolved_table"] is None
 
 
 @patch("confiture.core.connection.create_connection")
-@patch("confiture.core.ledger.ledger_exists", return_value=False)
+@patch("confiture.core.ledger.find_ledger_relations", return_value=[])
+@patch("confiture.core.ledger.probe_ledger", return_value=LedgerProbe(exists=False))
 def test_no_ledger_without_flag_emits_error_envelope(
-    _exists, _conn, cfg: Path, migrations_dir: Path
+    probe, _elsewhere, _conn, cfg: Path, migrations_dir: Path
 ) -> None:
     result = _invoke(cfg, migrations_dir)
 
+    assert probe.called, "ledger probe double unused — patch target is stale"
     assert result.exit_code == 2, result.output
     payload = json.loads(result.stdout)
     _validator("error-envelope.schema.json").validate(payload)

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -211,6 +211,18 @@ class TestFindLedgerRelations:
         assert find_ledger_relations(conn, "public.tb_confiture") == []
         assert cursor.execute.call_args[0][1] == ("tb_confiture",)
 
+    def test_the_name_is_split_the_same_way_the_probe_splits_it(self):
+        """Both split on the first dot, so the sweep follows up on what was probed.
+
+        A sweep for a different relation than the one probed would report
+        look-alikes that are not look-alikes.
+        """
+        conn, cursor = self._conn_returning_rows([])
+
+        find_ledger_relations(conn, "my_schema.weird.name")
+
+        assert cursor.execute.call_args[0][1] == ("weird.name",)
+
     def test_system_schemas_are_excluded(self):
         conn, cursor = self._conn_returning_rows([])
 

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -1,8 +1,27 @@
-"""Tests for the shared ledger-existence primitive."""
+"""SQL-shape contract for the shared ledger-existence primitive (#188).
+
+These are mock-cursor tests: they pin *which query* each path issues and how
+its rows are read, not what a real PostgreSQL says. The behavioural coverage —
+search_path resolution, privileges, a same-named relation in two schemas — is
+in ``tests/integration/test_ledger_probe.py``.
+
+Both layers are load-bearing, and the split is not stylistic: this repo's CI
+cannot reach a database (461 of its tests skip there), so an integration-only
+guard would gate nothing on a pull request.
+"""
 
 from unittest.mock import MagicMock, patch
 
-from confiture.core.ledger import ledger_exists
+import psycopg
+import pytest
+
+from confiture.core.ledger import (
+    LedgerProbe,
+    find_ledger_relations,
+    ledger_exists,
+    probe_ledger,
+)
+from confiture.exceptions import SQLError
 
 
 def _conn_returning(row: tuple | None) -> tuple[MagicMock, MagicMock]:
@@ -15,60 +34,189 @@ def _conn_returning(row: tuple | None) -> tuple[MagicMock, MagicMock]:
     return conn, cursor
 
 
-class TestLedgerExistsBareName:
-    """A bare table name matches the table in any schema."""
+def _conn_raising(exc: BaseException) -> MagicMock:
+    cursor = MagicMock()
+    cursor.execute.side_effect = exc
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
 
-    def test_ledger_exists_bare_name_present(self):
-        conn, cursor = _conn_returning((True,))
+
+class TestBareNameResolvesThroughSearchPath:
+    """A bare name asks the question the *next* query will ask (#188).
+
+    ``information_schema.tables WHERE table_name = 'tb_confiture'`` matched the
+    table in any schema, so a ledger in `staging` reported present to a session
+    that would go on to read `public`. ``to_regclass`` resolves the name exactly
+    as the subsequent query does.
+    """
+
+    def test_bare_probe_uses_to_regclass(self):
+        conn, cursor = _conn_returning(("public", "tb_confiture"))
+
+        assert probe_ledger(conn, "tb_confiture").exists is True
+
+        sql, params = cursor.execute.call_args[0]
+        assert "to_regclass" in sql
+        assert "information_schema" not in sql
+        assert params == ("tb_confiture",)
+        # to_regclass takes a string *literal*, so the name is the injection
+        # boundary CLAUDE.md's security section governs: bind it, never format.
+        assert "tb_confiture" not in sql
+
+    def test_bare_probe_reports_the_schema_it_resolved_to(self):
+        conn, _ = _conn_returning(("staging", "tb_confiture"))
+
+        probe = probe_ledger(conn, "tb_confiture")
+
+        assert probe == LedgerProbe(exists=True, resolved_name="staging.tb_confiture")
+
+    def test_bare_probe_absent_has_no_resolved_name(self):
+        conn, _ = _conn_returning(None)
+
+        assert probe_ledger(conn, "tb_confiture") == LedgerProbe(exists=False, resolved_name=None)
+
+    def test_bare_probe_excludes_non_table_relations(self):
+        """A sequence or index named `tb_confiture` is not a ledger.
+
+        ``to_regclass`` resolves *every* relation kind, where
+        ``information_schema.tables`` reported only tables, views and foreign
+        tables. Without this filter the conversion would smuggle in a second
+        behaviour change beside the search_path fix.
+        """
+        conn, cursor = _conn_returning(None)
+
+        probe_ledger(conn, "tb_confiture")
+
+        sql = cursor.execute.call_args[0][0]
+        assert "relkind" in sql
+        assert "'r'" in sql and "'v'" in sql
+
+    def test_ledger_exists_is_the_boolean_face_of_the_probe(self):
+        conn, _ = _conn_returning(("public", "tb_confiture"))
 
         assert ledger_exists(conn, "tb_confiture") is True
 
-        sql, params = cursor.execute.call_args[0]
-        assert params == ("tb_confiture",)
-        assert "table_schema" not in sql
-        assert "tb_confiture" not in sql  # bound as a parameter, never interpolated
 
-    def test_ledger_exists_bare_name_absent(self):
-        conn, _ = _conn_returning((False,))
+class TestBareProbePrivilegeErrorsAreTyped:
+    """`to_regclass` can raise where `information_schema` returned cleanly.
 
-        assert ledger_exists(conn, "tb_confiture") is False
+    Measured on PostgreSQL 17.8, a *bare* name cannot reach that: search_path
+    resolution silently skips schemas the role has no USAGE on and yields NULL.
+    The wrapper covers what remains — a role with EXECUTE revoked on
+    ``to_regclass``, say — and exists because letting a raw psycopg exception
+    out of a ledger probe is precisely the crash class #182 and 0.37.0 closed.
+    """
 
-    def test_ledger_exists_no_row_is_false(self):
-        conn, _ = _conn_returning(None)
+    def test_insufficient_privilege_becomes_a_confitur_error(self):
+        conn = _conn_raising(psycopg.errors.InsufficientPrivilege("permission denied"))
 
-        assert ledger_exists(conn, "tb_confiture") is False
+        with pytest.raises(SQLError) as excinfo:
+            probe_ledger(conn, "tb_confiture")
+
+        assert excinfo.value.error_code == "SQL_001"
+        assert "permission denied" in str(excinfo.value)
+
+    def test_other_database_errors_are_not_swallowed(self):
+        """Only the privilege case is translated; the rest propagate as-is.
+
+        A blanket ``except Exception`` here would hide a NameError in this very
+        module and keep every test in this file green.
+        """
+        conn = _conn_raising(psycopg.errors.UndefinedFunction("no such function"))
+
+        with pytest.raises(psycopg.errors.UndefinedFunction):
+            probe_ledger(conn, "tb_confiture")
 
 
-class TestLedgerExistsQualifiedName:
-    """A schema-qualified name filters on the schema too."""
+class TestQualifiedNameIsDeliberatelyUnchanged:
+    """The qualified path stays on `information_schema` — see #188's decision.
 
-    def test_ledger_exists_qualified_name_filters_schema(self):
+    ``to_regclass('hidden.tb_secret')`` *raises* `permission denied for schema
+    hidden` for a role without USAGE, where the `information_schema` query
+    returns cleanly (both measured). A qualified name already filters on schema
+    correctly, so converting it would buy nothing and reopen #182's crash class
+    on the path `_migrator/state.py` uses whenever `tracking_table` is
+    qualified.
+    """
+
+    def test_qualified_probe_still_queries_information_schema(self):
         conn, cursor = _conn_returning((True,))
 
-        assert ledger_exists(conn, "public.tb_confiture") is True
+        assert probe_ledger(conn, "public.tb_confiture").exists is True
 
         sql, params = cursor.execute.call_args[0]
+        assert "information_schema" in sql
+        assert "to_regclass" not in sql
         assert params == ("public", "tb_confiture")
-        assert "table_schema" in sql
-        assert "table_name" in sql
+
+    def test_qualified_probe_resolves_to_the_name_it_was_given(self):
+        conn, _ = _conn_returning((True,))
+
+        assert probe_ledger(conn, "public.tb_confiture") == LedgerProbe(
+            exists=True, resolved_name="public.tb_confiture"
+        )
 
     def test_qualified_name_does_not_match_other_schema(self):
-        """A `public.` qualified probe must not match tb_confiture elsewhere.
-
-        The schema filter is what enforces this; the database returns False
-        because the WHERE clause binds both parts.
-        """
         conn, cursor = _conn_returning((False,))
 
-        assert ledger_exists(conn, "public.tb_confiture") is False
+        probe = probe_ledger(conn, "public.tb_confiture")
+
+        assert probe == LedgerProbe(exists=False, resolved_name=None)
         assert cursor.execute.call_args[0][1] == ("public", "tb_confiture")
+
+    def test_no_row_is_absent(self):
+        conn, _ = _conn_returning(None)
+
+        assert ledger_exists(conn, "public.tb_confiture") is False
 
     def test_multi_dot_name_splits_on_first_dot_only(self):
         conn, cursor = _conn_returning((True,))
 
-        ledger_exists(conn, "my_schema.weird.name")
+        probe_ledger(conn, "my_schema.weird.name")
 
         assert cursor.execute.call_args[0][1] == ("my_schema", "weird.name")
+
+
+class TestFindLedgerRelations:
+    """The schema-blind sweep behind the auto-baseline guard.
+
+    ``LedgerProbe.resolved_name`` cannot answer "where else does this name
+    exist?" — it is None precisely when the probe says absent, which is the only
+    time the question is asked. So the guard needs this second query.
+    """
+
+    def _conn_returning_rows(self, rows: list[tuple]) -> tuple[MagicMock, MagicMock]:
+        cursor = MagicMock()
+        cursor.fetchall.return_value = rows
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return conn, cursor
+
+    def test_lists_every_schema_holding_the_name(self):
+        conn, cursor = self._conn_returning_rows([("archive",), ("staging",)])
+
+        assert find_ledger_relations(conn, "tb_confiture") == [
+            "archive.tb_confiture",
+            "staging.tb_confiture",
+        ]
+        assert cursor.execute.call_args[0][1] == ("tb_confiture",)
+
+    def test_a_qualified_name_is_swept_by_its_base(self):
+        """The point is to find copies *outside* the configured schema."""
+        conn, cursor = self._conn_returning_rows([])
+
+        assert find_ledger_relations(conn, "public.tb_confiture") == []
+        assert cursor.execute.call_args[0][1] == ("tb_confiture",)
+
+    def test_system_schemas_are_excluded(self):
+        conn, cursor = self._conn_returning_rows([])
+
+        find_ledger_relations(conn, "tb_confiture")
+
+        assert "pg_catalog" in cursor.execute.call_args[0][0]
 
 
 class TestStateDelegatesToLedgerExists:
@@ -80,7 +228,7 @@ class TestStateDelegatesToLedgerExists:
         migrator._table_base = base
         return migrator
 
-    def test_state_probe_delegates_to_ledger_exists(self):
+    def test_state_probe_delegates_to_the_shared_probe(self):
         from confiture.core._migrator import state
 
         migrator = self._migrator("public", "tb_confiture")

--- a/tests/unit/test_migrate_status_tracking_table.py
+++ b/tests/unit/test_migrate_status_tracking_table.py
@@ -530,3 +530,80 @@ class TestSemanticExitCodes:
         assert result.exit_code == 2
         data = json.loads(result.output)
         assert "warning" in data
+
+
+class TestMigrateStatusReportsTheResolvedLedger:
+    """`migrate status` says which ledger it read, not just which was configured (#188).
+
+    Since 0.41.0 a bare `tracking_table` is resolved through `search_path`, so
+    the configured name no longer identifies a relation on its own. The
+    configured and resolved names are both emitted rather than one
+    conditionally: a consumer should not have to work out which it is holding.
+    """
+
+    def _invoke_json(self, tmp_path, *, probe, elsewhere=None, exists=True):
+        from confiture.core.ledger import LedgerProbe
+
+        config_file = _write_config(tmp_path)
+        migrations_dir = tmp_path / "db" / "migrations"
+        _write_migrations(migrations_dir, count=2)
+        mock_migrator = _make_migrator_mock(tracking_table_exists=exists, applied_versions=[])
+
+        with (
+            patch("confiture.core.connection.load_config", return_value=_make_env()),
+            patch("confiture.core.connection.create_connection", return_value=MagicMock()),
+            patch("confiture.core.migrator.Migrator", return_value=mock_migrator),
+            patch(
+                "confiture.core.ledger.probe_ledger",
+                return_value=LedgerProbe(exists=exists, resolved_name=probe),
+            ) as probe_double,
+            patch(
+                "confiture.core.ledger.find_ledger_relations",
+                return_value=elsewhere or [],
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "migrate",
+                    "status",
+                    "--config",
+                    str(config_file),
+                    "--migrations-dir",
+                    str(migrations_dir),
+                    "--format",
+                    "json",
+                ],
+            )
+        assert probe_double.called, "ledger probe double unused — patch target is stale"
+        return result
+
+    def test_json_carries_both_names(self, tmp_path):
+        result = self._invoke_json(tmp_path, probe="staging.tb_confiture")
+
+        payload = json.loads(result.stdout)
+        assert payload["tracking_table"] == "tb_confiture"
+        assert payload["resolved_table"] == "staging.tb_confiture"
+
+    def test_an_absent_ledger_found_elsewhere_is_named_in_hints(self, tmp_path):
+        """The likeliest cause of a surprising all-pending report.
+
+        Without this the operator sees every migration 'pending' and a ledger
+        that "does not exist", while it sits in the next schema over.
+        """
+        result = self._invoke_json(
+            tmp_path, probe=None, exists=False, elsewhere=["staging.tb_confiture"]
+        )
+
+        payload = json.loads(result.stdout)
+        assert payload["resolved_table"] is None
+        assert any("staging.tb_confiture" in h for h in payload["hints"])
+        assert any("search_path" in h for h in payload["hints"])
+
+    def test_an_empty_database_gains_no_extra_hint(self, tmp_path):
+        """Nothing found elsewhere means the ordinary absent-ledger hint alone."""
+        result = self._invoke_json(tmp_path, probe=None, exists=False, elsewhere=[])
+
+        payload = json.loads(result.stdout)
+        assert not any("search_path" in h for h in payload["hints"])
+        assert any("baseline" in h for h in payload["hints"])

--- a/tests/unit/test_migration_table_config.py
+++ b/tests/unit/test_migration_table_config.py
@@ -81,18 +81,25 @@ class TestMigratorMigrationTableInit:
 
 
 class TestTrackingTableExistsCustomTable:
-    def _make_migrator(self, table_name: str) -> Migrator:
+    def _make_migrator(self, table_name: str, row: tuple) -> Migrator:
+        """A migrator whose ledger probe returns ``row``.
+
+        The two probe paths return different shapes and the double has to match
+        the one this table name selects (#188): a bare name resolves through
+        ``to_regclass`` and yields ``(schema, relname)``, a qualified name keeps
+        the ``information_schema`` ``EXISTS`` query and yields ``(bool,)``.
+        """
         conn = MagicMock()
         cursor = MagicMock()
         cursor.__enter__ = MagicMock(return_value=cursor)
         cursor.__exit__ = MagicMock(return_value=False)
-        cursor.fetchone.return_value = (True,)
+        cursor.fetchone.return_value = row
         conn.cursor.return_value = cursor
         return Migrator(connection=conn, migration_table=table_name)
 
     def test_tracking_table_exists_unqualified(self):
         """tracking_table_exists() checks correct table name (unqualified)."""
-        m = self._make_migrator("my_migrations")
+        m = self._make_migrator("my_migrations", ("public", "my_migrations"))
         result = m.tracking_table_exists()
         assert result is True
         cursor = m.connection.cursor.return_value.__enter__.return_value
@@ -101,7 +108,7 @@ class TestTrackingTableExistsCustomTable:
 
     def test_tracking_table_exists_schema_qualified(self):
         """tracking_table_exists() checks correct schema+table (qualified)."""
-        m = self._make_migrator("public.tb_confiture")
+        m = self._make_migrator("public.tb_confiture", (True,))
         result = m.tracking_table_exists()
         assert result is True
         cursor = m.connection.cursor.return_value.__enter__.return_value

--- a/tests/unit/test_migrator_edge_cases.py
+++ b/tests/unit/test_migrator_edge_cases.py
@@ -39,9 +39,11 @@ class TestMigratorInitializeEdgeCases:
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
 
-        # Simulate table already exists with new structure
+        # Simulate table already exists with new structure. The default
+        # tracking table is bare, so the first row is the `to_regclass` probe's
+        # (schema, relname) shape rather than an EXISTS boolean (#188).
         mock_cursor.fetchone.side_effect = [
-            (True,),  # Table exists
+            ("public", "tb_confiture"),  # Table exists
             (True,),  # Has new structure (pk_migration)
         ]
 
@@ -206,8 +208,11 @@ class TestExecuteSqlComposable:
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
 
-        # Table exists check succeeds, table doesn't exist
-        mock_cursor.fetchone.return_value = (False,)
+        # Table exists check succeeds, table doesn't exist. The bare-name probe
+        # signals absence by returning no row at all (#188) — an EXISTS-style
+        # `(False,)` is a *present* answer to the `to_regclass` query, which
+        # would send this test down the wrong branch.
+        mock_cursor.fetchone.return_value = None
         # CREATE TABLE fails with a permissions error
         call_count = 0
 

--- a/tests/unit/test_validate_composition_git_and_db.py
+++ b/tests/unit/test_validate_composition_git_and_db.py
@@ -312,3 +312,78 @@ def test_emit_remediation_fires_exactly_once_when_composed(
     assert "passed import check" in result.output
     assert len(calls) == 1, f"emit_remediation ran {len(calls)} times"
     assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# The 0.37.0 --idempotent conflict guard is RETIRED (0.41.0)
+# ---------------------------------------------------------------------------
+#
+# 0.37.0 rejected `--idempotent` alongside the four git flags because the
+# pre-composition dispatch ran the git branch and *silently skipped*
+# idempotency — the #181 defect. 0.40.0 made every requested check run but kept
+# the guard one release, so the composition refactor got production exposure
+# before its safety net came off. It is off now, and these tests are what
+# replaces it: the combination has to run *both* checks, not merely be accepted.
+
+
+@pytest.mark.parametrize(
+    ("git_flag", "subcheck"),
+    [
+        ("--check-drift", "drift"),
+        ("--require-migration", "accompaniment"),
+        ("--require-migration-bodies", "accompaniment"),
+        ("--require-grant-migration", "grant"),
+    ],
+)
+def test_idempotent_composes_with_each_previously_rejected_git_flag(
+    git_project: Path,
+    git_doubles: dict[str, Any],
+    git_flag: str,
+    subcheck: str,
+) -> None:
+    """Each of the four formerly-rejected combinations runs both checks."""
+    (git_project / "db" / "migrations" / "20260101120000_t.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS public.foo (id int);\n"
+    )
+
+    result = _invoke("--idempotent", git_flag)
+
+    assert result.exit_code == 0, result.output
+    assert git_doubles["ran"] == [subcheck], f"{git_flag} did not run: {result.output!r}"
+    assert "All migrations are idempotent" in result.output
+
+
+def test_failing_git_check_does_not_mask_the_idempotency_check(
+    git_project: Path,
+    git_doubles: dict[str, Any],
+) -> None:
+    """The composed run reports the git failure *and* still runs idempotency."""
+    git_doubles["drift_passes"] = False
+    (git_project / "db" / "migrations" / "20260101120000_t.up.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS public.foo (id int);\n"
+    )
+
+    result = _invoke("--idempotent", "--check-drift")
+
+    assert git_doubles["ran"] == ["drift"]
+    assert "All migrations are idempotent" in result.output
+    assert result.exit_code == 1, result.output
+
+
+def test_failing_idempotency_is_not_masked_by_a_passing_git_check(
+    git_project: Path,
+    git_doubles: dict[str, Any],
+) -> None:
+    """The exact regression #181 filed: a green git check hiding a bad migration.
+
+    ``CREATE TABLE`` with no ``IF NOT EXISTS`` is a blocking idempotency
+    violation. Before 0.40.0 this invocation exited 0.
+    """
+    (git_project / "db" / "migrations" / "20260101120000_t.up.sql").write_text(
+        "CREATE TABLE public.foo (id int);\n"
+    )
+
+    result = _invoke("--idempotent", "--check-drift")
+
+    assert git_doubles["ran"] == ["drift"], "the git check must still run"
+    assert result.exit_code == 1, result.output

--- a/tests/unit/test_validate_flag_composition.py
+++ b/tests/unit/test_validate_flag_composition.py
@@ -220,19 +220,30 @@ def test_report_modes_reject_composition(project: Path, report_flag: str) -> Non
 
 
 # ---------------------------------------------------------------------------
-# The 0.37.0 --idempotent conflict guard is RETAINED this release (D2)
+# The 0.37.0 --idempotent conflict guard is RETIRED (0.41.0)
 # ---------------------------------------------------------------------------
 
 
-def test_idempotent_git_conflict_guard_is_retained(project: Path) -> None:  # noqa: ARG001
-    """Deliberately still rejecting: retired in 0.41.0, not here.
+@pytest.mark.parametrize(
+    "git_flag",
+    [
+        "--check-drift",
+        "--require-migration",
+        "--require-migration-bodies",
+        "--require-grant-migration",
+    ],
+)
+def test_idempotent_no_longer_rejects_the_git_flags(project: Path, git_flag: str) -> None:  # noqa: ARG001
+    """No usage error for a combination that composed since 0.40.0.
 
-    Composition makes this combination safe in principle, but the guard is the
-    only loud-failure net over the flags #181 fixed. Removing it in the same
-    release as the refactor would trade a known-good behaviour for an unproven
-    one — so it stays one release longer, on purpose.
+    This project is not a git repo, so the git group fails on its own terms
+    (GIT_002 → exit 7). That is the point: the run gets far enough to *reach*
+    the git check instead of being turned away at the door with exit 5.
+
+    That both checks actually execute is proven in
+    ``test_validate_composition_git_and_db.py``, which has a real working tree.
     """
-    result = _invoke("--idempotent", "--check-drift")
+    result = _invoke("--idempotent", git_flag)
 
-    assert result.exit_code == 5, result.output
-    assert "--idempotent cannot be combined with --check-drift" in result.output
+    assert result.exit_code != 5, result.output
+    assert "cannot be combined with" not in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql-confiture"
-version = "0.40.0"
+version = "0.41.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Phase 05 of `.phases/2026-08-04-open-issues-backlog/`, plus phase 04's deferred
`--idempotent` conflict-guard retirement — which is why 0.41.0 is its own
release rather than a rider.

## What changes

**The ledger probe resolves a bare name through `search_path` (#188).**
`core/ledger.py` ran `information_schema.tables WHERE table_name = %s`, which is
schema-blind: a ledger in `staging` reported *present* to a session that would
go on to read `public`. It now runs `to_regclass`, resolving exactly as the
query it is a precondition for, and reports **which** relation it found.

A schema-qualified `tracking_table` deliberately keeps the old query.
`to_regclass('hidden.tb_secret')` **raises** `permission denied for schema
hidden` for a role without `USAGE`, where `information_schema` returns cleanly —
measured both ways on PostgreSQL 17.8. A qualified name already filters on
schema correctly, so converting it would buy nothing and would put an unhandled
psycopg exception on the hot ledger path, reopening the crash class #182 closed.

**One configuration changes answer**, and only one: a bare name whose ledger
sits in a schema off `search_path`. That configuration never worked — verified
empirically that the old probe said present, `initialize()` skipped the CREATE,
and the next statement died with `UndefinedTable`.

**`migrate up --auto-detect-baseline` refuses a ledger it cannot see.** Absence
now means "does not resolve here", which is the right precondition for reading
the ledger and the wrong trigger for rebuilding it. Without the guard the
command would build a second ledger and mark every migration applied in it. Exit
5, naming both what was searched and every schema holding the name.

**`migrate status` and `verify-checksums` report the resolved ledger** —
`resolved_table` in both JSON payloads (both schemas updated; they set
`additionalProperties: false`), and an absent ledger now says where it actually
is rather than "not present in this database".

**The `--idempotent` conflict guard is retired.** It composes with
`--check-drift` / `--require-migration` / `--require-migration-bodies` /
`--require-grant-migration` as of this release.

## Where the plan was wrong

Four of phase 05's own claims did not survive measurement, and the phase file
now records each: `to_regclass(…)::text` cannot carry a schema (so
`resolved_name` needs a `pg_class` join); `state.py` uses the **bare** path
under the default config, not "always" the qualified one; the bare path cannot
reach `InsufficientPrivilege` (search_path silently skips unusable schemas); and
the auto-baseline guard needs a second query, since `resolved_name` is None
exactly when the question is asked. The phase's headline claim — convert the
bare path only — held, and was load-bearing.

Also unanticipated: `to_regclass` resolves **every** relation kind, so a
sequence named `tb_confiture` would have started reading as a ledger. Filtered
to the kinds `information_schema.tables` reported, so search_path awareness is
the only behaviour that moves.

## Contract

No fraisier adapter floor bump — checked against the subcommand surface table,
not assumed. `migrate up` is on that surface this time, but the refusal fires
only under `--auto-detect-baseline`, which the adapter does not pass, and the
probe is a no-op for working configurations. Recorded as a behaviour advisory in
the contract doc.

## Verification

- 9755 passed, 79 skipped (9834 collected, 0 failures) — 9538 at 0.40.0
- `ruff check`, `ruff format --check`, `ty check`, `tests/contract`,
  `tests/unit/json_schemas` all clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings` clean
- Manual rehearsal against a real database with a non-`public` ledger:
  qualified ledger, ledger off `search_path`, and the auto-baseline refusal
  (exit 5 / `CONFIG_001`, nothing written)

Two doubles-related notes worth reading in the phase outcome: one stale patch
target survived the `ledger_exists` → `probe_ledger` move **silently** (the real
probe ran against a `MagicMock` whose row is truthy, so it read as "present"),
and this repo's CI cannot reach a database (6780/461 skipped there vs 9755/79
locally), so every semantic here is pinned by unit tests as well as integration
tests.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)