### PR TITLE
release: 0.42.0 — analyzer scoping (#184, #185) + lint rule selection (#150)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,6 +114,12 @@ jobs:
         # --no-sync keeps the wheel installed (see the install step above).
         uv run --no-sync pytest tests/ --cov=confiture --cov-report=xml --cov-report=term-missing -v
       env:
+        # See quality-gate.yml: CONFITURE_TEST_DB_URL is the variable the
+        # test fixtures read; without it the service container is unused and the
+        # DB-backed suite silently skips.
+        CONFITURE_TEST_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_test
+        CONFITURE_SOURCE_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_source_test
+        CONFITURE_TARGET_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_target_test
         DATABASE_URL: postgresql://confiture:confiture@localhost:5432/confiture_test
         SOURCE_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_source_test
         TARGET_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_target_test

--- a/.github/workflows/python-version-matrix.yml
+++ b/.github/workflows/python-version-matrix.yml
@@ -109,6 +109,12 @@ jobs:
 
     - name: Run tests with pytest
       env:
+        # See quality-gate.yml: CONFITURE_TEST_DB_URL is the variable the
+        # test fixtures read; without it the service container is unused and the
+        # DB-backed suite silently skips.
+        CONFITURE_TEST_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_test
+        CONFITURE_SOURCE_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_source_test
+        CONFITURE_TARGET_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_target_test
         DATABASE_URL: postgresql://confiture:confiture@localhost:5432/confiture_test
         SOURCE_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_source_test
         TARGET_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_target_test

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -78,6 +78,11 @@ jobs:
         uv run pytest --version
         rustc --version
         pg_isready -h localhost -p 5432 -U confiture && echo '✅ PostgreSQL Ready' || echo '❌ PostgreSQL Not Ready'
+        # Client version, on the record: pg_dump refuses to dump a server newer
+        # than itself, and pg_dump 17+ emits `SET transaction_timeout` which a
+        # 15 server rejects. Both directions of that skew break the restore
+        # round-trip tests, and neither is visible without this line.
+        pg_dump --version
         uv run python -c "import psycopg; conn = psycopg.connect('postgresql://confiture:confiture@localhost:5432/confiture_test'); print('✅ DB connection successful'); conn.close()" || echo "❌ DB connection failed"
         echo "=== Rust Extension Verification ==="
         uv run python -c "from confiture.core.builder import HAS_RUST; print(f'✅ Rust extension loaded: {HAS_RUST}')" || echo "❌ Builder import failed"
@@ -90,6 +95,18 @@ jobs:
 
     - name: Run core tests with coverage
       env:
+        # CONFITURE_TEST_DB_URL is the name tests/conftest.py's `test_db_url`
+        # fixture actually reads, and it was never set here: the service
+        # container above ran for nothing, ~460 DB-backed tests skipped on every
+        # PR (6780 passed / 461 skipped in CI vs 9792 / 79 locally), and any
+        # "integration tests cover this" claim gated nothing. DATABASE_URL is
+        # kept because tests/migration_testing/conftest.py reads that one, and
+        # both SOURCE/TARGET spellings are set because the syncer fixtures read
+        # the CONFITURE_-prefixed pair while the migration suites read the bare
+        # pair. Keep the whole block in sync when adding a database.
+        CONFITURE_TEST_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_test
+        CONFITURE_SOURCE_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_source_test
+        CONFITURE_TARGET_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_target_test
         DATABASE_URL: postgresql://confiture:confiture@localhost:5432/confiture_test
         SOURCE_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_source_test
         TARGET_DB_URL: postgresql://confiture:confiture@localhost:5432/confiture_target_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,101 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-08-06
+
+`--staged` becomes a real scope for every git-aware check (#184), SQL loaded
+through `Path(...).read_text()` is analyzed instead of skipped (#185),
+`confiture lint` gains ruff-style rule selection (#150) — and CI runs the
+database-backed test suite it has been provisioning and skipping since the
+suite existed.
+
+### ⚠️ Behaviour change
+
+- **`migrate validate --staged` now scopes `--check-drift`,
+  `--require-migration` and `--require-migration-bodies` to the staging index**
+  (#184). Only `--require-grant-migration` honoured the flag before; the others
+  compared `--base-ref` against `HEAD` regardless, so a pre-commit hook ignored
+  exactly the change being committed — while
+  `docs/guides/git-aware-validation.md` documented the combination as the
+  pre-commit recipe.
+
+  **What changes for you.** A hook running `--check-drift --staged` or
+  `--require-migration --staged` starts reporting findings it previously could
+  not see. That is the fix, not a regression: those runs were passing on a
+  comparison of the last commit with itself. Committed-ref runs (no `--staged`)
+  are unchanged.
+
+  Mechanically, staged mode materialises the index as a tree (`git write-tree`)
+  and uses it as the target ref, comparing from the merge base. Content comes
+  from the index blob, so a file staged and then edited further contributes its
+  staged content. A migration written but not `git add`-ed does not count as
+  accompanying a staged DDL change. In a shallow clone with no `origin/main`,
+  staged mode fails with `GIT_003` (exit 7) and the remedy rather than
+  reporting an empty scope.
+
+### Added
+
+- **`self.execute(Path("file.sql").read_text())` is resolved and analyzed**
+  (#185). The idempotency analyzer reported this shape as unanalyzable dynamic
+  SQL, so `migrate validate --idempotent` passed migrations whose statements it
+  had never read. Only a **literal** path resolves — `Path(target)` and
+  `(SQL_DIR / name)` are reported as a new `dynamic_read_text` warning whose
+  message names `execute_file(...)`, which resolves computed paths. Resolution
+  goes through `execute_file`'s own project-root confinement, so a path escaping
+  the project is refused rather than read, and reports the same
+  `execute_file_escaped` / `execute_file_missing` signals. Matching is pure
+  Python-AST, hence identical under `CONFITURE_IDEMPOTENCY_FORCE_REGEX=1`.
+
+- **`confiture lint --select` / `--ignore` / `--list-rules`** (#150), backed by
+  a rule registry (`core/linting/rule_registry.py`). Select by family
+  (`--select pk,naming`) or by code (`--select naming_001`); `--ignore` is
+  applied afterwards and always wins. `default` is a selector meaning "every
+  rule that is on by default", so `--select default,replica` is the usual lint
+  plus one opt-in family. An unknown code or family exits 5 listing the valid
+  set instead of silently selecting nothing. `--list-rules` prints the
+  catalogue as a table or as JSON (new schema: `lint-list-rules.schema.json`).
+
+- **Lint violations carry their rule code.** The text table gained a `Code`
+  column and JSON violations a `rule_id` field, so a finding maps back to the
+  selector that turns it off.
+
+- **`RestoreOptions.password`**, passed to `pg_restore` and the post-restore
+  `psql` ANALYZE via `PGPASSWORD` (never argv) and to the `--min-tables`
+  connection. `TestDbProvisioner` now forwards the password from its server
+  URL. Without it, `confiture restore` and `test-db provision --from-artifact`
+  — including the per-worker xdist fixtures — could not reach any server that
+  is not trust/peer-authenticated.
+
+### Deprecated
+
+- `confiture lint --replica-safe`, `--check-tenant-isolation` and
+  `--check-security-definer` are documented aliases for
+  `--select default,replica` / `default,tenant` / `default,security-definer`.
+  They keep working with identical output — pinned by test — and no removal is
+  scheduled. New lint rules register instead of adding a flag.
+
+### Fixed
+
+- **CI runs the DB-backed tests.** The quality gate started a PostgreSQL
+  service and exported `DATABASE_URL`, but the fixture every integration test
+  resolves through reads `CONFITURE_TEST_DB_URL`, so ~460 tests skipped on
+  every pull request (6780 passed / 461 skipped in CI vs 9792 / 79 locally).
+  All three pytest workflows now export the variables the fixtures actually
+  read. Turning them on surfaced 49 failures, fixed here: tests that rebuilt a
+  DSN field-by-field from psycopg's `ConnectionInfo` (which redacts the
+  password), tests that hardcoded `localhost:5432` for `pg_restore`, and one
+  `--force` walkthrough that two early `return`s had turned into a no-op.
+- **The shared test database no longer leaks confiture's helper schema.**
+  `migrate up` auto-installs the view helpers into a schema named `confiture`;
+  nothing dropped it, and under a role *also* named `confiture` — which is what
+  CI connects as — PostgreSQL's default `search_path` (`"$user", public`) then
+  silently redirected every later unqualified `CREATE TABLE` into it.
+  `install-helpers` now documents that interaction.
+- `confiture lint`'s help no longer claims an FK-index rule. `LintConfig`
+  carries `check_indexes` (computes a map, then discards it) and
+  `check_constraints` (no implementation); neither is listed by `--list-rules`
+  nor selectable, and both are left in place for library compatibility.
+
 ## [0.41.0] - 2026-08-05
 
 The migration-ledger probe answers the question its callers are actually asking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,6 +657,16 @@ uv run ruff check .
 uv run ty check python/confiture/
 ```
 
+### Adding a `confiture lint` rule
+
+Register it in `python/confiture/core/linting/rule_registry.py` — **do not add a
+per-rule CLI flag.** `--select` / `--ignore` / `--list-rules` are driven by that
+registry (#150), and the three flags that predate it (`--replica-safe`,
+`--check-tenant-isolation`, `--check-security-definer`) survive only as aliases.
+A rule that emits violations without a registry entry still reports (unregistered
+codes are never filtered out), but it is invisible to `--list-rules` and cannot
+be selected or ignored.
+
 Confiture runs a **deliberately focused ruff ruleset** (`E, W, F, I, B, C4, UP,
 ARG, SIM`), not the full prescribed superset. The heavier families (`PL, PERF,
 FURB, ERA, PTH, TCH, RUF`) are intentionally off for now; `[tool.ruff.lint]` in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.41.0
-**Last Updated**: 2026-08-05
+**Version**: 0.42.0
+**Last Updated**: 2026-08-06
 **Current Status**: Production-Ready
 
 > **Status**: Production-ready. Actively used in production since March 2026.
@@ -968,8 +968,8 @@ When stuck, ask:
 
 ---
 
-**Last Updated**: 2026-08-05
-**Version**: 0.41.0
+**Last Updated**: 2026-08-06
+**Version**: 0.42.0
 
 ---
 

--- a/docs/guides/git-aware-validation.md
+++ b/docs/guides/git-aware-validation.md
@@ -55,6 +55,28 @@ repos:
         stages: [commit]
 ```
 
+#### What `--staged` compares (0.42.0)
+
+`--staged` scopes the checks to the **staging index**: the content that `git
+commit` is about to record. Concretely, confiture writes the index out as a tree
+(`git write-tree`) and compares `merge-base(--base-ref, HEAD)` against that tree.
+
+Two consequences worth knowing:
+
+- A file that is staged and then edited further contributes its **staged**
+  content. The hook judges the commit, not the working tree.
+- A migration you wrote but did not `git add` does not count as accompanying a
+  staged DDL change — which is the point: it would not be in the commit either.
+
+Before 0.42.0 only `--require-grant-migration` honoured the flag; `--check-drift`
+and `--require-migration` compared `--base-ref` against `HEAD` even with
+`--staged` passed, so a pre-commit hook silently ignored the very change being
+committed (#184). If you relied on that hook passing, expect it to start
+reporting.
+
+In a shallow clone with no `origin/main`, staged mode fails with `GIT_003`
+(exit 7) naming the remedy rather than reporting an empty scope.
+
 **Setup:**
 ```bash
 # Install pre-commit
@@ -152,7 +174,7 @@ echo "✅ Schema validation passed"
 | `--require-migration` | - | Boolean | False | Ensure DDL changes have migration files |
 | `--base-ref` | - | String | `origin/main` | Reference point for comparison |
 | `--since` | - | String | None | Alias for `--base-ref` |
-| `--staged` | - | Boolean | False | Only validate staged files (pre-commit mode) |
+| `--staged` | - | Boolean | False | Compare the staging index instead of `HEAD` (pre-commit mode) |
 | `--format` | `-f` | String | `text` | Output format: `text` or `json` |
 | `--output` | `-o` | Path | None | Save output to file |
 

--- a/docs/guides/migrate-validate.md
+++ b/docs/guides/migrate-validate.md
@@ -267,6 +267,10 @@ without importing or executing the migration. The extractor handles:
 - f-strings with only literal parts: `self.execute(f"CREATE TABLE foo;")`
 - Constant string concatenation: `self.execute("CREATE " + "TABLE foo;")`
 - File references: `self.execute_file("db/schema/foo.sql")`
+- Literal file reads *(new in 0.42.0, #185)*:
+  `self.execute(Path("db/schema/foo.sql").read_text())`, with or without an
+  `encoding=` keyword, and `pathlib.Path(...)` spelled out. Only a string
+  **literal** is resolved — see below.
 - Keyword form: `self.execute(sql="…")`
 
 Calls whose argument can't be statically resolved produce a structured
@@ -280,6 +284,16 @@ top-level `warnings` array in JSON. Examples:
 - `self.execute_file("../../../outside/file.sql")` resolving outside the
   project root → `execute_file_escaped` (the file is **not** read)
 - `self.execute_file("db/schema/missing.sql")` → `execute_file_missing`
+- `self.execute(Path(target).read_text())`, or any other non-literal path
+  including `(SQL_DIR / "foo.sql").read_text()` → `dynamic_read_text`, whose
+  message names `execute_file(...)` as the supported alternative
+
+Resolved `read_text()` paths go through the **same** project-root confinement as
+`execute_file`, and report the same `execute_file_escaped` /
+`execute_file_missing` signals: a path escaping the project root is refused, not
+read. Resolution is pure AST matching — no variable, constant or expression is
+ever evaluated — and it is independent of the SQL backend, so
+`CONFITURE_IDEMPOTENCY_FORCE_REGEX=1` changes nothing here.
 
 Warnings do not fail the gate. Violations do. Combine the two
 appropriately for your CI policy: if you require zero dynamic SQL,
@@ -409,6 +423,11 @@ and pass. `--staged` reads the **staging index** instead:
 It analyzes the index blob, not the working tree — the two differ when a file is
 staged and then edited further, and the hook must judge what is about to be
 committed. When both `--staged` and `--base-ref` are passed, `--staged` wins.
+
+*Since 0.42.0* the same flag scopes `--check-drift`, `--require-migration` and
+`--require-migration-bodies` as well (#184); before that it reached only
+`--require-grant-migration`, and the others silently compared committed refs.
+See [git-aware validation](./git-aware-validation.md#what---staged-compares-0420).
 
 #### Scoping requires an explicit flag
 
@@ -741,8 +760,10 @@ confiture migrate validate --require-grant-migration --allow-grant-only --staged
   surface.
 - **SQL built by `str.format` / `%`-format.** Treated as dynamic. The
   template is not extracted even if the placeholders are not used.
-- **`Path(...).read_text()` outside of `execute_file()`.** Loaded SQL that
-  doesn't go through the official helper is invisible to the extractor.
+- **Non-literal `Path(...).read_text()`.** A literal path is resolved and
+  analyzed since 0.42.0; a computed one (`Path(target)`, `SQL_DIR / name`) is
+  reported as `dynamic_read_text`. Use `execute_file(<path>)`, which resolves
+  computed paths.
 
 These cases produce **warnings**, never silent passes — so a Python-only
 migrations directory full of dynamic SQL still exits 0 but tells you

--- a/docs/guides/schema-linting.md
+++ b/docs/guides/schema-linting.md
@@ -115,6 +115,73 @@ Exit code: 1 (failed)
 
 ---
 
+## Selecting rules — `--list-rules` / `--select` / `--ignore`
+
+*New in 0.42.0 (#150).*
+
+Every rule has a **code** (`naming_001`) and belongs to a **family** (`naming`).
+Start from the catalogue:
+
+```bash
+confiture lint --list-rules              # table: code, family, severity, default/opt-in
+confiture lint --list-rules --format json
+```
+
+| Rule | Family | Default | Notes |
+|------|--------|---------|-------|
+| `naming_001` | `naming` | on | Table names snake_case |
+| `naming_002` | `naming` | on | Column names snake_case |
+| `pk_001` | `pk` | on | Table has a primary key |
+| `doc_001` | `doc` | on | Table has a COMMENT |
+| `sec_001` | `security` | on | Secret-looking columns |
+| `acl_001` | `acl` | opt-in | Needs `acls.lint_enabled: true` |
+| `tenant_001` | `tenant` | opt-in | Multi-tenant FK isolation |
+| `replica_001` | `replica` | opt-in | Replica forward-compatibility |
+| `sec_002` | `security-definer` | opt-in | Needs `security_lint.enabled: true` |
+
+`sec_001` and `sec_002` share a code prefix but are different rules in different
+families — the flag that shipped `sec_002` named `security-definer`, and that is
+the selector.
+
+Select and skip by code or family:
+
+```bash
+confiture lint --select pk,naming          # only those families
+confiture lint --select naming_001         # one rule
+confiture lint --ignore doc                # the defaults, minus doc_001
+confiture lint --select default,replica    # the defaults plus a family
+```
+
+- **No `--select`** runs the default set — unchanged from earlier releases.
+- **`default`** is a selector meaning "every rule marked on", so opt-in families
+  can be *added* rather than replacing the defaults.
+- **`--ignore` wins over `--select`.** `--select naming --ignore naming_001` runs
+  `naming_002` only.
+- An unknown code or family **fails** with exit 5 and lists the valid set, rather
+  than quietly selecting nothing.
+- Selecting a rule is necessary but not always sufficient: `acl_001` and
+  `sec_002` also need their configuration block (see the table).
+
+### The three per-rule flags are now aliases
+
+`--replica-safe`, `--check-tenant-isolation` and `--check-security-definer` still
+work and mean exactly what they always did — the defaults plus that one family:
+
+| Flag | Equivalent |
+|------|-----------|
+| `--replica-safe` | `--select default,replica` |
+| `--check-tenant-isolation` | `--select default,tenant` |
+| `--check-security-definer` | `--select default,security-definer` |
+
+They are deprecated in the help text with no removal scheduled. New rules
+register in `confiture/core/linting/rule_registry.py` instead of adding a flag.
+
+Violation output now carries the code: the text table gained a **Code** column
+and JSON violations a `rule_id` field, so a finding maps back to the selector
+that turns it off.
+
+---
+
 ## Configuring Rules
 
 ### Option 1: YAML Configuration

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -370,6 +370,19 @@ Live-database drift report against expected DDL.
 
 Shape is identical to plain `drift` — items of type `missing_grant` / `extra_grant` may appear in `drift_items`.
 
+### `confiture lint --list-rules --format json`
+
+[lint-list-rules.schema.json](./json-schemas/lint-list-rules.schema.json)
+
+The rule catalogue: one entry per rule `confiture lint` can apply, carrying the
+`code` that `--select` / `--ignore` accept, its `family`, default severity,
+whether it runs by default, the deprecated per-rule flag it replaces (or
+`null`), and any configuration it additionally requires (#150). Report mode —
+always exits 0, never reads a schema.
+
+`code` matches the `rule_id` field on lint violations, so a finding can be
+mapped back to the selector that turns it off.
+
 ---
 
 ## Field-name traps (issue #123)

--- a/docs/reference/json-schemas/lint-list-rules.schema.json
+++ b/docs/reference/json-schemas/lint-list-rules.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confiture.fraiseql.dev/schemas/lint-list-rules.schema.json",
+  "title": "confiture lint --list-rules --format json",
+  "description": "The catalogue of rules `confiture lint` can apply, and the identifiers `--select` / `--ignore` accept (#150). A report mode: it never inspects a schema and always exits 0.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "status", "rules", "hints"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1"
+    },
+    "status": {
+      "type": "string",
+      "const": "ok"
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "code",
+          "family",
+          "title",
+          "severity",
+          "default_on",
+          "legacy_flag",
+          "requires_config"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable rule identifier, as it appears in violation output (`rule_id`)."
+          },
+          "family": {
+            "type": "string",
+            "description": "Selector group. Usually the code prefix — `sec_001` (security) and `sec_002` (security-definer) are the exception."
+          },
+          "title": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["error", "warning", "info"],
+            "description": "Severity the rule emits by default. sec_002 and replica_001 can be escalated by configuration."
+          },
+          "default_on": {
+            "type": "boolean",
+            "description": "Whether a plain `confiture lint` applies the rule."
+          },
+          "legacy_flag": {
+            "type": ["string", "null"],
+            "description": "Pre-0.42.0 per-rule flag kept as an alias, or null."
+          },
+          "requires_config": {
+            "type": ["string", "null"],
+            "description": "Configuration the rule additionally needs; selecting it is necessary, not sufficient."
+          }
+        }
+      }
+    },
+    "hints": {
+      "$ref": "_common.schema.json#/$defs/HintsArray"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.41.0"
+version = "0.42.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/admin.py
+++ b/python/confiture/cli/commands/admin.py
@@ -127,6 +127,11 @@ def install_helpers(
     Creates the `confiture` schema with `save_and_drop_dependent_views()`
     and `recreate_saved_views()` PL/pgSQL functions for use in migrations
     that need to ALTER COLUMN TYPE on tables with dependent views.
+
+    NOTE: if the role you connect as is *itself* named `confiture`, PostgreSQL's
+    default `search_path` (`"$user", public`) puts this new schema ahead of
+    public for that role — so unqualified CREATE statements start landing in it.
+    Schema-qualify your DDL, or pin `search_path` on that role.
     """
     try:
         from confiture.core.connection import load_config

--- a/python/confiture/cli/commands/schema.py
+++ b/python/confiture/cli/commands/schema.py
@@ -19,6 +19,7 @@ from confiture.core.error_handler import handle_cli_error, print_error_to_consol
 from confiture.core.introspector import SchemaIntrospector
 from confiture.core.linting import SchemaLinter
 from confiture.core.linting.schema_linter import LintConfig as LinterConfig
+from confiture.core.linting.schema_linter import LintReport as LinterReport
 from confiture.core.schema_artifact import build_schema_artifact, default_artifact_path
 from confiture.core.seed_applier import SeedApplier
 from confiture.exceptions import ConfigurationError, SchemaError, SeedError
@@ -721,11 +722,31 @@ def lint(
         "--fail-on-warning",
         help="Exit with code 1 if warnings found (default: off, stricter)",
     ),
+    select: list[str] = typer.Option(
+        None,
+        "--select",
+        help="Rules or families to run, comma-separated (#150). `default` means "
+        "the rules a plain lint runs, so `--select default,replica` is the "
+        "defaults plus one family. Omit to run the defaults. "
+        "See `--list-rules`.",
+    ),
+    ignore: list[str] = typer.Option(
+        None,
+        "--ignore",
+        help="Rules or families to skip, comma-separated. Applied after --select, "
+        "so --ignore always wins.",
+    ),
+    list_rules: bool = typer.Option(
+        False,
+        "--list-rules",
+        help="Print the rule catalogue (code, family, severity, default/opt-in) "
+        "and exit 0. Honours --format json.",
+    ),
     replica_safe: bool = typer.Option(
         False,
         "--replica-safe",
-        help="Also run the replica-aware forward-compatibility lint over the "
-        "migrations tree (#139).",
+        help="Deprecated alias for `--select default,replica` (#139). Still "
+        "supported; new rules register instead of adding a flag.",
     ),
     migrations_dir: Path = typer.Option(
         Path("db/migrations"),
@@ -735,13 +756,14 @@ def lint(
     check_tenant_isolation: bool = typer.Option(
         False,
         "--check-tenant-isolation",
-        help="Enable the multi-tenant isolation rule (tenant_001): flag function "
-        "INSERTs missing the FK column a tenant-scoped view requires (default: off).",
+        help="Deprecated alias for `--select default,tenant` (tenant_001): flag "
+        "function INSERTs missing the FK column a tenant-scoped view requires.",
     ),
     check_security_definer: bool = typer.Option(
         False,
         "--check-security-definer",
-        help="Also run sec_002 over the env's schema DDL: flag SECURITY DEFINER "
+        help="Deprecated alias for `--select default,security-definer`. Runs "
+        "sec_002 over the env's schema DDL: flag SECURITY DEFINER "
         "functions/procedures that do not pin search_path (CVE-2018-1058). "
         "No-op when the config has no `security_lint:` block or "
         "`security_lint.enabled` is false. Default severity is advisory "
@@ -754,25 +776,40 @@ def lint(
     """Validate schema against best practices.
 
     PROCESS:
-      Checks schema against 5 default rules (naming conventions, primary keys,
-      documentation, FK indexes, security) plus two opt-in rules: ACL coverage
-      (acl_001) and multi-tenant isolation (tenant_001). Results in table or
-      JSON format.
+      Runs the default rule set — naming_001, naming_002, pk_001, doc_001,
+      sec_001 — plus whatever `--select` adds. `--list-rules` prints the full
+      catalogue with codes and families. Results in table, JSON or CSV.
 
     RULES:
-      naming, primary keys, documentation, FK indexes, security — always on
-      (toggle via LintConfig fields).
+      Select by code or family: `--select pk,naming`, `--select naming_001`,
+      `--ignore doc`. `default` means every rule that is on by default, so
+      `--select default,replica` is the usual lint plus one opt-in family.
+      `--ignore` wins over `--select`; an unknown selector exits 5.
+
+      naming_001, naming_002, pk_001, doc_001, sec_001 — on by default.
+      (LintConfig also carries check_indexes / check_constraints; neither has a
+      rule behind it, so neither is listed or selectable.)
 
       ACL coverage (acl_001) — opt-in. Set ``acls.lint_enabled: true`` in
       the environment YAML to enable.  Merely defining ``acls:`` no longer
       auto-fires the rule (changed in 0.12.0).  See ``docs/guides/acl-coverage.md``.
 
-      Multi-tenant isolation (tenant_001) — opt-in via ``--check-tenant-isolation``.
-      Detects function INSERTs that omit the FK column a tenant-scoped view needs.
+      Multi-tenant isolation (tenant_001) — opt-in via ``--select default,tenant``
+      (or the ``--check-tenant-isolation`` alias). Detects function INSERTs that
+      omit the FK column a tenant-scoped view needs.
 
     EXAMPLES:
       confiture lint
         ↳ Lint local environment, display results as table
+
+      confiture lint --list-rules
+        ↳ Print every rule with its code, family and default state
+
+      confiture lint --select pk,naming
+        ↳ Run only the primary-key and naming families
+
+      confiture lint --ignore doc
+        ↳ The default rules, minus doc_001
 
       confiture lint --env production
         ↳ Lint production environment
@@ -807,18 +844,44 @@ def lint(
                 output_file=output,
             )
 
+        if list_rules:
+            _emit_rule_catalogue(format_type, output)
+            return
+
+        # One selection, resolved once (#150). The three per-rule flags are
+        # aliases over it rather than branches further down: each adds its
+        # family to the defaults, which is exactly what it always did.
+        selected = _resolve_lint_rules(
+            select=select,
+            ignore=ignore,
+            replica_safe=replica_safe,
+            check_tenant_isolation=check_tenant_isolation,
+            check_security_definer=check_security_definer,
+        )
+
         # Create linter configuration (use LinterConfig for the linter)
         config = LinterConfig(
             enabled=True,
             fail_on_error=fail_on_error,
             fail_on_warning=fail_on_warning,
-            check_tenant_isolation=check_tenant_isolation,
+            check_naming="naming_001" in selected or "naming_002" in selected,
+            check_primary_keys="pk_001" in selected,
+            check_documentation="doc_001" in selected,
+            check_security="sec_001" in selected,
+            check_tenant_isolation="tenant_001" in selected,
+            check_acl_coverage="acl_001" in selected,
         )
 
         # Create linter and run linting
         console.print(f"[cyan]🔍 Linting schema for environment: {env}[/cyan]")
         linter = SchemaLinter(env=env, config=config)
         linter_report = linter.lint()
+
+        # LintConfig's switches are coarser than the rule codes — `check_naming`
+        # covers naming_001 *and* naming_002 — so `--select naming_001` needs a
+        # second pass over the findings. Cheap, and it means every rule is
+        # selectable individually without reshaping LintConfig.
+        _keep_selected_rules(linter_report, selected)
 
         # Convert to model LintReport for formatting
         report = _convert_linter_report(linter_report, schema_name=env)
@@ -849,7 +912,7 @@ def lint(
 
         # #139: replica-aware forward-compatibility lint over the migrations tree
         # (a migration-tree check, distinct from the schema lint above).
-        if replica_safe:
+        if "replica_001" in selected:
             from confiture.core.linting.libraries.replica import Replica001ForwardCompat
             from confiture.core.linting.schema_linter import RuleSeverity
 
@@ -890,7 +953,7 @@ def lint(
         # Note: sec_002 findings print to the console here; they are NOT
         # folded into the JSON report produced above.  For machine-readable
         # output use `migrate validate --check-security-definer --format json`.
-        if check_security_definer:
+        if "sec_002" in selected:
             from confiture.core.builder import SchemaBuilder
             from confiture.core.linting.libraries.security_definer import (
                 Sec002SecurityDefinerSearchPath,
@@ -948,7 +1011,7 @@ def lint(
                     or (_sd_errors and fail_on_error)
                     or (_sd_warnings and fail_on_warning)
                 )
-            elif check_security_definer and _sec_cfg is not None:
+            elif _sec_cfg is not None:
                 console.print("\n[green]🔒 Security-definer search_path lint: no issues[/green]")
 
         if should_fail:
@@ -963,6 +1026,103 @@ def lint(
     except Exception as e:
         print_error_to_console(e)
         raise typer.Exit(handle_cli_error(e)) from e
+
+
+def _keep_selected_rules(linter_report: LinterReport, selected: frozenset[str]) -> None:
+    """Drop findings whose rule was deselected (#150), in place.
+
+    Only rules the registry knows are filtered. A violation carrying an
+    unregistered code — a rule added to the linter without registering it, or a
+    consumer's own — is passed through rather than silently swallowed: it could
+    not have been selected, and dropping it would turn "I forgot to register my
+    rule" into "my rule stopped reporting".
+    """
+    from confiture.core.linting.rule_registry import LINT_RULES
+
+    known = {rule.code for rule in LINT_RULES}
+    for bucket in (linter_report.errors, linter_report.warnings, linter_report.info):
+        bucket[:] = [v for v in bucket if v.rule_id in selected or v.rule_id not in known]
+
+
+def _resolve_lint_rules(
+    *,
+    select: list[str] | None,
+    ignore: list[str] | None,
+    replica_safe: bool,
+    check_tenant_isolation: bool,
+    check_security_definer: bool,
+) -> frozenset[str]:
+    """The rule codes this invocation applies, legacy flags folded in.
+
+    Each legacy flag means "the defaults *plus* this family", which is what it
+    did when it was a branch of its own. Expressing them as selectors keeps one
+    dispatch path — the point of #150 — and makes them exactly equivalent to the
+    ``--select`` form they are documented as aliasing.
+
+    Raises:
+        ConfigurationError: An unknown code or family was named.
+    """
+    from confiture.core.linting.rule_registry import DEFAULT_SELECTOR, resolve_selection
+
+    aliases = [
+        rule_family
+        for enabled, rule_family in (
+            (replica_safe, "replica"),
+            (check_tenant_isolation, "tenant"),
+            (check_security_definer, "security-definer"),
+        )
+        if enabled
+    ]
+    effective = list(select or [])
+    if aliases:
+        # A bare legacy flag keeps the default rules; combined with --select it
+        # extends whatever that selected, rather than re-adding the defaults.
+        effective = (effective or [DEFAULT_SELECTOR]) + aliases
+    return resolve_selection(effective or None, ignore or ())
+
+
+def _emit_rule_catalogue(format_type: str, output: Path | None) -> None:
+    """Print the rule registry: `confiture lint --list-rules`.
+
+    A report mode — it never consults the schema and always exits 0, so it works
+    in a project that does not lint cleanly (or at all).
+    """
+    from confiture.core.linting.rule_registry import LINT_RULES
+
+    if is_json(format_type):
+        _output_json(
+            {
+                "version": "1",
+                "status": "ok",
+                "rules": [rule.to_dict() for rule in LINT_RULES],
+                "hints": [],
+            },
+            output,
+            console,
+        )
+        return
+
+    from rich.table import Table
+
+    table = Table(title="confiture lint rules", show_lines=False)
+    table.add_column("Code", style="cyan")
+    table.add_column("Family", style="magenta")
+    table.add_column("Severity")
+    table.add_column("Default")
+    table.add_column("Description")
+    for rule in LINT_RULES:
+        table.add_row(
+            rule.code,
+            rule.family,
+            rule.severity,
+            "on" if rule.default_on else "opt-in",
+            rule.title + (f" (needs {rule.requires_config})" if rule.requires_config else ""),
+        )
+    console.print(table)
+    console.print(
+        "\n[dim]Select with --select <family|code>[,…]; skip with --ignore. "
+        "`default` selects every rule marked on.[/dim]"
+    )
 
 
 def lint_unified(

--- a/python/confiture/cli/commands/validate_checks.py
+++ b/python/confiture/cli/commands/validate_checks.py
@@ -168,9 +168,13 @@ def _run_git_group(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcom
     # HEAD, which is the whole point of a pre-commit flag. Grant accompaniment
     # keeps its own `staged_only` path: it diffs grant *files* through the index
     # directly and never built a schema from a ref.
-    base_ref = ctx.git_base_ref
-    target_ref = ctx.git_target_ref
-
+    #
+    # Read `ctx.git_base_ref` / `ctx.git_target_ref` only inside the branches
+    # that use them. Staged resolution runs real git (`rev-parse --verify`,
+    # `merge-base`, `write-tree`) and can legitimately fail with GIT_003 in a
+    # shallow clone, so resolving it up front would make
+    # `--require-grant-migration --staged` — which needs neither ref — start
+    # failing in exactly the CI checkout where it used to work.
     requested: list[str] = []
     results: dict[str, dict[str, Any]] = {}
     failed: list[str] = []
@@ -180,8 +184,8 @@ def _run_git_group(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcom
         try:
             drift_result = validate_git_drift(
                 env=opts.git_env,
-                base_ref=base_ref,
-                target_ref=target_ref,
+                base_ref=ctx.git_base_ref,
+                target_ref=ctx.git_target_ref,
                 console=console,
                 format_output=opts.format_output,
             )
@@ -196,8 +200,8 @@ def _run_git_group(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcom
         try:
             acc_result = validate_migration_accompaniment(
                 env=opts.git_env,
-                base_ref=base_ref,
-                target_ref=target_ref,
+                base_ref=ctx.git_base_ref,
+                target_ref=ctx.git_target_ref,
                 console=console,
                 format_output=opts.format_output,
                 check_bodies=opts.require_migration_bodies,

--- a/python/confiture/cli/commands/validate_checks.py
+++ b/python/confiture/cli/commands/validate_checks.py
@@ -161,10 +161,15 @@ def _run_git_group(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcom
     # NotAGitRepositoryError (GIT_002 → exit 7) propagates to fail().
     validate_git_flags_in_repo()
 
-    # ARCH-L1: --staged is only meaningful for the grant-accompaniment check.
-    # Drift and migration accompaniment compare committed refs (base_ref →
-    # HEAD); diffing the staged index for them is not implemented.
-    target_ref = "HEAD"
+    # ARCH-L1, revised in 0.42.0 (#184): --staged now reaches every check here,
+    # not just grant accompaniment. The context resolves one (base, target) pair
+    # for the group — in staged mode the target is the index materialised as a
+    # tree, so what gets judged is what is about to be committed rather than
+    # HEAD, which is the whole point of a pre-commit flag. Grant accompaniment
+    # keeps its own `staged_only` path: it diffs grant *files* through the index
+    # directly and never built a schema from a ref.
+    base_ref = ctx.git_base_ref
+    target_ref = ctx.git_target_ref
 
     requested: list[str] = []
     results: dict[str, dict[str, Any]] = {}
@@ -175,7 +180,7 @@ def _run_git_group(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcom
         try:
             drift_result = validate_git_drift(
                 env=opts.git_env,
-                base_ref=ctx.effective_base_ref,
+                base_ref=base_ref,
                 target_ref=target_ref,
                 console=console,
                 format_output=opts.format_output,
@@ -191,11 +196,12 @@ def _run_git_group(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcom
         try:
             acc_result = validate_migration_accompaniment(
                 env=opts.git_env,
-                base_ref=ctx.effective_base_ref,
+                base_ref=base_ref,
                 target_ref=target_ref,
                 console=console,
                 format_output=opts.format_output,
                 check_bodies=opts.require_migration_bodies,
+                two_dot=opts.staged,
             )
         except Exception as e:
             raise GitError(f"Accompaniment check failed: {e}") from e
@@ -213,7 +219,7 @@ def _run_git_group(opts: ValidateOptions, ctx: ValidationContext) -> CheckOutcom
             try:
                 grant_result = validate_grant_accompaniment(
                     base_ref=ctx.effective_base_ref,
-                    target_ref=target_ref,
+                    target_ref="HEAD",
                     staged_only=opts.staged,
                     console=console,
                     format_output=opts.format_output,

--- a/python/confiture/cli/git_validation.py
+++ b/python/confiture/cli/git_validation.py
@@ -95,6 +95,7 @@ def validate_migration_accompaniment(
     format_output: str = "text",
     *,
     check_bodies: bool = False,
+    two_dot: bool = False,
 ) -> dict:
     """Validate that DDL changes have migration files.
 
@@ -106,6 +107,8 @@ def validate_migration_accompaniment(
         format_output: Output format (text or json)
         check_bodies: Also require function *body* changes to be carried by a
             migration (#178).
+        two_dot: Diff two-dot rather than three-dot; set when *target_ref* is a
+            tree (the staged index, #184) instead of a commit.
 
     Returns:
         Dictionary with validation results
@@ -118,7 +121,9 @@ def validate_migration_accompaniment(
         validate_git_flags_in_repo()
 
         checker = MigrationAccompanimentChecker(env)
-        report = checker.check_accompaniment(base_ref, target_ref, check_bodies=check_bodies)
+        report = checker.check_accompaniment(
+            base_ref, target_ref, check_bodies=check_bodies, two_dot=two_dot
+        )
 
         if format_output == "text":
             if report.migration_error:

--- a/python/confiture/cli/helpers.py
+++ b/python/confiture/cli/helpers.py
@@ -120,6 +120,7 @@ def _convert_linter_report(linter_report: LinterReport, schema_name: str = "sche
     for violation in linter_report.errors:
         violations.append(
             Violation(
+                rule_id=violation.rule_id,
                 rule_name=violation.rule_name,
                 severity=severity_map[violation.severity],
                 message=violation.message,
@@ -130,6 +131,7 @@ def _convert_linter_report(linter_report: LinterReport, schema_name: str = "sche
     for violation in linter_report.warnings:
         violations.append(
             Violation(
+                rule_id=violation.rule_id,
                 rule_name=violation.rule_name,
                 severity=severity_map[violation.severity],
                 message=violation.message,
@@ -140,6 +142,7 @@ def _convert_linter_report(linter_report: LinterReport, schema_name: str = "sche
     for violation in linter_report.info:
         violations.append(
             Violation(
+                rule_id=violation.rule_id,
                 rule_name=violation.rule_name,
                 severity=severity_map[violation.severity],
                 message=violation.message,

--- a/python/confiture/cli/lint_formatter.py
+++ b/python/confiture/cli/lint_formatter.py
@@ -76,6 +76,8 @@ def format_table(report: LintReport, console: Console) -> None:
     # Violations table
     table = Table(title="Violations")
     table.add_column("Severity", style="bold")
+    # The code, not just the prose name: it is what --select / --ignore take.
+    table.add_column("Code", style="cyan")
     table.add_column("Rule", style="cyan")
     table.add_column("Location", style="yellow")
     table.add_column("Message", style="white")
@@ -90,6 +92,7 @@ def format_table(report: LintReport, console: Console) -> None:
     ):
         table.add_row(
             _severity_string(violation.severity),
+            violation.rule_id,
             violation.rule_name,
             violation.location,
             violation.message,
@@ -133,6 +136,7 @@ def format_json(report: LintReport) -> str:
             "items": [
                 {
                     "rule": v.rule_name,
+                    "rule_id": v.rule_id,
                     "severity": v.severity.value,
                     "location": v.location,
                     "message": v.message,

--- a/python/confiture/core/git.py
+++ b/python/confiture/core/git.py
@@ -358,6 +358,51 @@ class GitRepository:
 
         return result.stdout
 
+    def staged_tree_oid(self) -> str:
+        """Materialise the staging index as a tree object and return its OID.
+
+        This is what makes ``--staged`` a real scope for the git-aware checks
+        (#184): the resulting OID is a tree-ish, so ``git ls-tree`` and ``git
+        show <oid>:<path>`` read it exactly like a commit — the schema builder
+        and the file readers need no staged-specific code path. Reading the
+        index this way (rather than the working tree) is the point: a file that
+        is staged and then edited further contributes its **staged** content,
+        which is what the commit will contain.
+
+        ``git write-tree`` is index-global regardless of the directory it runs
+        in, but it runs from the repository root anyway so this behaves like
+        every other path here (#181's cwd-is-not-the-root trap).
+
+        Returns:
+            The tree OID. An empty index yields git's empty-tree OID, which is
+            a valid tree and compares as "nothing staged" rather than failing.
+
+        Raises:
+            NotAGitRepositoryError: If not in a git repository.
+            GitError: If the index cannot be written — notably during an
+                unresolved merge conflict, where no single tree exists.
+        """
+        root = self.get_repo_root()
+
+        try:
+            result = subprocess.run(
+                ["git", "write-tree"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise GitError("Git command timed out writing the staged index to a tree") from e
+
+        if result.returncode != 0 or not result.stdout.strip():
+            raise GitError(
+                "Cannot read the staged index: "
+                + (result.stderr.strip() or "git write-tree failed")
+            )
+
+        return result.stdout.strip()
+
     def get_merge_base(self, base_ref: str, target_ref: str) -> str | None:
         """Return the merge-base commit of two refs (``git merge-base``).
 

--- a/python/confiture/core/git_accompaniment.py
+++ b/python/confiture/core/git_accompaniment.py
@@ -49,7 +49,12 @@ class MigrationAccompanimentChecker:
         self.differ = GitSchemaDiffer(env, self.repo_path)
 
     def check_accompaniment(
-        self, base_ref: str, target_ref: str = "HEAD", *, check_bodies: bool = False
+        self,
+        base_ref: str,
+        target_ref: str = "HEAD",
+        *,
+        check_bodies: bool = False,
+        two_dot: bool = False,
     ) -> MigrationAccompanimentReport:
         """Check if DDL changes are accompanied by migrations.
 
@@ -64,6 +69,12 @@ class MigrationAccompanimentChecker:
             check_bodies: Also flag function *body* changes not carried by a
                 migration (#178). Off by default — opt-in via
                 ``--require-migration-bodies``.
+            two_dot: Diff ``base..target`` instead of ``base...target``. Required
+                when *target_ref* is a tree rather than a commit — the staged
+                index (#184) — because a symmetric difference has to compute a
+                merge base and git rejects a tree there. Callers passing this
+                are expected to have resolved *base_ref* to the merge base
+                themselves, which is what makes the two forms equivalent.
 
         Returns:
             MigrationAccompanimentReport with validation results
@@ -80,7 +91,7 @@ class MigrationAccompanimentChecker:
             >>> print(f"Valid: {report.is_valid}")
         """
         # Get new migration files regardless of whether schema parsing succeeds
-        new_migrations = self._get_new_migrations(base_ref, target_ref)
+        new_migrations = self._get_new_migrations(base_ref, target_ref, two_dot=two_dot)
 
         try:
             diff = self.differ.compare_refs(base_ref, target_ref)
@@ -99,12 +110,12 @@ class MigrationAccompanimentChecker:
 
         # Check function signature violations (param type changes need DROP FUNCTION)
         signature_violations = self._check_signature_violations(
-            new_migrations, base_ref, target_ref
+            new_migrations, base_ref, target_ref, two_dot=two_dot
         )
 
         # Check function body violations (body edits need a re-defining migration)
         body_violations = (
-            self._check_body_violations(new_migrations, base_ref, target_ref)
+            self._check_body_violations(new_migrations, base_ref, target_ref, two_dot=two_dot)
             if check_bodies
             else []
         )
@@ -125,10 +136,12 @@ class MigrationAccompanimentChecker:
         new_migrations: list[Path],
         base_ref: str,
         target_ref: str,
+        *,
+        two_dot: bool = False,
     ) -> list:
         """Return function signature violations for changed function files."""
         try:
-            function_files = self._get_changed_function_files(base_ref, target_ref)
+            function_files = self._get_changed_function_files(base_ref, target_ref, two_dot=two_dot)
             if not function_files:
                 return []
 
@@ -152,10 +165,12 @@ class MigrationAccompanimentChecker:
         new_migrations: list[Path],
         base_ref: str,
         target_ref: str,
+        *,
+        two_dot: bool = False,
     ) -> list:
         """Return function body violations for changed function files (#178)."""
         try:
-            function_files = self._get_changed_function_files(base_ref, target_ref)
+            function_files = self._get_changed_function_files(base_ref, target_ref, two_dot=two_dot)
             if not function_files:
                 return []
 
@@ -174,9 +189,11 @@ class MigrationAccompanimentChecker:
             # Body check is best-effort — never block CI on unexpected errors.
             return []
 
-    def _get_changed_function_files(self, base_ref: str, target_ref: str) -> list[Path]:
+    def _get_changed_function_files(
+        self, base_ref: str, target_ref: str, *, two_dot: bool = False
+    ) -> list[Path]:
         """Return SQL files that changed between refs and contain function definitions."""
-        changed_files = self.git_repo.get_changed_files(base_ref, target_ref)
+        changed_files = self._changed_files(base_ref, target_ref, two_dot=two_dot)
         result = []
         for f in changed_files:
             if not f.name.endswith(".sql"):
@@ -189,7 +206,15 @@ class MigrationAccompanimentChecker:
                 result.append(f)
         return result
 
-    def _get_new_migrations(self, base_ref: str, target_ref: str = "HEAD") -> list[Path]:
+    def _changed_files(self, base_ref: str, target_ref: str, *, two_dot: bool) -> list[Path]:
+        """Files changed between the refs, two-dot when the target is a tree."""
+        if two_dot:
+            return self.git_repo.get_changed_files_two_dot(base_ref, target_ref)
+        return self.git_repo.get_changed_files(base_ref, target_ref)
+
+    def _get_new_migrations(
+        self, base_ref: str, target_ref: str = "HEAD", *, two_dot: bool = False
+    ) -> list[Path]:
         """Get list of new migration files between refs.
 
         Searches for migration files (*.up.sql) that are new or modified
@@ -208,7 +233,7 @@ class MigrationAccompanimentChecker:
             GitError: If git operations fail
         """
         # Get all changed files between refs
-        changed_files = self.git_repo.get_changed_files(base_ref, target_ref)
+        changed_files = self._changed_files(base_ref, target_ref, two_dot=two_dot)
 
         # Filter to migration files in db/migrations/ directory.
         # Accepts both .up.sql files and .py migration files (generated by

--- a/python/confiture/core/idempotency/python_migration_extractor.py
+++ b/python/confiture/core/idempotency/python_migration_extractor.py
@@ -58,6 +58,7 @@ class WarningKind(Enum):
 
     DYNAMIC_EXECUTE = "dynamic_execute"
     DYNAMIC_EXECUTE_FILE = "dynamic_execute_file"
+    DYNAMIC_READ_TEXT = "dynamic_read_text"
     UNRESOLVED_FSTRING = "unresolved_fstring"
     EXECUTE_FILE_MISSING = "execute_file_missing"
     EXECUTE_FILE_ESCAPED = "execute_file_escaped"
@@ -154,8 +155,29 @@ def _resolve_sql_path(
     migration_path: Path,
     project_root: Path,
     source_line: int,
+    call_desc: str | None = None,
 ) -> tuple[Path | None, ExtractionWarning | None]:
-    """Resolve a constant ``execute_file`` path against the project boundary."""
+    """Resolve a literal SQL-file path against the project boundary.
+
+    The single boundary for every shape that names a file on disk —
+    ``execute_file(...)`` and ``execute(Path(...).read_text())`` alike. Keeping
+    one implementation is the point: a second resolution path would be a
+    path-traversal regression against the v0.8.4 hardening, so the read_text
+    shape routes here rather than reading the file itself.
+
+    Args:
+        raw: The literal path as written in the migration.
+        migration_path: The migration being analyzed (warning provenance, and
+            the fallback resolution base).
+        project_root: Confinement boundary; anything resolving outside is refused.
+        source_line: Line of the call, for the warning.
+        call_desc: How to name the call in warnings. Defaults to the
+            ``execute_file(...)`` wording.
+
+    Returns:
+        ``(resolved_path, None)`` or ``(None, warning)``.
+    """
+    described = call_desc or f"execute_file({raw!r})"
     raw_path = Path(raw)
     candidate = raw_path if raw_path.is_absolute() else Path.cwd() / raw_path
     if not candidate.exists():
@@ -170,18 +192,97 @@ def _resolve_sql_path(
             kind=WarningKind.EXECUTE_FILE_ESCAPED,
             source_file=migration_path,
             source_line=source_line,
-            message=(
-                f"execute_file({raw!r}) resolves outside project_root ({root}); refusing to read"
-            ),
+            message=(f"{described} resolves outside project_root ({root}); refusing to read"),
         )
     if not resolved.is_file():
         return None, ExtractionWarning(
             kind=WarningKind.EXECUTE_FILE_MISSING,
             source_file=migration_path,
             source_line=source_line,
-            message=f"execute_file({raw!r}) not found on disk (looked at {resolved})",
+            message=f"{described} not found on disk (looked at {resolved})",
         )
     return resolved, None
+
+
+def _read_text_literal_path(node: ast.expr) -> tuple[str | None, bool]:
+    """Recognise ``Path("<literal>").read_text()`` inside ``self.execute(...)`` (#185).
+
+    Migrations that keep their SQL in a file but call ``execute`` rather than
+    ``execute_file`` were reported as unanalyzable dynamic SQL, so the
+    idempotency gate passed them without ever reading the statements. Exactly
+    one shape is recognised — ``Path`` (or ``pathlib.Path``) applied to a string
+    **literal**, with ``read_text()`` taking no positional arguments:
+
+        self.execute(Path("db/schema/fn.sql").read_text())
+        self.execute(Path("db/schema/fn.sql").read_text(encoding="utf-8"))
+
+    Anything else (a variable, a ``/``-joined expression, a module constant) is
+    reported rather than evaluated. Evaluating user expressions to find a path
+    is a different and much larger commitment than matching a literal, and
+    ``execute_file`` already covers those cases with full resolution.
+
+    Returns:
+        ``(literal_path, is_read_text_call)``. The second element is True for
+        any ``….read_text(...)`` call, so the caller can tell "path shape we
+        will not resolve" apart from "not a path shape at all".
+    """
+    if not isinstance(node, ast.Call):
+        return None, False
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "read_text":
+        return None, False
+    if node.args:  # read_text() takes only keywords (encoding/errors)
+        return None, True
+
+    receiver = func.value
+    if not isinstance(receiver, ast.Call) or len(receiver.args) != 1:
+        return None, True
+    ctor = receiver.func
+    is_path_ctor = (isinstance(ctor, ast.Name) and ctor.id == "Path") or (
+        isinstance(ctor, ast.Attribute) and ctor.attr == "Path"
+    )
+    if not is_path_ctor:
+        return None, True
+
+    arg = receiver.args[0]
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return arg.value, True
+    return None, True
+
+
+def _extract_read_text_file(
+    raw: str,
+    migration_path: Path,
+    project_root: Path,
+    source_line: int,
+) -> tuple[ExtractedSQL | None, ExtractionWarning | None]:
+    """Resolve and read a literal ``Path(...).read_text()`` target.
+
+    Deliberately routes through :func:`_resolve_sql_path`, so this shape gets
+    ``execute_file``'s project-root confinement and its
+    ``EXECUTE_FILE_ESCAPED`` / ``EXECUTE_FILE_MISSING`` signals — same boundary,
+    same vocabulary, one implementation.
+    """
+    resolved, warn = _resolve_sql_path(
+        raw,
+        migration_path,
+        project_root,
+        source_line,
+        call_desc=f"execute(Path({raw!r}).read_text())",
+    )
+    if warn is not None:
+        return None, warn
+    assert resolved is not None
+    return (
+        ExtractedSQL(
+            sql=resolved.read_text(encoding="utf-8"),
+            source_file=migration_path,
+            source_line=source_line,
+            kind=ExtractionKind.FILE,
+            sql_file=resolved,
+        ),
+        None,
+    )
 
 
 def _emit_execute_warning(
@@ -267,6 +368,28 @@ def extract_sql_from_python_migration(
                         source_line=node.lineno,
                         kind=(
                             ExtractionKind.INLINE_FSTRING if is_fstring else ExtractionKind.INLINE
+                        ),
+                    )
+                )
+                continue
+            literal, is_read_text = _read_text_literal_path(first)
+            if literal is not None:
+                snippet, warn = _extract_read_text_file(literal, path, effective_root, node.lineno)
+                if warn is not None:
+                    warnings.append(warn)
+                else:
+                    assert snippet is not None
+                    snippets.append(snippet)
+            elif is_read_text:
+                warnings.append(
+                    ExtractionWarning(
+                        kind=WarningKind.DYNAMIC_READ_TEXT,
+                        source_file=path,
+                        source_line=node.lineno,
+                        message=(
+                            "self.execute(...read_text()) with a non-literal path; SQL file was "
+                            "not scanned. Use self.execute_file(<path>) — it resolves computed "
+                            "paths and is analyzed."
                         ),
                     )
                 )

--- a/python/confiture/core/linting/rule_registry.py
+++ b/python/confiture/core/linting/rule_registry.py
@@ -1,0 +1,224 @@
+"""The catalogue of rules ``confiture lint`` can run, and how to select them (#150).
+
+Before 0.42.0 every opt-in rule arrived as its own flag: ``--replica-safe``
+(0.19.0), ``--check-tenant-isolation``, ``--check-security-definer`` (0.28.0).
+Three flags, two naming styles, and no way to *turn a rule off* — #150's
+prediction, filed when there was one of them.
+
+This module is the single backing store: :func:`resolve_selection` turns
+``--select`` / ``--ignore`` into the exact set of rule codes a run will apply,
+``lint --list-rules`` enumerates :data:`LINT_RULES`, and the three legacy flags
+are re-expressed as ``--select default,<family>`` rather than as branches in the
+command body.
+
+**Only rules that can actually emit a violation are listed.** ``LintConfig``
+also carries ``check_indexes`` and ``check_constraints``; the first computes and
+discards, the second has no implementation at all. Listing them would move the
+existing over-claim into a new, more authoritative place.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+from confiture.exceptions import ConfigurationError
+
+#: Selector meaning "everything that runs by default". Not a family — it exists
+#: so the legacy flags stay expressible: ``--replica-safe`` is exactly
+#: ``--select default,replica``, i.e. the usual lint *plus* one family.
+DEFAULT_SELECTOR = "default"
+
+
+@dataclass(frozen=True)
+class LintRule:
+    """One rule ``confiture lint`` can apply.
+
+    Attributes:
+        code: Stable rule identifier, as it appears in violation output.
+        family: Selector group. Usually the code's prefix — with one exception:
+            ``sec_001`` (``security``) and ``sec_002`` (``security-definer``)
+            are unrelated rules that happen to share a prefix, and the flag
+            that shipped ``sec_002`` named the latter.
+        title: One-line description, shown by ``--list-rules``.
+        severity: Severity the rule emits *by default*. ``sec_002`` and
+            ``replica_001`` can be escalated by configuration.
+        default_on: Whether a plain ``confiture lint`` applies it.
+        legacy_flag: The pre-0.42.0 per-rule flag, kept as an alias, or None.
+        requires_config: Configuration the rule additionally needs before it can
+            report anything — selecting it is necessary, not sufficient.
+    """
+
+    code: str
+    family: str
+    title: str
+    severity: str
+    default_on: bool
+    legacy_flag: str | None = None
+    requires_config: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """JSON shape for ``lint --list-rules --format json``."""
+        return {
+            "code": self.code,
+            "family": self.family,
+            "title": self.title,
+            "severity": self.severity,
+            "default_on": self.default_on,
+            "legacy_flag": self.legacy_flag,
+            "requires_config": self.requires_config,
+        }
+
+
+LINT_RULES: tuple[LintRule, ...] = (
+    LintRule(
+        code="naming_001",
+        family="naming",
+        title="Table names should be snake_case",
+        severity="warning",
+        default_on=True,
+    ),
+    LintRule(
+        code="naming_002",
+        family="naming",
+        title="Column names should be snake_case",
+        severity="warning",
+        default_on=True,
+    ),
+    LintRule(
+        code="pk_001",
+        family="pk",
+        title="Every table should declare a primary key",
+        severity="warning",
+        default_on=True,
+    ),
+    LintRule(
+        code="doc_001",
+        family="doc",
+        title="Every table should carry a COMMENT",
+        severity="info",
+        default_on=True,
+    ),
+    LintRule(
+        code="sec_001",
+        family="security",
+        title="Columns that look like secrets should not be plain text",
+        severity="warning",
+        default_on=True,
+    ),
+    LintRule(
+        code="acl_001",
+        family="acl",
+        title="Every CREATE TABLE has a matching GRANT",
+        severity="warning",
+        default_on=False,
+        requires_config="acls.lint_enabled: true",
+    ),
+    LintRule(
+        code="tenant_001",
+        family="tenant",
+        title="Function INSERTs carry the FK a tenant-scoped view requires",
+        severity="warning",
+        default_on=False,
+        legacy_flag="--check-tenant-isolation",
+    ),
+    LintRule(
+        code="replica_001",
+        family="replica",
+        title="Migrations stay forward-compatible with streaming replicas",
+        severity="warning",
+        default_on=False,
+        legacy_flag="--replica-safe",
+    ),
+    LintRule(
+        code="sec_002",
+        family="security-definer",
+        title="SECURITY DEFINER routines pin search_path (CVE-2018-1058)",
+        severity="warning",
+        default_on=False,
+        legacy_flag="--check-security-definer",
+        requires_config="security_lint.enabled: true",
+    ),
+)
+
+
+def families() -> tuple[str, ...]:
+    """Every family name, in registry order, without duplicates."""
+    seen: list[str] = []
+    for rule in LINT_RULES:
+        if rule.family not in seen:
+            seen.append(rule.family)
+    return tuple(seen)
+
+
+def default_codes() -> frozenset[str]:
+    """The rule codes a plain ``confiture lint`` applies."""
+    return frozenset(rule.code for rule in LINT_RULES if rule.default_on)
+
+
+def _expand(token: str, *, option: str) -> frozenset[str]:
+    """Resolve one selector token to rule codes.
+
+    Args:
+        token: A rule code, a family name, or :data:`DEFAULT_SELECTOR`.
+        option: The flag the token came from, for the error message.
+
+    Returns:
+        The codes the token names.
+
+    Raises:
+        ConfigurationError: The token matches no rule and no family. Selecting
+            nothing silently is precisely the failure this replaces, so an
+            unknown selector is loud and lists what is valid.
+    """
+    key = token.strip().lower()
+    if not key:
+        return frozenset()
+    if key == DEFAULT_SELECTOR:
+        return default_codes()
+    by_code = {rule.code: rule for rule in LINT_RULES}
+    if key in by_code:
+        return frozenset({key})
+    matched = frozenset(rule.code for rule in LINT_RULES if rule.family == key)
+    if matched:
+        return matched
+    raise ConfigurationError(
+        f"Unknown lint rule or family in {option}: {token!r}",
+        error_code="CONFIG_010",
+        resolution_hint=(
+            f"Families: {', '.join(families())}, {DEFAULT_SELECTOR}. "
+            f"Codes: {', '.join(rule.code for rule in LINT_RULES)}. "
+            "Run `confiture lint --list-rules` for the full table."
+        ),
+    )
+
+
+def _expand_all(tokens: Iterable[str], *, option: str) -> frozenset[str]:
+    codes: set[str] = set()
+    for token in tokens:
+        for part in str(token).split(","):
+            codes |= _expand(part, option=option)
+    return frozenset(codes)
+
+
+def resolve_selection(
+    select: Sequence[str] | None,
+    ignore: Sequence[str],
+) -> frozenset[str]:
+    """The exact rule codes one ``confiture lint`` invocation applies.
+
+    Args:
+        select: ``--select`` values (each may be comma-separated). ``None`` or
+            empty means the default set, i.e. pre-0.42.0 behaviour.
+        ignore: ``--ignore`` values, removed after selection.
+
+    Returns:
+        The selected rule codes. Selecting a rule is necessary but not always
+        sufficient — see :attr:`LintRule.requires_config`.
+
+    Raises:
+        ConfigurationError: An unknown code or family appeared in either option.
+    """
+    selected = _expand_all(select, option="--select") if select else default_codes()
+    excluded = _expand_all(ignore, option="--ignore") if ignore else frozenset()
+    return frozenset(selected - excluded)

--- a/python/confiture/core/linting/schema_linter.py
+++ b/python/confiture/core/linting/schema_linter.py
@@ -100,6 +100,7 @@ class LintConfig:
         check_constraints: bool = True,
         check_security: bool = True,
         check_tenant_isolation: bool = False,
+        check_acl_coverage: bool = True,
     ):
         """Initialize linting configuration.
 
@@ -115,6 +116,10 @@ class LintConfig:
             check_security: Check for security issues (passwords, tokens)
             check_tenant_isolation: Detect INSERTs missing tenant FK columns
                 (multi-tenant rule, ``tenant_001``). Opt-in (default off).
+            check_acl_coverage: Allow the ACL coverage rule (``acl_001``) to run.
+                Default True, i.e. unchanged: the rule additionally requires
+                ``acls.lint_enabled: true`` in the environment YAML. Set False to
+                suppress it (``confiture lint --ignore acl``).
         """
         self.enabled = enabled
         self.fail_on_error = fail_on_error
@@ -126,6 +131,7 @@ class LintConfig:
         self.check_constraints = check_constraints
         self.check_security = check_security
         self.check_tenant_isolation = check_tenant_isolation
+        self.check_acl_coverage = check_acl_coverage
 
 
 class SchemaLinter:
@@ -229,7 +235,11 @@ class SchemaLinter:
         # used to auto-fire this rule, but that surprised users who set
         # ``acls:`` only for ``confiture drift --check-acls``.  Explicit
         # opt-in keeps the two surfaces independently controllable.
-        if self.environment.acls_lint_enabled and self.environment.acls:
+        if (
+            self.config.check_acl_coverage
+            and self.environment.acls_lint_enabled
+            and self.environment.acls
+        ):
             migrations_dir = self.project_dir / "db" / "migrations"
             if migrations_dir.exists():
                 grant_dir_str = self.environment.migration.grant_dir

--- a/python/confiture/core/restorer.py
+++ b/python/confiture/core/restorer.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import psycopg
 
+from confiture.core.url_redaction import libpq_env
 from confiture.exceptions import RestoreError
 
 _log = logging.getLogger(__name__)
@@ -81,6 +82,11 @@ class RestoreOptions:
         host: PostgreSQL host or socket directory path.
         port: PostgreSQL port.
         username: PostgreSQL role to connect as. None uses the OS default.
+        password: Password for ``username``, required by any server that is not
+            trust/peer-authenticated. Passed to the ``pg_restore`` / ``psql``
+            children via ``PGPASSWORD``, never on argv (``ps aux`` is world-
+            readable). None leaves the ambient environment untouched, so an
+            operator-set ``PGPASSWORD`` or ``~/.pgpass`` still works.
         jobs: Number of parallel workers for the data phase.
         no_owner: Skip restoration of object ownership (--no-owner).
         no_acl: Skip restoration of access privileges (--no-acl).
@@ -102,6 +108,7 @@ class RestoreOptions:
     host: str = "/var/run/postgresql"
     port: int = 5432
     username: str | None = None
+    password: str | None = None
     jobs: int = 4
     no_owner: bool = False
     no_acl: bool = False
@@ -616,6 +623,7 @@ class DatabaseRestorer:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 text=True,
+                env=libpq_env(options.password),
             ) as proc:
                 try:
                     assert proc.stderr is not None
@@ -759,6 +767,7 @@ class DatabaseRestorer:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 text=True,
+                env=libpq_env(options.password),
             ) as proc:
                 try:
                     assert proc.stderr is not None
@@ -821,6 +830,7 @@ class DatabaseRestorer:
                     port=options.port,
                     dbname=options.target_db,
                     user=options.username or None,
+                    password=options.password,
                 ) as conn,
                 conn.cursor() as cur,
             ):

--- a/python/confiture/core/test_db.py
+++ b/python/confiture/core/test_db.py
@@ -23,7 +23,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import psycopg
 import psycopg.errors
@@ -339,6 +339,9 @@ class TestDbProvisioner:
         self._host = parsed.hostname or "/var/run/postgresql"
         self._port = parsed.port or 5432
         self._user = parsed.username
+        # Percent-decoded, because PGPASSWORD is used verbatim by libpq while a
+        # password inside a URI is decoded first (same rule as split_password).
+        self._password = unquote(parsed.password) if parsed.password else None
 
     # -- connection helpers ------------------------------------------------
 
@@ -646,6 +649,7 @@ class TestDbProvisioner:
                 host=self._host,
                 port=self._port,
                 username=self._user,
+                password=self._password,
                 jobs=4,
                 parallel_restore=True,
                 no_owner=True,

--- a/python/confiture/core/validation/context.py
+++ b/python/confiture/core/validation/context.py
@@ -61,6 +61,7 @@ class ValidationContext:
         self._config_loaded = False
         self._connection: psycopg.Connection[Any] | None = None
         self._stack = ExitStack()
+        self._git_scope: tuple[str, str] | None = None
 
     def __enter__(self) -> ValidationContext:
         return self
@@ -80,6 +81,52 @@ class ValidationContext:
             self._config_data = load_config(self.config_path)
             self._config_loaded = True
         return self._config_data
+
+    def _resolve_git_scope(self) -> tuple[str, str]:
+        """``(base_ref, target_ref)`` for every git-aware check, resolved once.
+
+        Committed mode is unchanged: ``effective_base_ref`` against ``HEAD``,
+        compared three-dot downstream.
+
+        Staged mode (#184) answers "what is about to be committed?", so the
+        target is the index materialised as a tree and the base is the
+        merge-base — the commit three-dot semantics already compare against.
+        Pinning the base explicitly matters because the staged target is a tree,
+        and ``base...tree`` is not a valid symmetric difference (git rejects it),
+        so the diffs downstream run two-dot from this base instead.
+
+        Returns:
+            The base and target refs. Both are plain strings; the target is a
+            tree OID in staged mode and reads like any other ref.
+
+        Raises:
+            GitError: ``GIT_003`` if ``base_ref`` does not resolve in this
+                checkout — the shallow-clone case, which would otherwise
+                surface as git's own "bad revision" with no remedy.
+        """
+        if not self.staged:
+            return self.effective_base_ref, "HEAD"
+
+        from confiture.core.git import GitRepository
+
+        repo = GitRepository()
+        repo.require_ref(self.effective_base_ref)
+        base = repo.get_merge_base(self.effective_base_ref, "HEAD") or self.effective_base_ref
+        return base, repo.staged_tree_oid()
+
+    @property
+    def git_base_ref(self) -> str:
+        """The base ref the git checks compare against (see :meth:`_resolve_git_scope`)."""
+        if self._git_scope is None:
+            self._git_scope = self._resolve_git_scope()
+        return self._git_scope[0]
+
+    @property
+    def git_target_ref(self) -> str:
+        """``"HEAD"``, or the staged index as a tree OID (see :meth:`_resolve_git_scope`)."""
+        if self._git_scope is None:
+            self._git_scope = self._resolve_git_scope()
+        return self._git_scope[1]
 
     def connection(self) -> psycopg.Connection[Any]:
         """The live database connection, opened at most once per run.

--- a/python/confiture/models/lint.py
+++ b/python/confiture/models/lint.py
@@ -31,7 +31,10 @@ class Violation:
     """A single schema quality violation.
 
     Attributes:
-        rule_name: Name of the rule that detected this violation
+        rule_name: Human-readable name of the rule that detected this violation
+        rule_id: Stable rule code (``naming_001``…), the identifier
+            ``confiture lint --select`` / ``--ignore`` take. Empty for
+            violations produced by code that predates the registry (#150).
         severity: Severity level (ERROR, WARNING, INFO)
         message: Human-readable description of the issue
         location: Where the violation occurred (table name, column, etc.)
@@ -43,6 +46,7 @@ class Violation:
     message: str
     location: str
     suggested_fix: str | None = None
+    rule_id: str = ""
 
     def __str__(self) -> str:
         """Format violation for human consumption."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,8 +191,17 @@ def clean_test_db(test_db_connection: psycopg.Connection) -> psycopg.Connection:
     conn = test_db_connection
 
     def cleanup():
-        """Drop all objects in public schema"""
+        """Drop all objects in public schema, plus confiture's own helper schema"""
         with conn.cursor() as cur:
+            # `migrate up` auto-installs the view helpers into a schema literally
+            # named `confiture` (migration.view_helpers: auto), and nothing here
+            # used to drop it. In a shared test database that leak is inert only
+            # while the connecting role is named something else: PostgreSQL's
+            # default search_path is `"$user", public`, so under a role *named*
+            # confiture — which is exactly what CI connects as — the leaked schema
+            # silently becomes the target of every later unqualified CREATE TABLE.
+            cur.execute("DROP SCHEMA IF EXISTS confiture CASCADE")
+
             # Drop all views
             cur.execute("""
                 SELECT viewname FROM pg_views

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -272,7 +272,7 @@ class TestMigrateDiffCommand:
 class TestMigrateUpCommand:
     """Test 'confiture migrate up' command (Milestone 1.13)."""
 
-    def test_up_applies_pending_migrations(self, tmp_path, test_db_connection):
+    def test_up_applies_pending_migrations(self, tmp_path, test_db_connection, test_db_url):
         """Should apply all pending migrations."""
         migrations_dir = tmp_path / "migrations"
         migrations_dir.mkdir(parents=True)
@@ -297,14 +297,13 @@ class CreateTestTable(Migration):
         config_dir = tmp_path / "environments"
         config_dir.mkdir()
         config_file = config_dir / "test.yaml"
+        # database_url, not a decomposed `database:` block: psycopg's
+        # ConnectionInfo never exposes the password, so rebuilding the DSN field
+        # by field silently drops it and the CLI exits 3 against any server that
+        # is not trust/peer-authenticated — which is every CI service container.
         config_file.write_text(f"""
 name: test
-database:
-  host: {test_db_connection.info.host}
-  port: {test_db_connection.info.port}
-  database: {test_db_connection.info.dbname}
-  user: {test_db_connection.info.user}
-  password: ""
+database_url: {test_db_url}
 """)
 
         result = runner.invoke(
@@ -341,7 +340,7 @@ database:
             cursor.execute("DELETE FROM tb_confiture WHERE version = '001'")
         test_db_connection.commit()
 
-    def test_up_with_no_pending_migrations(self, tmp_path, test_db_connection):
+    def test_up_with_no_pending_migrations(self, tmp_path, test_db_connection, test_db_url):
         """Should report when no migrations need to be applied."""
         migrations_dir = tmp_path / "migrations"
         migrations_dir.mkdir(parents=True)
@@ -349,14 +348,13 @@ database:
         config_dir = tmp_path / "environments"
         config_dir.mkdir()
         config_file = config_dir / "test.yaml"
+        # database_url, not a decomposed `database:` block: psycopg's
+        # ConnectionInfo never exposes the password, so rebuilding the DSN field
+        # by field silently drops it and the CLI exits 3 against any server that
+        # is not trust/peer-authenticated — which is every CI service container.
         config_file.write_text(f"""
 name: test
-database:
-  host: {test_db_connection.info.host}
-  port: {test_db_connection.info.port}
-  database: {test_db_connection.info.dbname}
-  user: {test_db_connection.info.user}
-  password: ""
+database_url: {test_db_url}
 """)
 
         result = runner.invoke(
@@ -378,7 +376,7 @@ database:
 class TestMigrateDownCommand:
     """Test 'confiture migrate down' command (Milestone 1.13)."""
 
-    def test_down_rolls_back_last_migration(self, tmp_path, test_db_connection):
+    def test_down_rolls_back_last_migration(self, tmp_path, test_db_connection, test_db_url):
         """Should rollback the last applied migration."""
         migrations_dir = tmp_path / "migrations"
         migrations_dir.mkdir(parents=True)
@@ -402,14 +400,13 @@ class CreateRollbackTest(Migration):
         config_dir = tmp_path / "environments"
         config_dir.mkdir()
         config_file = config_dir / "test.yaml"
+        # database_url, not a decomposed `database:` block: psycopg's
+        # ConnectionInfo never exposes the password, so rebuilding the DSN field
+        # by field silently drops it and the CLI exits 3 against any server that
+        # is not trust/peer-authenticated — which is every CI service container.
         config_file.write_text(f"""
 name: test
-database:
-  host: {test_db_connection.info.host}
-  port: {test_db_connection.info.port}
-  database: {test_db_connection.info.dbname}
-  user: {test_db_connection.info.user}
-  password: ""
+database_url: {test_db_url}
 """)
 
         # Apply migration first

--- a/tests/e2e/test_cli_error_reporting.py
+++ b/tests/e2e/test_cli_error_reporting.py
@@ -1,6 +1,5 @@
 # tests/e2e/test_cli_error_reporting.py
 
-import os
 import tempfile
 from pathlib import Path
 
@@ -11,7 +10,7 @@ from confiture.cli.main import app
 runner = CliRunner()
 
 
-def test_migrate_up_shows_detailed_error_on_sql_failure():
+def test_migrate_up_shows_detailed_error_on_sql_failure(test_db_url):
     """CLI should show detailed error message when migration SQL fails"""
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -39,20 +38,13 @@ class FailingMigration(Migration):
         self.execute("DROP TABLE IF EXISTS users")
 """)
 
-        # Create test config using environment variables for credentials
+        # One source of truth for where the test database is: the same URL every
+        # other test uses. The POSTGRES_* reconstruction this replaced hardcoded
+        # localhost:5432, so it pointed at whatever server happened to be there.
         config_file = project_dir / "db" / "environments" / "local.yaml"
-        db_user = os.environ.get("POSTGRES_USER", "postgres")
-        db_password = os.environ.get("POSTGRES_PASSWORD", "postgres")
-        db_name = os.environ.get("POSTGRES_DB", "confiture_test")
-
         config_file.write_text(f"""
 name: local
-database:
-  host: localhost
-  port: 5432
-  database: {db_name}
-  user: {db_user}
-  password: {db_password}
+database_url: {test_db_url}
 include_dirs:
   - db/schema
 exclude_dirs: []
@@ -91,7 +83,7 @@ exclude_dirs: []
         ), f"Should show error details. Output: {output}"
 
 
-def test_migrate_up_shows_progress_and_stops_on_error(clean_test_db):
+def test_migrate_up_shows_progress_and_stops_on_error(clean_test_db, test_db_url):
     """CLI should show which migrations succeeded before stopping"""
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -102,14 +94,13 @@ def test_migrate_up_shows_progress_and_stops_on_error(clean_test_db):
 
         # Update config to use test database
         config_file = project_dir / "db" / "environments" / "local.yaml"
+        # database_url, not a decomposed `database:` block: psycopg's
+        # ConnectionInfo never exposes the password, so rebuilding the DSN field
+        # by field drops it and the CLI cannot reach a password-authenticated
+        # server.
         config_file.write_text(f"""
 name: local
-database:
-  host: {clean_test_db.info.host}
-  port: {clean_test_db.info.port}
-  database: {clean_test_db.info.dbname}
-  user: {clean_test_db.info.user}
-  password: ""
+database_url: {test_db_url}
 include_dirs:
   - db/schema/00_common
   - db/schema/10_tables
@@ -188,7 +179,7 @@ class Failure(Migration):
         assert result.exit_code == 3, "Should return exit code 3 (migration execution error)"
 
 
-def test_error_message_includes_troubleshooting_hints(clean_test_db):
+def test_error_message_includes_troubleshooting_hints(clean_test_db, test_db_url):
     """Error messages should include helpful troubleshooting guidance"""
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -197,14 +188,13 @@ def test_error_message_includes_troubleshooting_hints(clean_test_db):
 
         # Update config to use test database
         config_file = project_dir / "db" / "environments" / "local.yaml"
+        # database_url, not a decomposed `database:` block: psycopg's
+        # ConnectionInfo never exposes the password, so rebuilding the DSN field
+        # by field drops it and the CLI cannot reach a password-authenticated
+        # server.
         config_file.write_text(f"""
 name: local
-database:
-  host: {clean_test_db.info.host}
-  port: {clean_test_db.info.port}
-  database: {clean_test_db.info.dbname}
-  user: {clean_test_db.info.user}
-  password: ""
+database_url: {test_db_url}
 include_dirs:
   - db/schema/00_common
   - db/schema/10_tables

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,6 +25,7 @@ import os
 import pwd
 import shutil
 from collections.abc import Iterator
+from urllib.parse import unquote, urlparse
 
 import psycopg
 import psycopg.errors
@@ -215,3 +216,22 @@ def ram_setup_env() -> Iterator[tuple[TestDbProvisioner, str, str, str]]:
         yield provisioner, _RAMSETUP_TABLESPACE, _RAMSETUP_LOCATION, owner
     finally:
         _teardown_tmpfs_tablespace(url, _RAMSETUP_TABLESPACE, _RAMSETUP_LOCATION)
+
+
+@pytest.fixture
+def restore_connection_kwargs(test_db_url: str) -> dict[str, object]:
+    """``host``/``port``/``username``/``password`` for :class:`RestoreOptions`.
+
+    ``pg_restore`` is a subprocess: it inherits none of psycopg's connection
+    state, so every connection parameter has to be handed to it explicitly.
+    Tests used to hardcode ``localhost:5432`` with no credentials, which quietly
+    restores into whatever server owns that port and cannot authenticate at all
+    against a CI service container.
+    """
+    parsed = urlparse(test_db_url)
+    return {
+        "host": parsed.hostname or "/var/run/postgresql",
+        "port": parsed.port or 5432,
+        "username": parsed.username,
+        "password": unquote(parsed.password) if parsed.password else None,
+    }

--- a/tests/integration/test_build_artifact_roundtrip.py
+++ b/tests/integration/test_build_artifact_roundtrip.py
@@ -82,7 +82,11 @@ def _restored_tables(server_url: str, target_db: str) -> set[str]:
 
 @pytest.mark.parametrize("dump_format", ["custom", "directory"])
 def test_artifact_round_trips_through_restore(
-    server_url: str, fresh_target: str, tmp_path: Path, dump_format: str
+    server_url: str,
+    fresh_target: str,
+    tmp_path: Path,
+    dump_format: str,
+    restore_connection_kwargs: dict,
 ) -> None:
     ext = "pgdump" if dump_format == "custom" else "pgdir"
     artifact = tmp_path / f"schema_test.full.deadbeefcafe.{ext}"
@@ -98,13 +102,11 @@ def test_artifact_round_trips_through_restore(
     assert result.skipped is False
     assert artifact.exists()
 
-    host = "localhost"
     restore = DatabaseRestorer().restore(
         RestoreOptions(
             backup_path=artifact,
             target_db=fresh_target,
-            host=host,
-            port=5432,
+            **restore_connection_kwargs,
             jobs=2,
             parallel_restore=True,
             no_owner=True,
@@ -133,7 +135,7 @@ def _row_count(server_url: str, target_db: str, table: str) -> int:
 
 
 def test_copy_bearing_schema_and_seed_round_trip(
-    server_url: str, fresh_target: str, tmp_path: Path
+    server_url: str, fresh_target: str, tmp_path: Path, restore_connection_kwargs: dict
 ) -> None:
     """#159 end-to-end: build --dump applies a COPY-bearing schema *and* a
     COPY-bearing seed file via psql, then the artifact restores with rows intact."""
@@ -164,8 +166,7 @@ def test_copy_bearing_schema_and_seed_round_trip(
         RestoreOptions(
             backup_path=artifact,
             target_db=fresh_target,
-            host="localhost",
-            port=5432,
+            **restore_connection_kwargs,
             jobs=2,
             parallel_restore=True,
             no_owner=True,

--- a/tests/integration/test_migrate_force.py
+++ b/tests/integration/test_migrate_force.py
@@ -17,7 +17,7 @@ runner = CliRunner()
 class TestForceMigrationWorkflow:
     """Test the complete force migration workflow."""
 
-    def test_force_workflow_issue_4_scenario(self, test_db_connection, test_db_url):
+    def test_force_workflow_issue_4_scenario(self, clean_test_db, test_db_url):
         """Test the exact scenario from issue #4: DROP SCHEMA CASCADE then force migrate."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
@@ -71,8 +71,10 @@ CREATE TABLE test_force_table (
 
             # Create config file
             config_file = config_dir / "test.yaml"
-            # Use the same URL that the connection fixture uses
-            db_url = test_db_connection.info.dsn
+            # test_db_url, not info.dsn: psycopg redacts the password out of
+            # ConnectionInfo.dsn, so the config it produced could only ever
+            # reach a trust/peer-authenticated server.
+            db_url = test_db_url
             config_file.write_text(f"""
 name: test
 include_dirs:
@@ -92,10 +94,7 @@ database_url: {db_url}
                     str(project_dir),
                 ],
             )
-            print(f"Build result: exit_code={result.exit_code}, output={result.output}")
-            if result.exit_code != 0:
-                return  # Skip rest of test if build fails
-            assert result.exit_code == 0
+            assert result.exit_code == 0, result.output
 
             # Step 2: Migrate up (should succeed)
             result = runner.invoke(
@@ -109,14 +108,11 @@ database_url: {db_url}
                     str(config_file),
                 ],
             )
-            print(f"Migrate up result: exit_code={result.exit_code}, output={result.output}")
-            if result.exit_code != 0:
-                return  # Skip rest of test if migrate fails
-            assert result.exit_code == 0
+            assert result.exit_code == 0, result.output
             assert "applied" in result.stdout.lower() or "success" in result.stdout.lower()
 
             # Verify migration was tracked
-            with test_db_connection.cursor() as cursor:
+            with clean_test_db.cursor() as cursor:
                 cursor.execute("""
                     SELECT COUNT(*) FROM tb_confiture
                     WHERE version = '001'
@@ -124,20 +120,28 @@ database_url: {db_url}
                 count = cursor.fetchone()[0]
                 assert count == 1
 
-            # Step 3: Simulate DROP SCHEMA CASCADE (manual schema drop)
-            with test_db_connection.cursor() as cursor:
-                cursor.execute("DROP SCHEMA public CASCADE")
-                cursor.execute("CREATE SCHEMA public")
-            test_db_connection.commit()
+            # Step 3: the objects vanish, the ledger does not — issue #4's actual
+            # shape. This used to `DROP SCHEMA public CASCADE`, which with the
+            # default (unqualified) tracking table takes tb_confiture with it, so
+            # the "tracking still exists" check below could not hold. Nobody
+            # noticed because the two early `return`s above turned the whole test
+            # into a no-op whenever a step failed.
+            with clean_test_db.cursor() as cursor:
+                cursor.execute("DROP TABLE IF EXISTS test_force_table CASCADE")
+            clean_test_db.commit()
 
-            # Verify migration tracking still exists (DROP SCHEMA doesn't remove it)
-            with test_db_connection.cursor() as cursor:
+            # Verify migration tracking still exists (dropping the table doesn't)
+            with clean_test_db.cursor() as cursor:
                 cursor.execute("""
                     SELECT COUNT(*) FROM tb_confiture
                     WHERE version = '001'
                 """)
                 count = cursor.fetchone()[0]
                 assert count == 1
+            # End the read transaction before handing control to the CLI: the
+            # steps below take their own locks on tb_confiture, and an
+            # idle-in-transaction reader here blocks them until the test times out.
+            clean_test_db.commit()
 
             # Step 4: Try migrate up without force (should report up to date)
             result = runner.invoke(
@@ -172,7 +176,7 @@ database_url: {db_url}
             assert "Force mode enabled" in result.stdout
 
             # Verify table was recreated
-            with test_db_connection.cursor() as cursor:
+            with clean_test_db.cursor() as cursor:
                 cursor.execute("""
                     SELECT EXISTS (
                         SELECT FROM pg_tables
@@ -182,7 +186,7 @@ database_url: {db_url}
                 exists = cursor.fetchone()[0]
                 assert exists is True
 
-    def test_force_mode_updates_migration_tracking(self, clean_test_db):
+    def test_force_mode_updates_migration_tracking(self, clean_test_db, test_db_url):
         """Test that force mode properly updates migration tracking state."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
@@ -211,8 +215,10 @@ class TrackingTest(Migration):
 
             # Create config file
             config_file = config_dir / "test.yaml"
-            # Use the same URL that the connection fixture uses
-            db_url = clean_test_db.info.dsn
+            # test_db_url, not info.dsn: psycopg redacts the password out of
+            # ConnectionInfo.dsn, so the config it produced could only ever
+            # reach a trust/peer-authenticated server.
+            db_url = test_db_url
             config_file.write_text(f"""
 name: test
 include_dirs:
@@ -295,7 +301,7 @@ database_url: {db_url}
                 exists = cursor.fetchone()[0]
                 assert exists is True
 
-    def test_multiple_force_applications(self, clean_test_db):
+    def test_multiple_force_applications(self, clean_test_db, test_db_url):
         """Test that multiple force applications work correctly."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
@@ -330,7 +336,7 @@ name: test
 include_dirs:
   - db/schema/00_common
 exclude_dirs: []
-database_url: postgresql://{clean_test_db.info.user}:@{clean_test_db.info.host}:{clean_test_db.info.port}/{clean_test_db.info.dbname}
+database_url: {test_db_url}
 """)
 
             # Apply all migrations with force
@@ -391,7 +397,7 @@ database_url: postgresql://{clean_test_db.info.user}:@{clean_test_db.info.host}:
                     exists = cursor.fetchone()[0]
                     assert exists is True
 
-    def test_force_mode_with_empty_migrations_dir(self, clean_test_db):
+    def test_force_mode_with_empty_migrations_dir(self, clean_test_db, test_db_url):
         """Test force mode with empty migrations directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
@@ -404,8 +410,10 @@ database_url: postgresql://{clean_test_db.info.user}:@{clean_test_db.info.host}:
 
             # Create config file
             config_file = config_dir / "test.yaml"
-            # Use the same URL that the connection fixture uses
-            db_url = clean_test_db.info.dsn
+            # test_db_url, not info.dsn: psycopg redacts the password out of
+            # ConnectionInfo.dsn, so the config it produced could only ever
+            # reach a trust/peer-authenticated server.
+            db_url = test_db_url
             config_file.write_text(f"""
 name: test
 include_dirs:

--- a/tests/integration/test_restore_matview_deferral.py
+++ b/tests/integration/test_restore_matview_deferral.py
@@ -103,12 +103,11 @@ def _build_matview_artifact(server_url: str, tmp_path: Path) -> Path:
     return artifact
 
 
-def _restore_options(artifact: Path, target: str, **kwargs) -> RestoreOptions:
+def _restore_options(artifact: Path, target: str, conn_kwargs: dict, **kwargs) -> RestoreOptions:
     return RestoreOptions(
         backup_path=artifact,
         target_db=target,
-        host="localhost",
-        port=5432,
+        **conn_kwargs,
         jobs=2,
         parallel_restore=True,
         no_owner=True,
@@ -118,11 +117,13 @@ def _restore_options(artifact: Path, target: str, **kwargs) -> RestoreOptions:
 
 
 def test_default_restore_refreshes_matview_after_analyze(
-    server_url: str, fresh_target: str, tmp_path: Path
+    server_url: str, fresh_target: str, tmp_path: Path, restore_connection_kwargs: dict
 ) -> None:
     artifact = _build_matview_artifact(server_url, tmp_path)
 
-    result = DatabaseRestorer().restore(_restore_options(artifact, fresh_target))
+    result = DatabaseRestorer().restore(
+        _restore_options(artifact, fresh_target, restore_connection_kwargs)
+    )
 
     assert result.success, result.errors
     # The matview refresh was deferred out of the data phase and run after ANALYZE.
@@ -136,12 +137,14 @@ def test_default_restore_refreshes_matview_after_analyze(
 
 
 def test_no_refresh_matviews_leaves_matview_unpopulated(
-    server_url: str, fresh_target: str, tmp_path: Path
+    server_url: str, fresh_target: str, tmp_path: Path, restore_connection_kwargs: dict
 ) -> None:
     artifact = _build_matview_artifact(server_url, tmp_path)
 
     result = DatabaseRestorer().restore(
-        _restore_options(artifact, fresh_target, no_refresh_matviews=True)
+        _restore_options(
+            artifact, fresh_target, restore_connection_kwargs, no_refresh_matviews=True
+        )
     )
 
     assert result.success, result.errors

--- a/tests/integration/test_validate_staged_scope.py
+++ b/tests/integration/test_validate_staged_scope.py
@@ -1,0 +1,153 @@
+"""``migrate validate --staged`` scopes the git checks to the index (#184).
+
+``--staged`` is the pre-commit mode: it exists to judge what is *about to be
+committed*. Until 0.42.0 only ``--require-grant-migration`` honoured it, so
+``--check-drift --staged`` and ``--require-migration --staged`` compared
+``base_ref`` against ``HEAD`` — i.e. they ignored exactly the changes the
+developer was committing, and passed a branch whose staged schema change had no
+migration.
+
+Every test here drives the real CLI against a real repository. Two details are
+load-bearing:
+
+- the file is staged and then edited further, so a check that reads the
+  **worktree** instead of the **index** shows up as a wrong answer rather than
+  as a coincidence;
+- ``--base-ref HEAD`` is explicit, because the default (``origin/main``) does
+  not resolve in a fresh throwaway repository.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+_BASE_SCHEMA = "CREATE TABLE tb_machine (pk_machine BIGINT PRIMARY KEY);\n"
+_STAGED_SCHEMA = _BASE_SCHEMA + "CREATE TABLE tb_staged_only (pk_staged BIGINT PRIMARY KEY);\n"
+_WORKTREE_ONLY = "CREATE TABLE tb_worktree_only (pk_worktree BIGINT PRIMARY KEY);\n"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def staged_repo(tmp_path: Path) -> Iterator[Path]:
+    """A repo whose schema change exists **only in the index**.
+
+    ``db/schema/010_tables.sql`` is committed with one table, staged with a
+    second, and then edited in the worktree with a third that is *not* staged.
+    A check scoped to the index must see the second and never the third.
+    """
+    repo = tmp_path / "repo"
+    (repo / "db" / "schema").mkdir(parents=True)
+    (repo / "db" / "migrations").mkdir(parents=True)
+    (repo / "db" / "environments").mkdir(parents=True)
+    (repo / "db" / "environments" / "local.yaml").write_text(
+        "database_url: postgresql://localhost/test\ninclude_dirs:\n  - path: db/schema\n"
+    )
+    schema = repo / "db" / "schema" / "010_tables.sql"
+    schema.write_text(_BASE_SCHEMA)
+
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base schema")
+
+    schema.write_text(_STAGED_SCHEMA)
+    _git(repo, "add", "db/schema/010_tables.sql")
+    schema.write_text(_STAGED_SCHEMA + _WORKTREE_ONLY)
+
+    old_cwd = Path.cwd()
+    os.chdir(repo)
+    try:
+        yield repo
+    finally:
+        os.chdir(old_cwd)
+
+
+def _validate(*args: str) -> object:
+    return runner.invoke(app, ["migrate", "validate", "--base-ref", "HEAD", *args])
+
+
+class TestStagedDrift:
+    def test_staged_schema_change_is_reported_as_drift(self, staged_repo: Path) -> None:
+        result = _validate("--check-drift", "--staged")
+
+        assert result.exit_code == 1, result.output
+        assert "tb_staged_only" in result.output
+
+    def test_unstaged_worktree_change_is_invisible(self, staged_repo: Path) -> None:
+        """Content comes from the index blob, not from the file on disk."""
+        result = _validate("--check-drift", "--staged")
+
+        assert "tb_worktree_only" not in result.output
+
+    def test_without_staged_the_index_is_ignored(self, staged_repo: Path) -> None:
+        """The committed-ref comparison is unchanged: HEAD vs HEAD is no drift."""
+        result = _validate("--check-drift")
+
+        assert result.exit_code == 0, result.output
+        assert "tb_staged_only" not in result.output
+
+
+class TestStagedAccompaniment:
+    def test_staged_ddl_without_a_staged_migration_fails(self, staged_repo: Path) -> None:
+        result = _validate("--require-migration", "--staged")
+
+        assert result.exit_code == 1, result.output
+
+    def test_staged_ddl_with_a_staged_migration_passes(self, staged_repo: Path) -> None:
+        migration = staged_repo / "db" / "migrations" / "20260806000000_add_staged.up.sql"
+        migration.write_text("CREATE TABLE tb_staged_only (pk_staged BIGINT PRIMARY KEY);\n")
+        _git(staged_repo, "add", str(migration.relative_to(staged_repo)))
+
+        result = _validate("--require-migration", "--staged")
+
+        assert result.exit_code == 0, result.output
+
+    def test_an_unstaged_migration_does_not_count(self, staged_repo: Path) -> None:
+        """Written but not `git add`ed: it is not part of the commit under test."""
+        (staged_repo / "db" / "migrations" / "20260806000000_add_staged.up.sql").write_text(
+            "CREATE TABLE tb_staged_only (pk_staged BIGINT PRIMARY KEY);\n"
+        )
+
+        result = _validate("--require-migration", "--staged")
+
+        assert result.exit_code == 1, result.output
+
+
+class TestStagedDegradesLikeTheCommittedPath:
+    def test_unresolvable_base_ref_reports_git_003(self, staged_repo: Path) -> None:
+        """A shallow checkout has no origin/main; say so with the remedy (#181's GIT_003).
+
+        Staged mode resolves the base ref up front rather than letting the diff
+        fail later, because the later failure would be git's own "bad revision"
+        with nothing actionable in it.
+        """
+        result = runner.invoke(
+            app,
+            ["migrate", "validate", "--check-drift", "--base-ref", "origin/main", "--staged"],
+        )
+
+        assert result.exit_code == 7, result.output
+        assert "fetch-depth" in result.output
+
+    def test_empty_index_is_not_an_error(self, staged_repo: Path) -> None:
+        """Nothing staged is a clean pass, not a crash: the empty tree is a tree."""
+        _git(staged_repo, "reset", "-q", "HEAD")
+
+        result = _validate("--check-drift", "--staged")
+
+        assert result.exit_code == 0, result.output

--- a/tests/integration/test_view_manager.py
+++ b/tests/integration/test_view_manager.py
@@ -14,6 +14,12 @@ def vm_db(clean_test_db: psycopg.Connection) -> psycopg.Connection:
 
     # Also drop extra schemas and materialized views from previous tests
     with conn.cursor() as cur:
+        # Pin the search_path first. install_helpers() creates a schema named
+        # `confiture`, and PostgreSQL's default search_path is `"$user", public`
+        # — so when the connecting role is *itself* named confiture (CI's is),
+        # every unqualified CREATE VIEW in these tests lands in the helpers
+        # schema instead of public, and a sweep of ARRAY['public'] finds nothing.
+        cur.execute("SET search_path = public")
         cur.execute("DROP SCHEMA IF EXISTS confiture CASCADE")
         cur.execute("DROP SCHEMA IF EXISTS catalog CASCADE")
         # Drop materialized views separately (clean_test_db only drops regular views)

--- a/tests/unit/idempotency/test_cli.py
+++ b/tests/unit/idempotency/test_cli.py
@@ -1041,3 +1041,71 @@ class TestPhase04SeverityCLI:
         assert payload["violations"][0]["severity"] == "info"
         assert payload["violations"][0]["source_line"] is not None
         assert result.exit_code == 0
+
+
+class TestReadTextMigrationsAreAnalyzed:
+    """End to end for #185: SQL behind ``Path(...).read_text()`` reaches the gate.
+
+    The extractor-level tests pin the AST match; this pins the wiring — that a
+    non-idempotent statement living in a referenced .sql file actually fails
+    `migrate validate --idempotent`, and shows up in the JSON document.
+    """
+
+    def _project(self, tmp_path: Path, expression: str) -> Path:
+        migrations_dir = tmp_path / "db" / "migrations"
+        migrations_dir.mkdir(parents=True)
+        schema_dir = tmp_path / "db" / "schema"
+        schema_dir.mkdir(parents=True)
+        (schema_dir / "fn.sql").write_text("CREATE TABLE audit (id INT);\n")
+        (migrations_dir / "20260101000030_reads.py").write_text(
+            "from pathlib import Path\n"
+            "\n"
+            "from confiture.models.migration import Migration\n"
+            "\n"
+            "class Reads(Migration):\n"
+            '    version = "20260101000030"\n'
+            '    name = "reads"\n'
+            "    def up(self) -> None:\n"
+            f"        self.execute({expression})\n"
+            "    def down(self) -> None:\n"
+            "        pass\n"
+        )
+        return migrations_dir
+
+    def test_non_idempotent_statement_in_the_referenced_file_is_flagged(
+        self, tmp_path: Path, monkeypatch
+    ):
+        migrations_dir = self._project(tmp_path, 'Path("db/schema/fn.sql").read_text()')
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(
+            app,
+            ["migrate", "validate", "--idempotent", "--migrations-dir", str(migrations_dir)],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "CREATE TABLE" in result.output
+
+    def test_unresolvable_shape_is_reported_as_a_warning_in_json(self, tmp_path: Path, monkeypatch):
+        import json
+
+        migrations_dir = self._project(tmp_path, "Path(target).read_text()")
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "migrate",
+                "validate",
+                "--idempotent",
+                "--migrations-dir",
+                str(migrations_dir),
+                "--format",
+                "json",
+            ],
+        )
+
+        payload = json.loads(result.stdout)
+        kinds = [w["kind"] for w in payload["warnings"]]
+        assert kinds == ["dynamic_read_text"]
+        assert "execute_file" in payload["warnings"][0]["message"]

--- a/tests/unit/idempotency/test_python_migration_extractor.py
+++ b/tests/unit/idempotency/test_python_migration_extractor.py
@@ -528,3 +528,239 @@ class TestEdgeCases:
         assert result.warnings == []
         assert len(result.snippets) == 1
         assert result.snippets[0].sql == "CREATE TABLE x (id int);"
+
+
+def _migration_reading(tmp_path: Path, expression: str, name: str = "20260101000020_rt.py") -> Path:
+    """A migration whose up() is ``self.execute(<expression>)``."""
+    return _write(
+        tmp_path / "db" / "migrations",
+        name,
+        "from pathlib import Path\n"
+        "\n"
+        "from confiture.models.migration import Migration\n"
+        "\n"
+        "class ReadsText(Migration):\n"
+        f'    version = "{name[:14]}"\n'
+        '    name = "reads_text"\n'
+        "    def up(self) -> None:\n"
+        f"        self.execute({expression})\n"
+        "    def down(self) -> None:\n"
+        "        pass\n",
+    )
+
+
+class TestExecuteReadTextLiteral:
+    """``self.execute(Path("x.sql").read_text())`` is analyzed, not skipped (#185).
+
+    This shape is common enough that treating it as unanalyzable dynamic SQL
+    meant the idempotency gate silently passed migrations it had never read —
+    the failure mode the extractor's structured warnings exist to prevent. Only
+    a *literal* path is resolved: no variables, no module constants, no
+    expression evaluation.
+    """
+
+    def test_literal_path_read_text_is_extracted(self, tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        (tmp_path / "db" / "migrations").mkdir(parents=True)
+        (tmp_path / "db" / "schema").mkdir(parents=True)
+        (tmp_path / "db" / "schema" / "fn.sql").write_text(
+            "CREATE TABLE fn (id int);\n", encoding="utf-8"
+        )
+        migration = _migration_reading(tmp_path, 'Path("db/schema/fn.sql").read_text()')
+        monkeypatch.chdir(tmp_path)
+
+        result = extract_sql_from_python_migration(migration, project_root=tmp_path)
+
+        assert result.warnings == []
+        assert len(result.snippets) == 1
+        snippet = result.snippets[0]
+        assert snippet.kind == ExtractionKind.FILE
+        assert snippet.sql == "CREATE TABLE fn (id int);\n"
+        assert snippet.sql_file is not None
+        assert snippet.sql_file.name == "fn.sql"
+
+    def test_encoding_keyword_is_accepted(self, tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        (tmp_path / "db" / "migrations").mkdir(parents=True)
+        (tmp_path / "db" / "schema").mkdir(parents=True)
+        (tmp_path / "db" / "schema" / "fn.sql").write_text("SELECT 1;\n", encoding="utf-8")
+        migration = _migration_reading(
+            tmp_path, 'Path("db/schema/fn.sql").read_text(encoding="utf-8")'
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = extract_sql_from_python_migration(migration, project_root=tmp_path)
+
+        assert [s.sql for s in result.snippets] == ["SELECT 1;\n"]
+
+    def test_pathlib_qualified_call_is_accepted(self, tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        (tmp_path / "db" / "migrations").mkdir(parents=True)
+        (tmp_path / "db" / "schema").mkdir(parents=True)
+        (tmp_path / "db" / "schema" / "fn.sql").write_text("SELECT 2;\n", encoding="utf-8")
+        migration = _migration_reading(tmp_path, 'pathlib.Path("db/schema/fn.sql").read_text()')
+        monkeypatch.chdir(tmp_path)
+
+        result = extract_sql_from_python_migration(migration, project_root=tmp_path)
+
+        assert [s.sql for s in result.snippets] == ["SELECT 2;\n"]
+
+
+class TestExecuteReadTextBoundary:
+    """Resolution shares ``execute_file``'s project-root confinement (v0.8.4)."""
+
+    def test_traversal_outside_the_project_is_refused(self, tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        project = tmp_path / "project"
+        outside = tmp_path / "outside"
+        (project / "db" / "migrations").mkdir(parents=True)
+        outside.mkdir(parents=True)
+        secret = outside / "secret.sql"
+        secret.write_text("SECRET CONTENTS", encoding="utf-8")
+
+        migration = _migration_reading(project, 'Path("../../outside/secret.sql").read_text()')
+
+        original_read_text = Path.read_text
+
+        def _guarded_read_text(self_path: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if self_path.resolve() == secret.resolve():
+                raise AssertionError(f"Extractor read forbidden file {self_path!r}")
+            return original_read_text(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", _guarded_read_text)
+        monkeypatch.chdir(project)
+
+        result = extract_sql_from_python_migration(migration, project_root=project)
+
+        assert result.snippets == []
+        assert [w.kind for w in result.warnings] == [WarningKind.EXECUTE_FILE_ESCAPED]
+        assert "read_text" in result.warnings[0].message
+
+    def test_both_shapes_resolve_through_one_implementation(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Patch the boundary check: neither shape may bypass it."""
+        from confiture.core.idempotency import python_migration_extractor as extractor
+
+        (tmp_path / "db" / "migrations").mkdir(parents=True)
+        (tmp_path / "db" / "schema").mkdir(parents=True)
+        (tmp_path / "db" / "schema" / "fn.sql").write_text("SELECT 3;\n", encoding="utf-8")
+        migration = _write(
+            tmp_path / "db" / "migrations",
+            "20260101000021_both.py",
+            "from pathlib import Path\n"
+            "\n"
+            "from confiture.models.migration import Migration\n"
+            "\n"
+            "class Both(Migration):\n"
+            '    version = "20260101000021"\n'
+            '    name = "both"\n'
+            "    def up(self) -> None:\n"
+            '        self.execute_file("db/schema/fn.sql")\n'
+            '        self.execute(Path("db/schema/fn.sql").read_text())\n'
+            "    def down(self) -> None:\n"
+            "        pass\n",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        calls: list[str] = []
+        original = extractor._resolve_sql_path
+
+        def _spy(raw: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(raw)
+            return original(raw, *args, **kwargs)
+
+        monkeypatch.setattr(extractor, "_resolve_sql_path", _spy)
+
+        result = extract_sql_from_python_migration(migration, project_root=tmp_path)
+
+        assert calls == ["db/schema/fn.sql", "db/schema/fn.sql"]
+        assert len(result.snippets) == 2
+
+
+class TestExecuteReadTextUnsupportedShapes:
+    """Anything but a literal is refused — with a signal that names the fix."""
+
+    def test_variable_path_emits_an_actionable_signal(self, tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        (tmp_path / "db" / "migrations").mkdir(parents=True)
+        migration = _write(
+            tmp_path / "db" / "migrations",
+            "20260101000022_var.py",
+            "from pathlib import Path\n"
+            "\n"
+            "from confiture.models.migration import Migration\n"
+            "\n"
+            "SQL_DIR = Path"
+            '("db/schema")\n'
+            "\n"
+            "class Var(Migration):\n"
+            '    version = "20260101000022"\n'
+            '    name = "var"\n'
+            "    def up(self) -> None:\n"
+            "        target = 'db/schema/fn.sql'\n"
+            "        self.execute(Path(target).read_text())\n"
+            "    def down(self) -> None:\n"
+            "        pass\n",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = extract_sql_from_python_migration(migration, project_root=tmp_path)
+
+        assert result.snippets == []
+        assert [w.kind for w in result.warnings] == [WarningKind.DYNAMIC_READ_TEXT]
+        assert "execute_file" in result.warnings[0].message
+
+    def test_joined_path_expression_is_refused(self, tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """``(SQL_DIR / "x.sql").read_text()`` is deliberately out of scope."""
+        (tmp_path / "db" / "migrations").mkdir(parents=True)
+        migration = _write(
+            tmp_path / "db" / "migrations",
+            "20260101000023_join.py",
+            "from pathlib import Path\n"
+            "\n"
+            "from confiture.models.migration import Migration\n"
+            "\n"
+            'SQL_DIR = Path("db/schema")\n'
+            "\n"
+            "class Join(Migration):\n"
+            '    version = "20260101000023"\n'
+            '    name = "join"\n'
+            "    def up(self) -> None:\n"
+            '        self.execute((SQL_DIR / "fn.sql").read_text())\n'
+            "    def down(self) -> None:\n"
+            "        pass\n",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = extract_sql_from_python_migration(migration, project_root=tmp_path)
+
+        assert result.snippets == []
+        assert [w.kind for w in result.warnings] == [WarningKind.DYNAMIC_READ_TEXT]
+        assert "execute_file" in result.warnings[0].message
+
+    def test_any_read_text_receiver_gets_the_read_text_signal(
+        self,
+        tmp_path: Path,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """Even an unrecognised receiver: it is still a file read, so name execute_file."""
+        (tmp_path / "db" / "migrations").mkdir(parents=True)
+        migration = _migration_reading(
+            tmp_path, "self.template.read_text()", name="20260101000024_other.py"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = extract_sql_from_python_migration(migration, project_root=tmp_path)
+
+        assert [w.kind for w in result.warnings] == [WarningKind.DYNAMIC_READ_TEXT]
+        assert "execute_file" in result.warnings[0].message
+
+    def test_a_plain_variable_keeps_the_dynamic_execute_signal(
+        self,
+        tmp_path: Path,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """No file read in sight — the pre-existing signal is the accurate one."""
+        (tmp_path / "db" / "migrations").mkdir(parents=True)
+        migration = _migration_reading(tmp_path, "sql", name="20260101000025_plain.py")
+        monkeypatch.chdir(tmp_path)
+
+        result = extract_sql_from_python_migration(migration, project_root=tmp_path)
+
+        assert [w.kind for w in result.warnings] == [WarningKind.DYNAMIC_EXECUTE]

--- a/tests/unit/json_schemas/test_lint_list_rules_schema.py
+++ b/tests/unit/json_schemas/test_lint_list_rules_schema.py
@@ -1,0 +1,40 @@
+"""Validate ``confiture lint --list-rules --format json`` against its schema (#150)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+SCHEMA_FILE = "lint-list-rules.schema.json"
+
+
+def _load(schemas_dir: Path, name: str) -> dict:
+    return json.loads((schemas_dir / name).read_text())
+
+
+def _payload() -> dict:
+    result = CliRunner().invoke(app, ["lint", "--list-rules", "--format", "json"])
+    assert result.exit_code == 0, result.output
+    return json.loads(result.stdout)
+
+
+def test_list_rules_payload_validates_against_schema(schemas_dir, schema_registry):
+    schema = _load(schemas_dir, SCHEMA_FILE)
+    Draft202012Validator(schema, registry=schema_registry).validate(_payload())
+
+
+def test_every_registry_rule_is_in_the_payload():
+    """The document is generated from the registry, not maintained beside it."""
+    from confiture.core.linting.rule_registry import LINT_RULES
+
+    codes = [rule["code"] for rule in _payload()["rules"]]
+    assert codes == [rule.code for rule in LINT_RULES]
+
+
+def test_schema_is_valid_draft_2020_12(schemas_dir):
+    Draft202012Validator.check_schema(_load(schemas_dir, SCHEMA_FILE))

--- a/tests/unit/test_lint_rule_registry.py
+++ b/tests/unit/test_lint_rule_registry.py
@@ -1,0 +1,132 @@
+"""The lint rule registry and its `--select` / `--ignore` resolution (#150).
+
+#150 asked for a ruff-style selection surface instead of one flag per rule. Its
+own trigger — "a second opt-in `confiture lint` rule family" — had already fired
+twice unnoticed (`tenant_001`, then `sec_002` in 0.28.0), which is why the
+command carries three inconsistent per-rule flags today.
+
+The registry is the backing store for all of it: `--list-rules` enumerates it,
+selection resolves against it, and the legacy flags become aliases over it. It
+lists only rules that can actually produce a violation — `check_indexes` and
+`check_constraints` are LintConfig fields with no implementation behind them, so
+advertising them here would be the same dishonesty in a new place.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.linting.rule_registry import (
+    DEFAULT_SELECTOR,
+    LINT_RULES,
+    families,
+    resolve_selection,
+)
+from confiture.exceptions import ConfigurationError
+
+
+class TestRegistryContents:
+    def test_every_rule_confiture_lint_can_emit_is_listed(self) -> None:
+        codes = {rule.code for rule in LINT_RULES}
+        assert codes == {
+            "naming_001",
+            "naming_002",
+            "pk_001",
+            "doc_001",
+            "sec_001",
+            "acl_001",
+            "tenant_001",
+            "replica_001",
+            "sec_002",
+        }
+
+    def test_the_default_set_is_the_pre_0420_default_behaviour(self) -> None:
+        default_on = {rule.code for rule in LINT_RULES if rule.default_on}
+        assert default_on == {"naming_001", "naming_002", "pk_001", "doc_001", "sec_001"}
+
+    def test_each_legacy_flag_maps_to_exactly_one_family(self) -> None:
+        by_flag = {rule.legacy_flag: rule.family for rule in LINT_RULES if rule.legacy_flag}
+        assert by_flag == {
+            "--check-tenant-isolation": "tenant",
+            "--replica-safe": "replica",
+            "--check-security-definer": "security-definer",
+        }
+
+    def test_sec_001_and_sec_002_are_separate_families(self) -> None:
+        """Shared code prefix, different rules: the flag named one, not the other."""
+        by_code = {rule.code: rule.family for rule in LINT_RULES}
+        assert by_code["sec_001"] == "security"
+        assert by_code["sec_002"] == "security-definer"
+
+    def test_families_are_reported_in_registry_order(self) -> None:
+        assert families() == (
+            "naming",
+            "pk",
+            "doc",
+            "security",
+            "acl",
+            "tenant",
+            "replica",
+            "security-definer",
+        )
+
+
+class TestSelection:
+    def test_no_selection_is_the_default_set(self) -> None:
+        assert resolve_selection(None, ()) == frozenset(
+            {"naming_001", "naming_002", "pk_001", "doc_001", "sec_001"}
+        )
+
+    def test_a_family_selects_its_rules_and_nothing_else(self) -> None:
+        assert resolve_selection(["naming"], ()) == frozenset({"naming_001", "naming_002"})
+
+    def test_a_code_selects_exactly_that_rule(self) -> None:
+        assert resolve_selection(["naming_001"], ()) == frozenset({"naming_001"})
+
+    def test_the_default_selector_composes_with_a_family(self) -> None:
+        """This is what the legacy flags mean: the defaults *plus* one family."""
+        assert resolve_selection([DEFAULT_SELECTOR, "replica"], ()) == frozenset(
+            {"naming_001", "naming_002", "pk_001", "doc_001", "sec_001", "replica_001"}
+        )
+
+    def test_comma_separated_values_are_split(self) -> None:
+        assert resolve_selection(["naming,pk"], ()) == frozenset(
+            {"naming_001", "naming_002", "pk_001"}
+        )
+
+    def test_ignore_wins_over_select(self) -> None:
+        assert resolve_selection(["naming"], ["naming_001"]) == frozenset({"naming_002"})
+
+    def test_ignore_accepts_a_family(self) -> None:
+        assert resolve_selection([DEFAULT_SELECTOR], ["naming"]) == frozenset(
+            {"pk_001", "doc_001", "sec_001"}
+        )
+
+    def test_ignoring_everything_selects_nothing(self) -> None:
+        assert resolve_selection([DEFAULT_SELECTOR], [DEFAULT_SELECTOR]) == frozenset()
+
+    def test_selection_is_case_insensitive(self) -> None:
+        assert resolve_selection(["NAMING"], ()) == frozenset({"naming_001", "naming_002"})
+
+
+class TestUnknownSelectors:
+    """Silently selecting nothing is the failure mode this replaces."""
+
+    def test_unknown_select_value_raises_naming_the_valid_set(self) -> None:
+        with pytest.raises(ConfigurationError) as exc:
+            resolve_selection(["nameing"], ())
+        assert "nameing" in str(exc.value)
+        # The valid set travels in the resolution hint, which is what the CLI
+        # renders to the user and what the JSON error envelope carries.
+        assert "naming" in (exc.value.resolution_hint or "")
+
+    def test_unknown_ignore_value_raises_too(self) -> None:
+        with pytest.raises(ConfigurationError) as exc:
+            resolve_selection(None, ["replika"])
+        assert "replika" in str(exc.value)
+
+    def test_the_error_carries_the_usage_error_code(self) -> None:
+        """Exit 5 (CONFIG_*), not exit 2 — 2 is PRECON_1001, "no tracking table"."""
+        with pytest.raises(ConfigurationError) as exc:
+            resolve_selection(["nope"], ())
+        assert exc.value.error_code.startswith("CONFIG")

--- a/tests/unit/test_lint_rule_selection_cli.py
+++ b/tests/unit/test_lint_rule_selection_cli.py
@@ -1,0 +1,164 @@
+"""`confiture lint --list-rules` / `--select` / `--ignore` (#150).
+
+The three legacy per-rule flags stay, as documented aliases over the same
+dispatch — #150 explicitly requires no breakage for 0.19.0 / 0.28.0 users, so
+each one is pinned here against its `--select` equivalent rather than against a
+hand-written expectation.
+
+Every test builds a real project and chdirs into it: `SchemaLinter` resolves
+`db/environments/<env>.yaml` from the working directory, so a test that skips
+this silently borrows confiture's own `db/`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+
+runner = CliRunner()
+
+_SCHEMA = """
+CREATE TABLE BadName (
+    id INT,
+    userPassword TEXT
+);
+"""
+
+
+@pytest.fixture
+def lint_project(tmp_path: Path) -> Iterator[Path]:
+    """A project whose schema trips naming_001, naming_002, pk_001, doc_001 and sec_001."""
+    (tmp_path / "db" / "schema").mkdir(parents=True)
+    (tmp_path / "db" / "migrations").mkdir(parents=True)
+    (tmp_path / "db" / "environments").mkdir(parents=True)
+    (tmp_path / "db" / "environments" / "local.yaml").write_text(
+        "database_url: postgresql://localhost/test\ninclude_dirs:\n  - path: db/schema\n"
+    )
+    (tmp_path / "db" / "schema" / "010_tables.sql").write_text(_SCHEMA)
+
+    old_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(old_cwd)
+
+
+def _lint(*args: str):  # type: ignore[no-untyped-def]
+    return runner.invoke(app, ["lint", *args])
+
+
+class TestListRules:
+    def test_lists_every_rule_with_its_family_and_default_state(self, lint_project: Path) -> None:
+        result = _lint("--list-rules")
+
+        assert result.exit_code == 0, result.output
+        for code in ("naming_001", "pk_001", "acl_001", "tenant_001", "replica_001", "sec_002"):
+            assert code in result.output
+        assert "security-definer" in result.output
+
+    def test_does_not_advertise_rules_with_no_implementation(self, lint_project: Path) -> None:
+        """`check_indexes` computes nothing and `check_constraints` has no code."""
+        result = _lint("--list-rules")
+
+        assert "fk_001" not in result.output
+        assert "constraint" not in result.output.lower()
+
+    def test_json_output_is_machine_readable(self, lint_project: Path) -> None:
+        result = _lint("--list-rules", "--format", "json")
+
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        codes = [rule["code"] for rule in payload["rules"]]
+        assert "replica_001" in codes
+        replica = next(r for r in payload["rules"] if r["code"] == "replica_001")
+        assert replica["family"] == "replica"
+        assert replica["default_on"] is False
+        assert replica["legacy_flag"] == "--replica-safe"
+
+    def test_report_mode_never_fails_even_on_a_dirty_schema(self, lint_project: Path) -> None:
+        """It prints a catalogue; the schema is not consulted."""
+        result = _lint("--list-rules", "--fail-on-warning")
+
+        assert result.exit_code == 0, result.output
+
+
+class TestSelect:
+    def test_selecting_one_family_suppresses_the_others(self, lint_project: Path) -> None:
+        result = _lint("--select", "pk")
+
+        assert "pk_001" in result.output
+        assert "naming_001" not in result.output
+
+    def test_selecting_a_single_code_runs_only_that_rule(self, lint_project: Path) -> None:
+        result = _lint("--select", "naming_001")
+
+        assert "naming_001" in result.output
+        assert "naming_002" not in result.output
+
+    def test_unknown_rule_exits_5_naming_the_valid_set(self, lint_project: Path) -> None:
+        """Exit 5 is this repo's usage error; exit 2 is "tracking table absent"."""
+        result = _lint("--select", "nameing")
+
+        assert result.exit_code == 5, result.output
+        assert "naming" in result.output
+
+    def test_default_selector_keeps_the_usual_rules(self, lint_project: Path) -> None:
+        selected = _lint("--select", "default")
+        plain = _lint()
+
+        assert selected.output == plain.output
+
+
+class TestIgnore:
+    def test_ignore_removes_a_rule_from_the_default_set(self, lint_project: Path) -> None:
+        result = _lint("--ignore", "naming")
+
+        assert "naming_001" not in result.output
+        assert "pk_001" in result.output
+
+    def test_ignore_wins_over_select(self, lint_project: Path) -> None:
+        result = _lint("--select", "naming", "--ignore", "naming_001")
+
+        assert "naming_001" not in result.output
+        assert "naming_002" in result.output
+
+
+class TestLegacyFlagsAreAliases:
+    """0.19.0 / 0.28.0 invocations keep working, and mean what they always meant."""
+
+    def test_replica_safe_equals_select_default_replica(self, lint_project: Path) -> None:
+        legacy = _lint("--replica-safe")
+        modern = _lint("--select", "default,replica")
+
+        assert legacy.exit_code == modern.exit_code
+        assert legacy.output == modern.output
+
+    def test_check_tenant_isolation_equals_select_default_tenant(self, lint_project: Path) -> None:
+        legacy = _lint("--check-tenant-isolation")
+        modern = _lint("--select", "default,tenant")
+
+        assert legacy.exit_code == modern.exit_code
+        assert legacy.output == modern.output
+
+    def test_check_security_definer_equals_select_default_security_definer(
+        self, lint_project: Path
+    ) -> None:
+        legacy = _lint("--check-security-definer")
+        modern = _lint("--select", "default,security-definer")
+
+        assert legacy.exit_code == modern.exit_code
+        assert legacy.output == modern.output
+
+    def test_a_legacy_flag_still_runs_the_default_rules(self, lint_project: Path) -> None:
+        """The flags add a family; they never replaced the default lint."""
+        result = _lint("--replica-safe")
+
+        assert "naming_001" in result.output

--- a/tests/unit/test_restorer.py
+++ b/tests/unit/test_restorer.py
@@ -1082,3 +1082,62 @@ class TestDeferredMatviewOrchestration:
         assert "TABLE DATA public tb_order" in tables_txt
         assert "MATERIALIZED VIEW DATA public mv_maintenance_price" in matviews_txt
         assert "TABLE DATA" not in matviews_txt
+
+
+# ---------------------------------------------------------------------------
+# Password handling: a password-authenticated server
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordReachesTheSubprocess:
+    """A password-authenticated server is reachable, and the password stays off argv.
+
+    Every restore phase — pg_restore per section and the psql ANALYZE — runs as a
+    subprocess, so a password held only by the caller never reaches libpq unless
+    it is put in the child's environment. Without this, `confiture restore` and
+    `confiture test-db provision --from-artifact` fail with `fe_sendauth: no
+    password supplied` against any server that is not trust/peer-authenticated.
+    """
+
+    def _opts(self, **kwargs) -> RestoreOptions:
+        defaults = {
+            "backup_path": Path("d.pgdump"),
+            "target_db": "db",
+            "host": "db.internal",
+            "username": "migrator",
+            "password": "s3cret",
+        }
+        defaults.update(kwargs)
+        return RestoreOptions(**defaults)
+
+    def test_pg_restore_gets_pgpassword_in_env(self):
+        mock_proc = _make_proc([], 0)
+        with patch("subprocess.Popen", return_value=mock_proc) as popen:
+            DatabaseRestorer()._run_section("pre-data", self._opts(), parallel=False)
+        assert popen.call_args.kwargs["env"]["PGPASSWORD"] == "s3cret"
+
+    def test_password_never_appears_on_argv(self):
+        mock_proc = _make_proc([], 0)
+        with patch("subprocess.Popen", return_value=mock_proc) as popen:
+            DatabaseRestorer()._run_section("pre-data", self._opts(), parallel=False)
+        assert "s3cret" not in " ".join(popen.call_args.args[0])
+
+    def test_analyze_gets_pgpassword_in_env(self):
+        mock_proc = _make_proc([], 0)
+        with patch("subprocess.Popen", return_value=mock_proc) as popen:
+            DatabaseRestorer()._run_analyze(self._opts())
+        assert popen.call_args.kwargs["env"]["PGPASSWORD"] == "s3cret"
+
+    def test_no_password_leaves_env_alone(self):
+        """Without a password the child inherits the ambient env, PG* vars included."""
+        mock_proc = _make_proc([], 0)
+        with patch("subprocess.Popen", return_value=mock_proc) as popen:
+            DatabaseRestorer()._run_section("pre-data", self._opts(password=None), parallel=False)
+        assert "PGPASSWORD" not in popen.call_args.kwargs["env"]
+
+    def test_table_count_validation_connects_with_the_password(self):
+        """--min-tables opens its own psycopg connection; it needs the credential too."""
+        mock_conn, _ = _make_db_mock((7,))
+        with patch("psycopg.connect", return_value=mock_conn) as connect:
+            DatabaseRestorer()._validate_table_count(self._opts(min_tables=1))
+        assert connect.call_args.kwargs["password"] == "s3cret"

--- a/tests/unit/test_test_db.py
+++ b/tests/unit/test_test_db.py
@@ -7,6 +7,7 @@ testable without a database. DB-touching behaviour is integration-tested.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import psycopg
 import pytest
@@ -660,3 +661,29 @@ class TestSetupRamTablespace:
         monkeypatch.setattr(prov, "_maintenance_conn", lambda: fake)
         with pytest.raises(SchemaError, match="not usable"):
             prov.setup_ram_tablespace("ram_ts", "/dev/shm/ram_ts", owner="postgres")
+
+
+class TestArtifactRestoreCarriesTheCredential:
+    """`test-db provision --from-artifact` must reach a password-authed server.
+
+    The provisioner parses host/port/user out of the server URL and hands them to
+    :class:`~confiture.core.restorer.RestoreOptions`; the password was dropped on
+    the floor, so every artifact restore against a non-trust server died with
+    ``fe_sendauth: no password supplied`` — including the per-worker xdist
+    fixtures, whose whole point is unattended CI provisioning.
+    """
+
+    def test_password_from_the_server_url_reaches_restore_options(self) -> None:
+        from unittest.mock import MagicMock
+
+        from confiture.core.restorer import RestoreResult
+
+        provisioner = TestDbProvisioner("postgresql://migrator:s3cret@db.internal:5433/app")
+        restorer = MagicMock()
+        restorer.restore.return_value = RestoreResult(success=True, phases_completed=["pre-data"])
+
+        provisioner._restore_into("tmpl", Path("artifact.pgdump"), restorer)
+
+        options = restorer.restore.call_args.args[0]
+        assert (options.host, options.port, options.username) == ("db.internal", 5433, "migrator")
+        assert options.password == "s3cret"

--- a/tests/unit/test_validate_staged_routing.py
+++ b/tests/unit/test_validate_staged_routing.py
@@ -130,3 +130,32 @@ def test_non_staged_grant_accompaniment_is_not_staged(
     )
     assert result.exit_code == 0, result.output
     assert captured_git_calls["grant"]["staged_only"] is False
+
+
+def test_grant_only_staged_never_resolves_a_git_scope(
+    captured_git_calls: dict[str, dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--require-grant-migration --staged` must not touch the git scope at all.
+
+    Grant accompaniment reads the index itself (`staged_only`) and ignores both
+    refs. Resolving the scope anyway runs `rev-parse --verify` / `merge-base` /
+    `write-tree`, which legitimately fails with GIT_003 in a shallow clone — so
+    an eager resolution turns a working pre-commit gate into exit 7 on exactly
+    the CI checkout where it used to pass. Caught in CI, not locally: a full
+    clone resolves `origin/main` and hides it.
+    """
+    from confiture.core.validation.context import ValidationContext
+
+    def _explode(self: ValidationContext) -> tuple[str, str]:
+        raise AssertionError("git scope resolved for a check that does not use it")
+
+    monkeypatch.setattr(ValidationContext, "_resolve_git_scope", _explode)
+
+    result = runner.invoke(
+        app,
+        ["migrate", "validate", "--require-grant-migration", "--staged"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_git_calls["grant"]["staged_only"] is True

--- a/tests/unit/test_validate_staged_routing.py
+++ b/tests/unit/test_validate_staged_routing.py
@@ -1,18 +1,31 @@
 """ARCH-L1: pin where ``migrate validate --staged`` actually routes.
 
-The pre-Phase-03 code carried a dead ``target_ref = "HEAD" if not staged else
-"HEAD"`` ternary for the drift and migration-accompaniment checks — both
-branches were ``"HEAD"``, so ``--staged`` was a silent no-op there. The staged
-index is only honored by the grant-accompaniment check (``staged_only=staged``).
+Before 0.42.0 the answer was "almost nowhere": drift and migration
+accompaniment received ``target_ref="HEAD"`` whether or not ``--staged`` was
+passed, so the pre-commit flag compared the last commit against itself and the
+staged change — the thing being committed — was invisible. Only
+grant-accompaniment honoured the index.
 
-These tests pin that contract: ``--staged`` reaches grant-accompaniment as
-``staged_only=True``, while drift/accompaniment receive ``target_ref="HEAD"``
-regardless. The git-validation functions are patched on their source module
+#184 makes ``--staged`` a real scope for the whole group. These tests pin the
+new routing at the seam, one level below the end-to-end behaviour in
+``tests/integration/test_validate_staged_scope.py``:
+
+- drift and accompaniment receive the **staged index as a tree OID** in place
+  of ``"HEAD"``, and accompaniment additionally receives ``two_dot=True``,
+  because ``base...tree`` is not a valid symmetric difference;
+- grant-accompaniment keeps its own ``staged_only`` path against ``"HEAD"`` —
+  it diffs grant *files* through the index and never built a schema from a ref;
+- without ``--staged``, every ref is ``"HEAD"`` and nothing is two-dot.
+
+``--base-ref HEAD`` is explicit throughout: the default ``origin/main`` does not
+resolve in a shallow CI checkout, and staged mode verifies the base ref up front
+(GIT_003). The git-validation functions are patched on their source module
 (``confiture.cli.git_validation``) since ``migrate_validate`` imports them lazily.
 """
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
@@ -21,6 +34,8 @@ from typer.testing import CliRunner
 from confiture.cli.main import app
 
 runner = CliRunner()
+
+_OID_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 @pytest.fixture
@@ -51,7 +66,7 @@ def captured_git_calls(monkeypatch: pytest.MonkeyPatch) -> dict[str, dict[str, A
     return calls
 
 
-def test_staged_reaches_grant_accompaniment_only(
+def test_staged_scopes_drift_and_accompaniment_to_the_index(
     captured_git_calls: dict[str, dict[str, Any]],
 ) -> None:
     result = runner.invoke(
@@ -62,15 +77,48 @@ def test_staged_reaches_grant_accompaniment_only(
             "--check-drift",
             "--require-migration",
             "--require-grant-migration",
+            "--base-ref",
+            "HEAD",
             "--staged",
         ],
     )
     assert result.exit_code == 0, result.output
-    # ARCH-L1: drift/accompaniment ignore --staged (committed-ref comparison).
+
+    # #184: the target is the index written out as a tree, not the last commit.
+    staged_tree = captured_git_calls["drift"]["target_ref"]
+    assert _OID_RE.match(staged_tree), staged_tree
+    assert captured_git_calls["accompaniment"]["target_ref"] == staged_tree
+    # A tree has no merge base, so the file diffs must run two-dot.
+    assert captured_git_calls["accompaniment"]["two_dot"] is True
+    # Both checks share one resolved base, so they cannot disagree about scope.
+    assert (
+        captured_git_calls["drift"]["base_ref"] == captured_git_calls["accompaniment"]["base_ref"]
+    )
+    # Grant accompaniment reaches the index its own way, against HEAD.
+    assert captured_git_calls["grant"]["staged_only"] is True
+    assert captured_git_calls["grant"]["target_ref"] == "HEAD"
+
+
+def test_without_staged_every_check_compares_committed_refs(
+    captured_git_calls: dict[str, dict[str, Any]],
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "migrate",
+            "validate",
+            "--check-drift",
+            "--require-migration",
+            "--require-grant-migration",
+            "--base-ref",
+            "HEAD",
+        ],
+    )
+    assert result.exit_code == 0, result.output
     assert captured_git_calls["drift"]["target_ref"] == "HEAD"
     assert captured_git_calls["accompaniment"]["target_ref"] == "HEAD"
-    # The staged index is honored only by grant-accompaniment.
-    assert captured_git_calls["grant"]["staged_only"] is True
+    assert captured_git_calls["accompaniment"]["two_dot"] is False
+    assert captured_git_calls["grant"]["staged_only"] is False
 
 
 def test_non_staged_grant_accompaniment_is_not_staged(

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql-confiture"
-version = "0.41.0"
+version = "0.42.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Release **0.42.0** — phases 06 and 13 of the open-issue backlog, plus the CI-database fix that had to land first because it changes how any coverage claim in this repo should be read.

## CI runs the DB-backed tests (prerequisite)

`quality-gate.yml` started a PostgreSQL service and exported `DATABASE_URL`, but the `test_db_url` fixture every integration test resolves through reads `CONFITURE_TEST_DB_URL`. Result: **~460 tests skipped on every pull request** (6780 passed / 461 skipped in CI vs 9792 / 79 locally), and every success criterion phrased as "integration tests cover this" gated nothing.

Wiring the variable turned the suite on, and **49 tests failed on first contact**. All are fixed here. Verified by rehearsing the exact CI shape locally — throwaway `postgres:15` and `:17` containers with CI's role, password and TCP port:

| Root cause | Tests |
|---|---|
| `clean_test_db` never dropped the `confiture` helper schema that `migrate up` auto-installs. Under a role *also* named `confiture` — CI's — `"$user", public` then redirects every later unqualified `CREATE TABLE` into it | 32 |
| Configs rebuilt field-by-field from psycopg's `ConnectionInfo`, which redacts the password | 8 |
| `RestoreOptions` hardcoded `localhost:5432` with no credentials | 5 |
| `RestoreOptions` had no `password` at all — `pg_restore` could not authenticate (product fix) | 1 |
| Views created unqualified *after* `install_helpers()` in the same test | 2 |
| `test_force_workflow_issue_4_scenario`: two early `return`s made it a no-op, and its `DROP SCHEMA public CASCADE` also dropped the ledger it then asserted had survived | 1 |

## #184 — `--staged` scopes every git-aware check ⚠️ behaviour change

Only `--require-grant-migration` honoured `--staged`. `--check-drift --staged` and `--require-migration --staged` compared `--base-ref` against `HEAD`, so a pre-commit hook ignored exactly the change being committed — while the pre-commit recipe in `docs/guides/git-aware-validation.md` has advertised that combination since it shipped.

Staged mode now materialises the index as a tree (`git write-tree`) and compares from the merge base. Three things measured rather than assumed:

- `git ls-tree`/`git show` accept a tree OID, so the schema builder needed no change (the phase predicted this);
- `git diff base...<tree>` is **rejected** — a symmetric difference needs two commits — so the accompaniment file diffs run two-dot;
- `git merge-base base <tree>` is rejected too, so the base resolves against `HEAD` first.

Content comes from the index blob, so a file staged and then edited further contributes its staged content, and an unstaged migration does not count as accompanying a staged DDL change. Shallow clone → `GIT_003` (exit 7) with the remedy, not an empty scope.

## #185 — `self.execute(Path("x.sql").read_text())` is analyzed

Previously reported as unanalyzable dynamic SQL, so `--idempotent` passed migrations whose statements it had never read. Only a **literal** path resolves; computed ones get a new `dynamic_read_text` warning naming `execute_file(...)`. Resolution routes through `execute_file`'s own project-root confinement — proven by a test that patches the boundary and asserts both shapes call it, plus a sentinel that fails if the out-of-project file is ever opened.

## #150 — `confiture lint --select` / `--ignore` / `--list-rules`

The RFC's own trigger ("a second opt-in rule family") had fired twice unnoticed. Now registry-backed: select by family or code, `--ignore` wins, `default` means "every rule on by default" so opt-in families compose. Unknown selectors exit 5 with the valid set. The three legacy flags stay as aliases, pinned by tests comparing their output byte-for-byte against the selector form.

Two things surfaced: rule codes never reached the user (violations now carry `rule_id`; the table gained a `Code` column), and `check_indexes` / `check_constraints` are `LintConfig` fields with no rule behind them — the help text no longer claims otherwise.

## Verification

- 10183 passed / 67 skipped against a CI-shaped `postgres:17` container
- 10153 passed / 79 skipped locally
- `ruff check`, `ruff format --check`, `ty check`, json-schema suite
- `cargo fmt --check`, `cargo clippy --locked`
- No adapter-contract floor bump: nothing this release touches is on the contract's subcommand surface

Closes #184
Closes #185
Closes #150
