### PR TITLE
feat(preflight): emit a per-change risk tier (0.43.0)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -426,6 +426,37 @@ touches it. This ops-path-only coupling is the intended end state.
 > Rust reshape and omits fraisier + SpecQL; `fraise-stack/ROADMAP.md` (2026-05-31)
 > is the current source of truth and supersedes it.
 
+### Decision 9: Risk classification lives on the preflight seam, not in a scoring engine
+
+**Choice**: `core/risk_tier.py` (a pure five-value taxonomy) and
+`core/change_set.py` (a statement-level classifier) emit a per-change risk tier
+in `migrate preflight --format json`, wired into the adapter seam from the first
+commit.
+
+**Rationale**: Confiture previously had a risk engine — `core/risk/`, a
+`DowntimePredictor` with numeric scoring — deleted at `2bf38f1` (−2043 lines) as
+a never-wired parallel implementation with zero production importers. That
+deletion was correct and this decision does not reverse it. Two things are
+different:
+
+- **It is consumed.** The tier crosses the migration-adapter seam as typed data
+  under a ratified cross-repo contract (#197 / fraisier-core#44), tested from
+  both sides against the same golden fixtures. The deleted engine answered a
+  question nobody asked.
+- **It is a taxonomy, not a score.** Five named tiers with documented boundaries,
+  derived from the parsed statement by a pure function. A predicted downtime in
+  seconds cannot be validated against reality; "this `DROP COLUMN` is
+  irreversible" can. Resist reconstituting a score.
+
+**Why a second parser**: the change set does *not* reuse
+`core/replica/classifier.py`. That classifier feeds the pinned `window_safe`
+verdict (#154) and reports only the operations in its safety matrix — anything
+outside it degrades to `depends`, which flips `window_safe` to false. Widening it
+to the change-set vocabulary would move a cross-repo contract as a side effect,
+so `change_set.py` walks the statements itself and the two verdicts stay
+independent. The cost is one extra parse per migration file, filesystem-bound and
+measured in milliseconds; the alternative was a false verdict on a safety gate.
+
 ---
 
 ## Testing Architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-08-06
+
+`migrate preflight` now says **what kind of risk** each pending change carries,
+not just whether the migration set is window-safe. The tier crosses the
+migration-adapter seam as typed data under a contract ratified with
+[fraisier-core#44](https://github.com/fraiseql/fraisier-core/issues/44) (#197).
+
+### Added
+
+- **`change_set` in `migrate preflight --format json`** (#197), in both the
+  default and `--against` payloads:
+
+  ```json
+  "change_set": {
+    "contract_version": 1,
+    "changes": [
+      {
+        "kind": "drop_column",
+        "object": "public.tb_user.legacy_flag",
+        "migration": "20260804120100",
+        "tier": "irreversible",
+        "detail": "DROP COLUMN legacy_flag"
+      }
+    ]
+  }
+  ```
+
+  Five tiers, `snake_case`, ordered least- to most-severe: `additive` <
+  `reversible` < `lock_risky` < `destructive` < `irreversible`. That order picks
+  the worst tier in a set and sorts a plan render; it is **not** how policy
+  decisions are made — consumers map each tier to an action independently.
+
+  The **object wrapper is load-bearing**. `{"changes": []}` means "confiture
+  classified the set and there is nothing to change"; an **absent** `change_set`
+  means "confiture did not classify", which a consumer treats as unclassified
+  and denies. A bare array cannot express the difference, and the conflation
+  resolves the dangerous way.
+
+- **Honest non-answers.** A change confiture cannot tier truthfully carries **no
+  `tier` key** rather than a guess — a non-SQL `.py` migration
+  (`kind: "python_migration"`), an `ALTER COLUMN … TYPE` (reversible when
+  widening, irreversible when narrowing: preflight has no connection and cannot
+  tell), or any statement outside the taxonomy (`kind: "unclassified"`). No
+  statement is ever dropped from the set: a shorter list of fully-classified
+  changes would read as a *cleaner* plan than the truth.
+
+- **Text mode** leads with the worst tier, lists the non-additive changes, and
+  says how many could not be classified.
+
+- `confiture.core.risk_tier` (`RiskTier`, `worst_tier`) and
+  `confiture.core.change_set` (`ChangeEntry`, `ChangeSet`, `build_change_set`,
+  `classify_statements`) are importable for library use.
+
+### Unchanged, deliberately
+
+- **`window_safe` is byte-identical to 0.42.0.** It answers a different question
+  — can N-1 and N share this database for a cutover window? — and the two
+  verdicts are independent by design: `RENAME COLUMN` is replica-*unsafe* and
+  risk-tier `reversible`. Re-proven end-to-end over the replica corpus, which
+  now pins both verdicts per row so a change moving one without the other shows
+  up.
+
+- **The fraisier adapter's minimum stays at Confiture ≥ 0.20.0.** `change_set`
+  is new on a command the adapter calls, but its absence is *meaningful* rather
+  than an error, so raising the floor would delete the fail-safe path instead of
+  protecting it. The adapter advertises the `risk_tier` capability on a detected
+  version ≥ 0.43.0 — recorded in the contract's new capability table.
+
+### Notes
+
+- The change set does **not** reuse `core/replica/classifier.py`. That
+  classifier feeds the pinned `window_safe` verdict and reports only the
+  operations in its safety matrix; an operation outside it degrades to
+  `depends`, which would flip `window_safe` to false. Widening it would have
+  moved a cross-repo contract as a side effect, so `core/change_set.py` walks
+  the statements itself — one extra parse per migration file, filesystem-bound.
+  See ARCHITECTURE.md Decision 9.
+- Both parser backends are implemented and parity-tested entry for entry, so an
+  install without the `[ast]` extra classifies identically. The regex fallback
+  gained a dollar-quote-aware statement splitter, so a `;` inside a
+  `CREATE FUNCTION` body no longer shreds the statement.
+- `detail` is synthesised from the parsed statement rather than echoed from the
+  source, so it can never carry a credential from a statement such as
+  `CREATE USER … PASSWORD …`.
+- fraisier-core's eight golden preflight fixtures are vendored under
+  `tests/fixtures/preflight-contract/`; confiture's CI cannot see the sibling
+  repository, so producer drift had nowhere to fail before.
+
 ## [0.42.0] - 2026-08-06
 
 `--staged` becomes a real scope for every git-aware check (#184), SQL loaded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.42.0
+**Version**: 0.43.0
 **Last Updated**: 2026-08-06
 **Current Status**: Production-Ready
 
@@ -969,7 +969,7 @@ When stuck, ask:
 ---
 
 **Last Updated**: 2026-08-06
-**Version**: 0.42.0
+**Version**: 0.43.0
 
 ---
 

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -19,6 +19,17 @@ The adapter requires **Confiture ≥ 0.20.0** — the release that introduced
 `migrate current`, `migrate down-to`, and the `--no-config` env-only DSN mode the
 adapter relies on. See the [compatibility policy](#compatibility-policy) below.
 
+**Version-gated capabilities.** Some fields exist only from a given release, and
+their *absence* is meaningful rather than an error. The minimum stays where it
+is; the adapter gates the capability on the detected version instead. Advertising
+a capability the installed binary cannot fulfil turns every deploy into a denial
+— safe, but useless.
+
+| Capability | From | Field | Absent means |
+|------------|------|-------|--------------|
+| `window_safe` | 0.23.0 (#154) | top-level `window_safe` on `preflight` | cannot certify → blocked |
+| `risk_tier` | **0.43.0** (#197) | `change_set` on `preflight` | did not classify → denied |
+
 ## Invocation shape
 
 Every call the adapter makes follows the same shape:
@@ -87,7 +98,9 @@ The adapter-consumed fields per command:
   to the pre-0.37.0 schema must update to accept the new field.
 - **preflight** — `ok`, the top-level `window_safe` verdict (the typed blue-green
   window-safety contract — see [below](#replica-forward-compatibility-namespace-window-safety-seam)),
-  `summary`, each `issues[].{severity, code, message, migration}`.
+  `summary`, each `issues[].{severity, code, message, migration}`, and — since
+  0.43.0 — the `change_set` object carrying per-change risk tiers (see
+  [below](#per-change-risk-tier-change_set)).
 
 ## Replica forward-compatibility namespace (window-safety seam)
 
@@ -187,6 +200,102 @@ and pinned in the published schemas + the contract test. The `ok` flag **cannot*
 substitute for it: replica findings are warn-by-default, so `ok == true` can
 coincide with `window_safe == false`.
 
+## Per-change risk tier (`change_set`)
+
+**Since 0.43.0** (#197), paired with
+[fraisier-core#44](https://github.com/fraiseql/fraisier-core/issues/44). The
+specification is
+[`docs/proposals/migration-risk-contract.md`](https://github.com/fraiseql/fraisier-core/blob/main/docs/proposals/migration-risk-contract.md)
+in fraisier-core; this section is the producer-side statement of the same
+contract.
+
+`window_safe` answers one question — *can N-1 and N share this database for a
+cutover window?* — and deliberately answers nothing else. `change_set` answers a
+different one: *what does this migration set do to the data, change by change?*
+Both ship; neither replaces the other.
+
+```json
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": { "...": "unchanged" },
+  "issues": [],
+  "change_set": {
+    "contract_version": 1,
+    "changes": [
+      {
+        "kind": "drop_column",
+        "object": "public.tb_user.legacy_flag",
+        "migration": "20260804120100",
+        "tier": "irreversible",
+        "detail": "DROP COLUMN legacy_flag"
+      }
+    ]
+  }
+}
+```
+
+### The five tiers
+
+`snake_case` on the wire, ordered least- to most-severe:
+
+| Tier | Meaning | Emitted for |
+|------|---------|-------------|
+| `additive` | Adds a new object; no existing reader or writer can break. | `CREATE TABLE`, `ADD COLUMN … NULL`, `CREATE INDEX CONCURRENTLY`, `INSERT` |
+| `reversible` | Changes existing state, with a down path that restores it. | `RENAME COLUMN`, `SET`/`DROP DEFAULT`, `CREATE OR REPLACE`, `GRANT`, `COMMENT` |
+| `lock_risky` | Semantically safe, but takes a lock that can stall a hot table. | non-concurrent `CREATE INDEX`, `ADD COLUMN … NOT NULL`, immediate `ADD CONSTRAINT`, `SET NOT NULL` |
+| `destructive` | Destroys data or an object; the loss is bounded and restorable from backup. | `DROP INDEX`, `DROP VIEW`, `DROP CONSTRAINT`, `TRUNCATE`, `DELETE`, `UPDATE` |
+| `irreversible` | Destroys data with no down path that can restore it. | `DROP COLUMN`, `DROP TABLE`, `DROP SCHEMA`, `DROP SEQUENCE` |
+
+The ordering exists to pick the worst tier in a set and to sort a plan render
+worst-first. **It is not how policy decisions are made** — policy maps each tier
+to an action independently.
+
+Boundary rulings, so they are not re-litigated per pull request:
+
+- `DROP INDEX` is `destructive`, not `irreversible` — the index is rebuildable
+  from the data it indexes.
+- `DROP COLUMN` is `irreversible` **even with a `.down.sql`** — the down path
+  restores the schema, not the data.
+- A change qualifying for two tiers takes the more severe one.
+- `RENAME COLUMN` is `reversible`, not `destructive`. It breaks readers on the
+  old name, but that is `window_safe`'s question, and this taxonomy classifies on
+  data and DDL grounds. Consumers that need the deployment view read both fields.
+
+### Absence is never safety
+
+Four ways the answer can be missing. None of them mean *proceed*:
+
+| Situation | Wire | Meaning |
+|---|---|---|
+| Confiture < 0.43.0 | `change_set` key absent | The producer cannot classify at all. |
+| Classified, nothing to do | `{"contract_version": 1, "changes": []}` | The producer looked. There is nothing to change. **Safe.** |
+| `contract_version` too new | present but unreadable | Treat as absent, and name both versions in the refusal. Never a best-effort parse. |
+| One change confiture cannot tier | that entry has no `tier` key | That change is unclassified; the others stay classified. |
+
+Confiture emits **no `tier`** rather than a guess. It does so for a non-SQL
+`.py` migration (`kind: "python_migration"`), for `ALTER COLUMN … TYPE` (whose
+direction needs the source and target types — preflight has no connection), and
+for any statement outside the taxonomy (`kind: "unclassified"`). A statement is
+never dropped from the set: a shorter list of fully-classified changes would read
+as a *cleaner* plan than the truth, which is the one failure direction this
+contract exists to prevent.
+
+### Stability
+
+The five tier values and the `contract_version` rule are a **cross-repo
+contract**. Adding a field to a change entry does not bump `contract_version`;
+removing or renaming a field, or changing what a tier *means*, does. A sixth tier
+is a `contract_version` conversation, not a silent addition — a consumer parses
+an unrecognised tier string to *unclassified*, never to a nearest match.
+
+Both repositories test against the same bytes:
+[`tests/fixtures/preflight-contract/`](../../tests/fixtures/preflight-contract/)
+here, `crates/fraisier-adapter-confiture/tests/fixtures/preflight/` there.
+`change_set` is declared but **not required** in the published schema, so
+payloads from earlier Confiture stay valid and correctly read as "did not
+classify".
+
 ## Exit codes
 
 The adapter branches on Confiture's [exit-code convention](exit-codes.md). The
@@ -231,3 +340,11 @@ The exit-code convention and the JSON shapes above are a **stability contract**
   note — and should update the contract test in the same commit.
 - New fields may be added to a JSON shape additively; the published schemas pin
   the adapter-consumed fields so a removal or rename is caught in CI.
+- **A new field is not a floor bump.** 0.43.0 added `change_set` to `migrate
+  preflight` — a command on the surface above — and the minimum stayed at
+  0.20.0, because the contract makes the field's absence meaningful (§ [Absence is
+  never safety](#absence-is-never-safety)). Raising the floor would delete the
+  fail-safe path rather than protect it. Record the release in the
+  [capability table](#minimum-version) and gate on the detected version instead.
+  Bump the floor only when an older Confiture would be *misread*, not merely
+  less capable.

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -323,6 +323,15 @@ Rewrites non-idempotent SQL files in place (or previews with `--dry-run`). Pytho
 
 Structured preflight report (#148): `{ok, summary, issues[]}`, where each `issues[]` element is the shared [issue object](./json-schemas/issue-object.schema.json) (`PFLIGHT_*` codes). Covers reversibility, transactionality, duplicate version prefixes, and checksum mismatches. No DB required. Errors → exit 7; warnings are non-fatal unless `--strict`. A preflight that *crashes* (config/DB error) emits the [error envelope](./json-schemas/error-envelope.schema.json) instead.
 
+> **New in 0.43.0 (#197).** The payload also carries `change_set` — per-change
+> risk tiers (`additive` / `reversible` / `lock_risky` / `destructive` /
+> `irreversible`). The **object wrapper is load-bearing**: `{"changes": []}`
+> means "classified, nothing to change", while an *absent* `change_set` means
+> "did not classify". A change confiture cannot tier honestly carries **no
+> `tier` key** rather than a guess, and is never dropped from the set. It is
+> declared but not required, so older payloads stay valid. See the
+> [fraisier adapter contract](./fraisier-adapter-contract.md#per-change-risk-tier-change_set).
+
 ### `confiture migrate preflight --against <url> --format json`
 
 [migrate-preflight-against.schema.json](./json-schemas/migrate-preflight-against.schema.json)
@@ -430,6 +439,11 @@ The `_common.schema.json` file holds shared `$defs`:
 The `_preflight_defs.schema.json` file holds preflight-specific
 sub-schemas:
 
+* `ChangeSet` / `SchemaChange` — the #197 risk-tier change set, referenced by
+  both `migrate-preflight.schema.json` and `migrate-preflight-against.schema.json`.
+  A cross-repo contract with fraisier-core#44; the five tier values and the
+  `contract_version` rule are pinned by `tests/contract/` against the shared
+  fixtures in `tests/fixtures/preflight-contract/`
 * `DependentAnalysis` — the optional dependent-objects analysis, referenced by
   both `migrate-preflight.schema.json` and `migrate-preflight-against.schema.json`
 * `StaticPreflight` — the legacy `PreflightResult.to_dict()` shape. **Unused

--- a/docs/reference/json-schemas/_preflight_defs.schema.json
+++ b/docs/reference/json-schemas/_preflight_defs.schema.json
@@ -4,6 +4,55 @@
   "title": "Confiture preflight $defs",
   "description": "Sub-schemas shared by migrate-preflight.schema.json and migrate-preflight-against.schema.json.",
   "$defs": {
+    "ChangeSet": {
+      "type": "object",
+      "description": "Per-change risk classification for the pending migration set (#197, contract version 1). The OBJECT WRAPPER IS LOAD-BEARING: `{\"changes\": []}` means \"confiture classified the set and there is nothing to change\" (safe), while an ABSENT `change_set` key means \"confiture did not classify\" — unknown, and unknown is not safe. A bare array cannot express that difference and the conflation resolves the dangerous way. The key is declared but NOT required, so payloads from confiture < 0.43.0 stay valid and correctly read as \"did not classify\".",
+      "required": ["contract_version", "changes"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_version": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The revision of this contract the payload is written to. Adding a field to a change entry does NOT bump it; removing or renaming a field, or changing what a tier means, does. A consumer reading a version newer than it understands must treat the whole change set as ABSENT and name both versions in its refusal — never a best-effort parse.",
+          "$comment": "STABILITY: cross-repo contract with fraisier-core#44. Confiture emits 1."
+        },
+        "changes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/SchemaChange" }
+        }
+      }
+    },
+    "SchemaChange": {
+      "type": "object",
+      "description": "One classified change. Order is migration order; the consumer picks the worst tier independently of it.",
+      "required": ["kind", "object"],
+      "additionalProperties": false,
+      "$comment": "additionalProperties is false because this schema describes what confiture EMITS. The contract still requires consumers to ignore keys they do not recognise, so a later additive field is a schema edit here, not a breaking change there.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Stable machine code, snake_case (add_column, drop_column, create_index, …). Rendered verbatim; never parsed for meaning, and never a substitute for `tier`."
+        },
+        "object": {
+          "type": "string",
+          "description": "Fully-qualified target: schema.table, schema.table.column, schema.table.index. Rendered to the operator, so it identifies the object without further lookup. The schema defaults to `public` when the DDL omits one — preflight has no connection with which to resolve search_path. For a statement whose target cannot be determined, this is the migration filename."
+        },
+        "migration": {
+          "type": ["string", "null"],
+          "description": "The migration VERSION PREFIX (\"20260804120100\"), not the filename — matching `issues[].migration`, so the two never disagree on format."
+        },
+        "tier": {
+          "type": "string",
+          "enum": ["additive", "reversible", "lock_risky", "destructive", "irreversible"],
+          "description": "What kind of risk the change carries. ABSENT means confiture could not classify it honestly (a non-SQL .py migration, an ALTER COLUMN TYPE whose direction needs the source and target types, a statement outside the taxonomy) — a consumer treats that as unclassified and denies, never as safe. Severity order for picking the worst of a set: additive < reversible < lock_risky < destructive < irreversible; that order is NOT how policy decisions are made.",
+          "$comment": "STABILITY: these five values are a cross-repo contract (#197 / fraisier-core#44). A sixth value is a contract_version conversation, not a silent addition — consumers parse an unrecognised string to unclassified, never to a nearest match."
+        },
+        "detail": {
+          "type": ["string", "null"],
+          "description": "One human-readable line for the plan render. Never parsed. Synthesised from the parsed statement rather than echoed from the source, so it can never carry a DSN or a credential."
+        }
+      }
+    },
     "StaticPreflight": {
       "type": "object",
       "description": "Static analysis output (PreflightResult.to_dict). Reports per-migration reversibility and transactionality.",

--- a/docs/reference/json-schemas/migrate-preflight-against.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight-against.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://confiture.fraiseql.dev/schemas/migrate-preflight-against.schema.json",
   "title": "confiture migrate preflight --against <url> --format json",
-  "description": "Structured preflight report (issue #151): the SAME {ok, summary, issues[]} envelope as `migrate preflight` without --against. Static findings (reversibility, transactionality, duplicate versions, checksums) and replica-forward-compat lints are joined by per-migration execution-replay results: each migration that fails to replay against the --against database appears as a `PFLIGHT_REPLAY_FAILED` issue (the database error is in `details.error`). Run-level metadata that is not a finding — `db_consumed` — rides in `summary`. A preflight that *crashed* (config/DB/connection error, e.g. an unreachable --against URL → CONFIG_006/exit 3) emits the #145 error envelope instead — branch on `issues` vs `error`.\n\nNote: `summary.migrations_checked` is the number of migrations *replayed* (the pending set), which may be smaller than the directory-wide set the static findings are drawn from.",
+  "description": "Structured preflight report (issue #151): the SAME {ok, summary, issues[]} envelope as `migrate preflight` without --against. Static findings (reversibility, transactionality, duplicate versions, checksums) and replica-forward-compat lints are joined by per-migration execution-replay results: each migration that fails to replay against the --against database appears as a `PFLIGHT_REPLAY_FAILED` issue (the database error is in `details.error`). Run-level metadata that is not a finding — `db_consumed` — rides in `summary`. A preflight that *crashed* (config/DB/connection error, e.g. an unreachable --against URL → CONFIG_006/exit 3) emits the #145 error envelope instead — branch on `issues` vs `error`.\n\nNote: `summary.migrations_checked` is the number of migrations *replayed* (the pending set), which may be smaller than the directory-wide set the static findings are drawn from. Since 0.43.0 the payload also carries `change_set` (#197): the per-change risk tiers for the pending set. It is declared but not required — an absent `change_set` is the honest signal that the producer did not classify, which a consumer treats as unclassified and denies.",
   "type": "object",
   "required": ["ok", "window_safe", "summary", "issues"],
   "properties": {
@@ -43,6 +43,9 @@
     "issues": {
       "type": "array",
       "items": { "$ref": "issue-object.schema.json#" }
+    },
+    "change_set": {
+      "$ref": "_preflight_defs.schema.json#/$defs/ChangeSet"
     },
     "dependent_analysis": {
       "$ref": "_preflight_defs.schema.json#/$defs/DependentAnalysis"

--- a/docs/reference/json-schemas/migrate-preflight.schema.json
+++ b/docs/reference/json-schemas/migrate-preflight.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://confiture.fraiseql.dev/schemas/migrate-preflight.schema.json",
   "title": "confiture migrate preflight --format json (no --against)",
-  "description": "Structured preflight report (issue #148/#154): {ok, window_safe, summary, issues[]}. Reports per-migration reversibility (.down.sql present), transactionality, duplicate version prefixes, checksum mismatches, and replica forward-compatibility as a uniform issues[] of the shared issue object. No database connection required. A preflight that *crashed* (config/DB error) emits the #145 error envelope instead — branch on `issues` vs `error`.",
+  "description": "Structured preflight report (issue #148/#154): {ok, window_safe, summary, issues[]}. Reports per-migration reversibility (.down.sql present), transactionality, duplicate version prefixes, checksum mismatches, and replica forward-compatibility as a uniform issues[] of the shared issue object. No database connection required. A preflight that *crashed* (config/DB error) emits the #145 error envelope instead — branch on `issues` vs `error`. Since 0.43.0 the payload also carries `change_set` (#197): the per-change risk tiers for the pending set. It is declared but not required — an absent `change_set` is the honest signal that the producer did not classify, which a consumer treats as unclassified and denies.",
   "type": "object",
   "required": ["ok", "window_safe", "summary", "issues"],
   "properties": {
@@ -29,6 +29,9 @@
     "issues": {
       "type": "array",
       "items": { "$ref": "issue-object.schema.json#" }
+    },
+    "change_set": {
+      "$ref": "_preflight_defs.schema.json#/$defs/ChangeSet"
     },
     "dependent_analysis": {
       "$ref": "_preflight_defs.schema.json#/$defs/DependentAnalysis"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.42.0"
+version = "0.43.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -1793,6 +1793,44 @@ def _resolve_preflight_pending(
     return all_files
 
 
+_CHANGE_SET_TIER_COLOR = {
+    "additive": "green",
+    "reversible": "green",
+    "lock_risky": "yellow",
+    "destructive": "red",
+    "irreversible": "red",
+}
+
+
+def _display_change_set(change_set: Any, cons: Any) -> None:
+    """Render the #197 risk tiers: the worst tier, then the changes that are not additive.
+
+    Text mode is for a human deciding whether to look closer, so it leads with
+    the verdict. The full per-change set is the JSON payload's job.
+    """
+    if not change_set.changes:
+        return
+
+    worst = change_set.worst_tier
+    if worst is not None:
+        color = _CHANGE_SET_TIER_COLOR.get(worst.value, "yellow")
+        cons.print(
+            f"Risk: [{color}]{worst.value}[/{color}] "
+            f"({len(change_set.changes)} change(s) classified)"
+        )
+    if change_set.has_unclassified:
+        unclassified = sum(1 for c in change_set.changes if c.tier is None)
+        cons.print(
+            f"  [yellow]⚠️  {unclassified} change(s) could not be classified — "
+            "a consumer gating on risk will refuse them[/yellow]"
+        )
+    for change in change_set.changes:
+        if change.tier is None or change.tier.severity == 0:
+            continue  # additive changes are the floor; they do not need a line
+        color = _CHANGE_SET_TIER_COLOR.get(change.tier.value, "yellow")
+        cons.print(f"  [{color}]{change.tier.value}[/{color}] {change.kind} {change.object}")
+
+
 def _display_against_result(
     result: Any,
     format_type: str,
@@ -2093,6 +2131,7 @@ def migrate_preflight(
     """
     from rich.table import Table
 
+    from confiture.core.change_set import build_change_set
     from confiture.core.linting.libraries.replica import replica_preflight_issues
     from confiture.core.preflight import (
         is_window_safe,
@@ -2134,6 +2173,7 @@ def migrate_preflight(
             "migrations_checked": len(result.migrations),
         }
         exit_code = preflight_exit_code(summary, strict=strict)
+        change_set = build_change_set(migrations_dir)
 
         if format_type == "json":
             payload = {
@@ -2144,6 +2184,10 @@ def migrate_preflight(
                 "window_safe": is_window_safe(all_issues),
                 "summary": summary,
                 "issues": [i.to_dict() for i in all_issues],
+                # #197: per-change risk tiers. The object wrapper is load-bearing —
+                # an empty `changes` means "classified, nothing to change", while an
+                # absent `change_set` means "did not classify" and denies.
+                "change_set": change_set.to_dict(),
             }
             if dependent_skip_payload is not None:
                 payload["dependent_analysis"] = dependent_skip_payload
@@ -2171,6 +2215,7 @@ def migrate_preflight(
             f"\nSummary: {summary['migrations_checked']} migration(s) checked, "
             f"{summary['errors']} error(s), {summary['warnings']} warning(s)"
         )
+        _display_change_set(change_set, console)
 
         issues = all_issues
         if not issues:
@@ -2319,6 +2364,8 @@ def migrate_preflight(
     }
     exit_code = preflight_exit_code(summary, strict=strict)
 
+    change_set = build_change_set(migrations_dir)
+
     if format_type == "json":
         payload: dict[str, Any] = {
             "ok": exit_code == 0,
@@ -2326,12 +2373,16 @@ def migrate_preflight(
             "window_safe": is_window_safe(all_issues),
             "summary": summary,
             "issues": [i.to_dict() for i in all_issues],
+            # #197: same change set as the no-`--against` path — it is static
+            # analysis, so replaying against a database does not change it.
+            "change_set": change_set.to_dict(),
         }
         if dependent_report is not None:
             payload["dependent_analysis"] = dependent_report.to_dict()
         _output_json(payload, output_file, console)
     else:
         _display_against_result(against_result, format_type, console)
+        _display_change_set(change_set, console)
         if dependent_report is not None:
             _display_dependent_analysis(dependent_report, console)
 

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -1811,15 +1811,19 @@ def _display_change_set(change_set: Any, cons: Any) -> None:
     if not change_set.changes:
         return
 
+    total = len(change_set.changes)
+    unclassified = sum(1 for c in change_set.changes if c.tier is None)
+
     worst = change_set.worst_tier
     if worst is not None:
         color = _CHANGE_SET_TIER_COLOR.get(worst.value, "yellow")
+        # "classified" counts only what carries a tier — saying it of the whole
+        # set would be the confident-wrong phrasing this feature exists to avoid.
         cons.print(
             f"Risk: [{color}]{worst.value}[/{color}] "
-            f"({len(change_set.changes)} change(s) classified)"
+            f"(worst of {total - unclassified} classified change(s) of {total})"
         )
-    if change_set.has_unclassified:
-        unclassified = sum(1 for c in change_set.changes if c.tier is None)
+    if unclassified:
         cons.print(
             f"  [yellow]⚠️  {unclassified} change(s) could not be classified — "
             "a consumer gating on risk will refuse them[/yellow]"

--- a/python/confiture/core/_pglast_enums.py
+++ b/python/confiture/core/_pglast_enums.py
@@ -44,6 +44,9 @@ REQUIRED_MEMBERS: Final[dict[str, tuple[str, ...]]] = {
         "AT_AddConstraint",
         "AT_DropConstraint",
         "AT_ChangeOwner",
+        "AT_ColumnDefault",
+        "AT_SetNotNull",
+        "AT_DropNotNull",
     ),
     "ConstrType": (
         "CONSTR_NOTNULL",
@@ -64,6 +67,10 @@ REQUIRED_MEMBERS: Final[dict[str, tuple[str, ...]]] = {
         "OBJECT_SCHEMA",
         "OBJECT_SEQUENCE",
         "OBJECT_COLUMN",
+        "OBJECT_TRIGGER",
+        "OBJECT_POLICY",
+        "OBJECT_EXTENSION",
+        "OBJECT_DOMAIN",
     ),
 }
 

--- a/python/confiture/core/change_set.py
+++ b/python/confiture/core/change_set.py
@@ -1,0 +1,1387 @@
+"""The preflight change set: what a migration set changes, and how risky it is (#197).
+
+`migrate preflight --format json` carries a `change_set` object beside the
+`window_safe` boolean. Each entry names one change and — when confiture can say
+so honestly — its :class:`~confiture.core.risk_tier.RiskTier`. The wire shape,
+the tier boundaries and the version rule are the ratified cross-repo contract
+(fraisier-core#44, ``docs/proposals/migration-risk-contract.md``).
+
+Three rules shape the code:
+
+1. **Never drop a statement.** A statement this module cannot classify still
+   produces an entry, with no ``tier``. Dropping it would shrink the set, and a
+   shorter list of fully-classified changes reads as a *cleaner* plan than the
+   truth — the one failure direction the contract exists to prevent.
+2. **Never guess a tier.** ``ALTER COLUMN … TYPE`` is reversible when widening
+   and irreversible when narrowing; preflight runs without a database and cannot
+   tell, so it emits no tier rather than a confident wrong answer.
+3. **This is not the replica classifier.** ``core/replica/classifier.py`` feeds
+   the pinned ``window_safe`` verdict (#154) and reports only the operations in
+   its safety matrix — an operation outside that matrix degrades to ``depends``
+   there, which flips ``window_safe`` to false. Widening *it* to cover the
+   change-set vocabulary would move that pinned field, so this module walks the
+   statements itself. The cost is a second parse of files preflight has already
+   read; the alternative was a false verdict on a cross-repo contract.
+
+Both backends of the house two-tier strategy are implemented — pglast primary,
+regex fallback — and are parity-tested statement by statement.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final
+
+from confiture.core._pglast_enums import enums_are_usable
+from confiture.core._pglast_enums import member as _pg_member
+from confiture.core.idempotency.ast_detector import is_pglast_available
+from confiture.core.risk_tier import RiskTier, worst_tier
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "ChangeEntry",
+    "ChangeSet",
+    "build_change_set",
+    "classify_statements",
+]
+
+# Bumped only by a removal, a rename, or a change in what a tier *means*.
+# Adding a field to an entry does not bump it.
+CONTRACT_VERSION: Final = 1
+
+_DEFAULT_SCHEMA: Final = "public"
+
+_HAS_PGLAST = is_pglast_available()
+
+
+# --------------------------------------------------------------------------- #
+# Wire types
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ChangeEntry:
+    """One change, as it crosses the adapter seam."""
+
+    kind: str
+    """Stable machine code, ``snake_case``. Rendered verbatim; never parsed for meaning."""
+
+    object: str
+    """Fully-qualified target — ``schema.table``, ``schema.table.column``, ``schema.table.index``."""
+
+    migration: str | None = None
+    """The migration **version prefix**, matching ``issues[].migration``."""
+
+    tier: RiskTier | None = None
+    """``None`` ⇒ unclassified ⇒ the consumer denies. Never inferred from ``kind``."""
+
+    detail: str | None = None
+    """One human-readable line for the plan render. Never parsed, never a credential."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Wire form. Absent optional fields are omitted, not emitted as ``null``."""
+        payload: dict[str, Any] = {"kind": self.kind, "object": self.object}
+        if self.migration is not None:
+            payload["migration"] = self.migration
+        if self.tier is not None:
+            payload["tier"] = self.tier.value
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+@dataclass(frozen=True)
+class ChangeSet:
+    """The classified change set for a migration tree.
+
+    An **empty** ``changes`` means "looked, nothing to change". A change set that
+    is *absent* from the payload means "did not classify". The object wrapper is
+    what keeps those two apart, and that distinction is the point of it.
+    """
+
+    changes: tuple[ChangeEntry, ...] = ()
+    contract_version: int = CONTRACT_VERSION
+
+    @property
+    def worst_tier(self) -> RiskTier | None:
+        """Most severe tier over the *classifiable* entries (``None`` if none are)."""
+        return worst_tier(entry.tier for entry in self.changes)
+
+    @property
+    def has_unclassified(self) -> bool:
+        """True when any entry carries no tier."""
+        return any(entry.tier is None for entry in self.changes)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "changes": [entry.to_dict() for entry in self.changes],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Taxonomy
+# --------------------------------------------------------------------------- #
+
+# kind → tier, for the kinds whose tier does not depend on the statement's own
+# attributes. A kind absent from this table is unclassified. Shared by both
+# backends, so they cannot disagree about a boundary.
+_TIER_BY_KIND: Final[dict[str, RiskTier | None]] = {
+    # additive — adds a new object; no existing reader or writer can break
+    "create_table": RiskTier.ADDITIVE,
+    "create_table_as": RiskTier.ADDITIVE,
+    "create_view": RiskTier.ADDITIVE,
+    "create_materialized_view": RiskTier.ADDITIVE,
+    "create_schema": RiskTier.ADDITIVE,
+    "create_sequence": RiskTier.ADDITIVE,
+    "create_type": RiskTier.ADDITIVE,
+    "create_domain": RiskTier.ADDITIVE,
+    "create_extension": RiskTier.ADDITIVE,
+    "create_function": RiskTier.ADDITIVE,
+    "create_procedure": RiskTier.ADDITIVE,
+    "create_trigger": RiskTier.ADDITIVE,
+    "create_policy": RiskTier.ADDITIVE,
+    "create_rule": RiskTier.ADDITIVE,
+    "insert": RiskTier.ADDITIVE,
+    # `ALTER TYPE … ADD VALUE` cannot be taken back, but it destroys nothing and
+    # breaks no reader — irreversibility in this taxonomy is about data.
+    "alter_type": RiskTier.ADDITIVE,
+    # reversible — changes existing state, with a down path that restores it
+    "rename_column": RiskTier.REVERSIBLE,
+    "rename_object": RiskTier.REVERSIBLE,
+    "set_column_default": RiskTier.REVERSIBLE,
+    "drop_column_default": RiskTier.REVERSIBLE,
+    "drop_not_null": RiskTier.REVERSIBLE,
+    "replace_view": RiskTier.REVERSIBLE,
+    "replace_function": RiskTier.REVERSIBLE,
+    "replace_procedure": RiskTier.REVERSIBLE,
+    "change_owner": RiskTier.REVERSIBLE,
+    "alter_sequence": RiskTier.REVERSIBLE,
+    "alter_default_privileges": RiskTier.REVERSIBLE,
+    "grant": RiskTier.REVERSIBLE,
+    "revoke": RiskTier.REVERSIBLE,
+    "comment": RiskTier.REVERSIBLE,
+    # lock_risky — semantically safe, but takes a lock that can stall a hot table
+    "set_not_null": RiskTier.LOCK_RISKY,
+    "cluster": RiskTier.LOCK_RISKY,
+    "refresh_materialized_view": RiskTier.LOCK_RISKY,
+    "reindex": RiskTier.LOCK_RISKY,
+    # destructive — destroys data or an object, restorable from backup
+    "drop_index": RiskTier.DESTRUCTIVE,
+    "drop_view": RiskTier.DESTRUCTIVE,
+    "drop_materialized_view": RiskTier.DESTRUCTIVE,
+    "drop_function": RiskTier.DESTRUCTIVE,
+    "drop_procedure": RiskTier.DESTRUCTIVE,
+    "drop_type": RiskTier.DESTRUCTIVE,
+    "drop_domain": RiskTier.DESTRUCTIVE,
+    "drop_trigger": RiskTier.DESTRUCTIVE,
+    "drop_policy": RiskTier.DESTRUCTIVE,
+    "drop_rule": RiskTier.DESTRUCTIVE,
+    "drop_extension": RiskTier.DESTRUCTIVE,
+    "drop_constraint": RiskTier.DESTRUCTIVE,
+    "truncate": RiskTier.DESTRUCTIVE,
+    "delete": RiskTier.DESTRUCTIVE,
+    "update": RiskTier.DESTRUCTIVE,
+    # irreversible — destroys data with no down path that can restore it
+    "drop_column": RiskTier.IRREVERSIBLE,
+    "drop_table": RiskTier.IRREVERSIBLE,
+    "drop_schema": RiskTier.IRREVERSIBLE,
+    "drop_sequence": RiskTier.IRREVERSIBLE,
+}
+
+# Detail lines that read better than the generic "KIND WITH UNDERSCORES" form.
+_DETAIL_BY_KIND: Final[dict[str, str]] = {
+    "replace_view": "CREATE OR REPLACE VIEW",
+    "replace_function": "CREATE OR REPLACE FUNCTION",
+    "replace_procedure": "CREATE OR REPLACE PROCEDURE",
+    "create_table_as": "CREATE TABLE AS",
+}
+
+
+def _detail_for(kind: str) -> str:
+    """The default one-line detail for ``kind`` — shared by both backends."""
+    return _DETAIL_BY_KIND.get(kind, kind.replace("_", " ").upper())
+
+
+_ALTER_COLUMN_TYPE_DETAIL: Final = (
+    "reversible when widening and irreversible when narrowing; preflight cannot "
+    "tell without the source and target types"
+)
+
+
+def tier_for_add_column(*, nullable: bool, has_default: bool) -> RiskTier:
+    """`ADD COLUMN`: additive when nullable, otherwise a lock risk.
+
+    ``NOT NULL DEFAULT`` rewrites the table on PostgreSQL below 11 and takes an
+    ACCESS EXCLUSIVE lock on every version; ``NOT NULL`` without a default aborts
+    outright on a non-empty table. Neither destroys data, and preflight has no
+    connection with which to check the server version, so both take the more
+    severe of the two readings available to it.
+    """
+    del has_default  # both NOT NULL forms are lock-risky; named for the call sites
+    return RiskTier.ADDITIVE if nullable else RiskTier.LOCK_RISKY
+
+
+def tier_for_create_index(*, concurrently: bool) -> RiskTier:
+    """`CREATE INDEX CONCURRENTLY` is additive; a plain one blocks writes."""
+    return RiskTier.ADDITIVE if concurrently else RiskTier.LOCK_RISKY
+
+
+def tier_for_add_constraint(*, not_valid: bool) -> RiskTier:
+    """`NOT VALID` defers the scan; immediate validation locks and can reject rows."""
+    return RiskTier.REVERSIBLE if not_valid else RiskTier.LOCK_RISKY
+
+
+# --------------------------------------------------------------------------- #
+# Classification context
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _Context:
+    """What every entry produced from one file gets stamped with."""
+
+    migration: str | None = None
+    source: str | None = None
+    default_schema: str = _DEFAULT_SCHEMA
+
+    def entry(
+        self,
+        kind: str,
+        obj: str | None = None,
+        *,
+        detail: str | None = None,
+        tier: RiskTier | None = None,
+    ) -> ChangeEntry:
+        """Build an entry, defaulting the tier from :data:`_TIER_BY_KIND`."""
+        return ChangeEntry(
+            kind=kind,
+            object=obj or self.source or "unknown",
+            migration=self.migration,
+            tier=tier if tier is not None else _TIER_BY_KIND.get(kind),
+            detail=detail,
+        )
+
+    def unclassified(self, kind: str, obj: str | None, detail: str) -> ChangeEntry:
+        """An entry confiture will not tier. Explicitly tier-less, never dropped."""
+        return ChangeEntry(
+            kind=kind,
+            object=obj or self.source or "unknown",
+            migration=self.migration,
+            tier=None,
+            detail=detail,
+        )
+
+    def qualified(self, schema: str | None, name: str | None, child: str | None = None) -> str:
+        """`schema.name[.child]`, defaulting the schema when the DDL omits one."""
+        parts = [_ident(schema) or self.default_schema, _ident(name)]
+        if child:
+            parts.append(_ident(child))
+        return ".".join(part for part in parts if part)
+
+    def dotted(self, raw: str | None, child: str | None = None) -> str | None:
+        """Qualify an already-dotted identifier such as ``app.tb_user``.
+
+        With a ``child``, ``raw`` is the relation and ``child`` the leaf; without
+        one, ``raw`` may itself already carry the leaf (``app.tb_user.nickname``).
+        """
+        if not raw:
+            return None
+        parts = _split_dotted(raw)
+        if child is None:
+            return self.from_parts(parts)
+        if len(parts) >= 2:
+            return self.qualified(parts[-2], parts[-1], child)
+        return self.qualified(None, parts[0], child)
+
+    def bare(self, raw: str | None) -> str | None:
+        """A name that is not schema-scoped (a schema, an extension, a role)."""
+        if not raw:
+            return None
+        return _ident(_split_dotted(raw)[-1])
+
+    def from_parts(self, parts: list[str]) -> str | None:
+        """Qualify already-split identifier parts.
+
+        Three parts is ``schema.table.child`` — a column, or a trigger/policy
+        whose name is scoped to its table. Taking only the last two would report
+        the *table* as the schema.
+        """
+        if not parts:
+            return None
+        if len(parts) >= 3:
+            return self.qualified(parts[-3], parts[-2], parts[-1])
+        if len(parts) == 2:
+            return self.qualified(parts[0], parts[1])
+        return self.qualified(None, parts[0])
+
+
+def _ident(raw: str | None) -> str | None:
+    """Fold an identifier the way PostgreSQL folds an unquoted one."""
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if text.startswith('"') and text.endswith('"') and len(text) > 1:
+        return text[1:-1]
+    return text.lower()
+
+
+def _split_dotted(raw: str) -> list[str]:
+    """Split ``a.b`` on dots, keeping quoted segments intact."""
+    parts: list[str] = []
+    buf: list[str] = []
+    in_quotes = False
+    for char in raw.strip():
+        if char == '"':
+            in_quotes = not in_quotes
+            buf.append(char)
+        elif char == "." and not in_quotes:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(char)
+    parts.append("".join(buf))
+    return [part for part in parts if part]
+
+
+# --------------------------------------------------------------------------- #
+# Entry points
+# --------------------------------------------------------------------------- #
+
+
+def build_change_set(
+    migrations_dir: Path,
+    *,
+    versions: list[str] | None = None,
+    default_schema: str = _DEFAULT_SCHEMA,
+) -> ChangeSet:
+    """Classify every change in ``migrations_dir``.
+
+    Mirrors ``run_preflight``'s discovery — ``*.up.sql`` then ``*.py`` (skipping
+    ``__init__.py`` and ``_``-prefixed helpers) — so the change set covers exactly
+    the migrations preflight reports on. A missing directory classifies to an
+    empty set; preflight already reports that condition on its own.
+    """
+    from confiture.core._migrator.discovery import _version_from_migration_filename
+
+    if not migrations_dir.exists():
+        return ChangeSet()
+
+    entries: list[ChangeEntry] = []
+
+    for up_file in sorted(migrations_dir.glob("*.up.sql"), key=lambda f: f.name):
+        version = _version_from_migration_filename(up_file.name)
+        if versions is not None and version not in versions:
+            continue
+        entries.extend(
+            classify_statements(
+                _read_sql(up_file),
+                migration=version,
+                source=up_file.name,
+                default_schema=default_schema,
+            )
+        )
+
+    for py_file in sorted(_python_migrations(migrations_dir), key=lambda f: f.name):
+        version = _version_from_migration_filename(py_file.name)
+        if versions is not None and version not in versions:
+            continue
+        entries.append(
+            ChangeEntry(
+                kind="python_migration",
+                object=py_file.name,
+                migration=version,
+                tier=None,
+                detail=(
+                    "non-SQL migration: confiture cannot read its DDL, so its "
+                    "changes are unclassified — review by hand"
+                ),
+            )
+        )
+
+    return ChangeSet(changes=tuple(entries))
+
+
+def classify_statements(
+    sql: str,
+    *,
+    migration: str | None = None,
+    source: str | None = None,
+    default_schema: str = _DEFAULT_SCHEMA,
+) -> list[ChangeEntry]:
+    """Classify every statement in ``sql``.
+
+    ``source`` names the file and is the ``object`` for statements whose target
+    cannot be determined. SQL the parser rejects yields an unclassified entry
+    rather than an empty list, so a broken migration denies instead of reading as
+    "nothing changes".
+    """
+    ctx = _Context(migration=migration, source=source, default_schema=default_schema)
+    if _use_ast():
+        try:
+            return _ast_entries(sql, ctx)
+        except Exception:  # noqa: BLE001 — any parse hiccup falls back to regex
+            pass
+    return _regex_entries(sql, ctx)
+
+
+def _use_ast() -> bool:
+    # A half-resolvable enum surface would mis-map operations silently — the #192
+    # failure mode. Degrade to the regex backend instead.
+    return _HAS_PGLAST and enums_are_usable()
+
+
+def _python_migrations(migrations_dir: Path) -> Iterator[Path]:
+    """`.py` migrations, filtered exactly as ``run_preflight`` filters them."""
+    return (
+        f
+        for f in migrations_dir.glob("*.py")
+        if f.name != "__init__.py" and not f.name.startswith("_")
+    )
+
+
+def _read_sql(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _command_prefix(statement: str, *, words: int = 5) -> str:
+    """The leading keywords of a statement, with every literal stripped.
+
+    ``detail`` is rendered to an operator and must never carry a credential, and
+    an unclassified statement is exactly the kind that might hold one
+    (``CREATE USER … PASSWORD 'x'``). Only bare word tokens survive.
+    """
+    tokens: list[str] = []
+    for token in statement.split():
+        if not re.fullmatch(r"[A-Za-z_][\w$.]*", token):
+            break
+        tokens.append(token)
+        if len(tokens) >= words:
+            break
+    return " ".join(tokens) or "statement"
+
+
+# --------------------------------------------------------------------------- #
+# pglast backend
+# --------------------------------------------------------------------------- #
+
+# Resolved BY NAME, never by literal ordinal (#192).
+_AT_ADD_COLUMN = _pg_member("AlterTableType", "AT_AddColumn")
+_AT_DROP_COLUMN = _pg_member("AlterTableType", "AT_DropColumn")
+_AT_ALTER_COLUMN_TYPE = _pg_member("AlterTableType", "AT_AlterColumnType")
+_AT_ADD_CONSTRAINT = _pg_member("AlterTableType", "AT_AddConstraint")
+_AT_DROP_CONSTRAINT = _pg_member("AlterTableType", "AT_DropConstraint")
+_AT_CHANGE_OWNER = _pg_member("AlterTableType", "AT_ChangeOwner")
+_AT_COLUMN_DEFAULT = _pg_member("AlterTableType", "AT_ColumnDefault")
+_AT_SET_NOT_NULL = _pg_member("AlterTableType", "AT_SetNotNull")
+_AT_DROP_NOT_NULL = _pg_member("AlterTableType", "AT_DropNotNull")
+
+_OBJECT_COLUMN = _pg_member("ObjectType", "OBJECT_COLUMN")
+_OBJECT_MATVIEW = _pg_member("ObjectType", "OBJECT_MATVIEW")
+
+# DropStmt.removeType → kind. Names resolved by member, never by ordinal.
+_DROP_KIND: Final[dict[int, str]] = {
+    _pg_member("ObjectType", "OBJECT_TABLE"): "drop_table",
+    _pg_member("ObjectType", "OBJECT_INDEX"): "drop_index",
+    _pg_member("ObjectType", "OBJECT_VIEW"): "drop_view",
+    _OBJECT_MATVIEW: "drop_materialized_view",
+    _pg_member("ObjectType", "OBJECT_SEQUENCE"): "drop_sequence",
+    _pg_member("ObjectType", "OBJECT_SCHEMA"): "drop_schema",
+    _pg_member("ObjectType", "OBJECT_TYPE"): "drop_type",
+    _pg_member("ObjectType", "OBJECT_DOMAIN"): "drop_domain",
+    _pg_member("ObjectType", "OBJECT_FUNCTION"): "drop_function",
+    _pg_member("ObjectType", "OBJECT_PROCEDURE"): "drop_procedure",
+    _pg_member("ObjectType", "OBJECT_TRIGGER"): "drop_trigger",
+    _pg_member("ObjectType", "OBJECT_POLICY"): "drop_policy",
+    _pg_member("ObjectType", "OBJECT_EXTENSION"): "drop_extension",
+}
+
+# Objects that are not schema-scoped: their name *is* fully qualified.
+_STANDALONE_DROP_KINDS: Final = frozenset({"drop_schema", "drop_extension"})
+
+# Statement types that change neither schema nor data. Emitting entries for
+# these would make every migration with a `BEGIN;` deny.
+_AST_SKIP: Final = frozenset(
+    {
+        "TransactionStmt",
+        "VariableSetStmt",
+        "VariableShowStmt",
+        "CheckPointStmt",
+        "DiscardStmt",
+        "LockStmt",
+        "VacuumStmt",
+        "ConstraintsSetStmt",
+        "NotifyStmt",
+        "ListenStmt",
+        "UnlistenStmt",
+    }
+)
+
+
+def _ast_entries(sql: str, ctx: _Context) -> list[ChangeEntry]:
+    import pglast  # noqa: PLC0415 — optional [ast] extra
+
+    entries: list[ChangeEntry] = []
+    for raw in pglast.parse_sql(sql):
+        entries.extend(_ast_statement(raw, sql, ctx))
+    return entries
+
+
+def _ast_statement(raw: object, sql: str, ctx: _Context) -> list[ChangeEntry]:
+    node = getattr(raw, "stmt", None)
+    name = type(node).__name__
+    if name in _AST_SKIP:
+        return []
+    handler = _AST_HANDLERS.get(name)
+    if handler is None:
+        return [
+            ctx.unclassified(
+                "unclassified",
+                None,
+                f"{_command_prefix(_ast_source(raw, sql))} — confiture does not "
+                "classify this statement",
+            )
+        ]
+    return handler(node, ctx)
+
+
+def _ast_source(raw: object, sql: str) -> str:
+    """The original text of one statement, for a keyword-only detail line."""
+    start = getattr(raw, "stmt_location", 0) or 0
+    length = getattr(raw, "stmt_len", 0) or 0
+    return sql[start : start + length] if length else sql[start:]
+
+
+def _enum_int(value: object) -> int | None:
+    if value is None:
+        return None
+    inner = getattr(value, "value", value)
+    try:
+        return int(inner)
+    except (TypeError, ValueError):
+        return None
+
+
+def _rel(relation: object) -> tuple[str | None, str | None]:
+    if relation is None:
+        return (None, None)
+    return (getattr(relation, "schemaname", None), getattr(relation, "relname", None))
+
+
+def _ast_alter_table(node: object, ctx: _Context) -> list[ChangeEntry]:
+    # `core/replica/classifier.py` owns the column-attribute helpers; reusing
+    # them keeps the two surfaces agreeing on what "nullable" means.
+    from confiture.core.replica.classifier import _column_has_default, _column_is_not_null
+
+    schema, table = _rel(getattr(node, "relation", None))
+    target = ctx.qualified(schema, table)
+    entries: list[ChangeEntry] = []
+
+    for cmd in getattr(node, "cmds", None) or ():
+        subtype = _enum_int(cmd.subtype)
+        name = getattr(cmd, "name", None)
+        if subtype == _AT_ADD_COLUMN:
+            coldef = cmd.def_
+            column = getattr(coldef, "colname", None)
+            nullable = not _column_is_not_null(coldef)
+            has_default = _column_has_default(coldef)
+            entries.append(
+                ctx.entry(
+                    "add_column",
+                    ctx.qualified(schema, table, column),
+                    tier=tier_for_add_column(nullable=nullable, has_default=has_default),
+                    detail=_add_column_detail(column, nullable=nullable, has_default=has_default),
+                )
+            )
+        elif subtype == _AT_DROP_COLUMN:
+            entries.append(
+                ctx.entry(
+                    "drop_column",
+                    ctx.qualified(schema, table, name),
+                    detail=f"DROP COLUMN {_ident(name)}",
+                )
+            )
+        elif subtype == _AT_ALTER_COLUMN_TYPE:
+            entries.append(
+                ctx.unclassified(
+                    "alter_column_type",
+                    ctx.qualified(schema, table, name),
+                    f"ALTER COLUMN {_ident(name)} TYPE — {_ALTER_COLUMN_TYPE_DETAIL}",
+                )
+            )
+        elif subtype == _AT_ADD_CONSTRAINT:
+            constraint = cmd.def_
+            not_valid = bool(getattr(constraint, "skip_validation", False))
+            conname = getattr(constraint, "conname", None)
+            entries.append(
+                ctx.entry(
+                    "add_constraint",
+                    ctx.qualified(schema, table, conname),
+                    tier=tier_for_add_constraint(not_valid=not_valid),
+                    detail="ADD CONSTRAINT" + (" NOT VALID" if not_valid else ""),
+                )
+            )
+        elif subtype == _AT_DROP_CONSTRAINT:
+            entries.append(
+                ctx.entry(
+                    "drop_constraint",
+                    ctx.qualified(schema, table, name),
+                    detail=f"DROP CONSTRAINT {_ident(name)}",
+                )
+            )
+        elif subtype == _AT_COLUMN_DEFAULT:
+            setting = cmd.def_ is not None
+            entries.append(
+                ctx.entry(
+                    "set_column_default" if setting else "drop_column_default",
+                    ctx.qualified(schema, table, name),
+                    detail=f"ALTER COLUMN {_ident(name)} "
+                    + ("SET DEFAULT" if setting else "DROP DEFAULT"),
+                )
+            )
+        elif subtype == _AT_SET_NOT_NULL:
+            entries.append(
+                ctx.entry(
+                    "set_not_null",
+                    ctx.qualified(schema, table, name),
+                    detail=f"ALTER COLUMN {_ident(name)} SET NOT NULL — scans the table",
+                )
+            )
+        elif subtype == _AT_DROP_NOT_NULL:
+            entries.append(
+                ctx.entry(
+                    "drop_not_null",
+                    ctx.qualified(schema, table, name),
+                    detail=f"ALTER COLUMN {_ident(name)} DROP NOT NULL",
+                )
+            )
+        elif subtype == _AT_CHANGE_OWNER:
+            entries.append(ctx.entry("change_owner", target, detail="OWNER TO"))
+        else:
+            entries.append(
+                ctx.unclassified(
+                    "alter_table",
+                    target,
+                    "ALTER TABLE subcommand confiture does not classify",
+                )
+            )
+    return entries
+
+
+def _add_column_detail(column: str | None, *, nullable: bool, has_default: bool) -> str:
+    detail = f"ADD COLUMN {_ident(column)}"
+    if nullable:
+        return detail + " NULL"
+    detail += " NOT NULL"
+    if has_default:
+        return detail + " DEFAULT — takes an ACCESS EXCLUSIVE lock, rewrites below PG 11"
+    return detail + " without a default — fails if the table has rows"
+
+
+def _ast_rename(node: object, ctx: _Context) -> list[ChangeEntry]:
+    schema, table = _rel(getattr(node, "relation", None))
+    old = getattr(node, "subname", None)
+    new = getattr(node, "newname", None)
+    if _enum_int(getattr(node, "renameType", None)) == _OBJECT_COLUMN:
+        return [
+            ctx.entry(
+                "rename_column",
+                ctx.qualified(schema, table, old),
+                detail=f"RENAME COLUMN {_ident(old)} TO {_ident(new)} — "
+                "readers on the old name break until they are redeployed",
+            )
+        ]
+    return [
+        ctx.entry(
+            "rename_object",
+            ctx.qualified(schema, table) if table else ctx.bare(new),
+            detail=f"RENAME TO {_ident(new)}",
+        )
+    ]
+
+
+def _ast_index(node: object, ctx: _Context) -> list[ChangeEntry]:
+    schema, table = _rel(getattr(node, "relation", None))
+    idxname = getattr(node, "idxname", None)
+    concurrently = bool(getattr(node, "concurrent", False))
+    return [
+        ctx.entry(
+            "create_index",
+            ctx.qualified(schema, table, idxname),
+            tier=tier_for_create_index(concurrently=concurrently),
+            detail="CREATE INDEX" + (" CONCURRENTLY" if concurrently else " — blocks writes"),
+        )
+    ]
+
+
+def _ast_create_table(node: object, ctx: _Context) -> list[ChangeEntry]:
+    schema, table = _rel(getattr(node, "relation", None))
+    return [ctx.entry("create_table", ctx.qualified(schema, table), detail="CREATE TABLE")]
+
+
+def _ast_create_table_as(node: object, ctx: _Context) -> list[ChangeEntry]:
+    into = getattr(node, "into", None)
+    schema, name = _rel(getattr(into, "rel", None))
+    is_matview = _enum_int(getattr(node, "objtype", None)) == _OBJECT_MATVIEW
+    kind = "create_materialized_view" if is_matview else "create_table_as"
+    return [ctx.entry(kind, ctx.qualified(schema, name), detail=_detail_for(kind))]
+
+
+def _object_names(obj: object) -> list[str]:
+    """Flatten one ``DropStmt.objects`` element into its identifier parts."""
+    inner = getattr(obj, "objname", obj)  # ObjectWithArgs → its name
+    sval = getattr(inner, "sval", None)
+    if sval is not None:
+        return [str(sval)]
+    if isinstance(inner, (list, tuple)):
+        return [str(getattr(part, "sval", part)) for part in inner]
+    return [str(inner)]
+
+
+def _ast_drop(node: object, ctx: _Context) -> list[ChangeEntry]:
+    remove_type = _enum_int(getattr(node, "removeType", None))
+    kind = _DROP_KIND.get(remove_type if remove_type is not None else -1)
+    entries: list[ChangeEntry] = []
+    for obj in getattr(node, "objects", None) or ():
+        parts = _object_names(obj)
+        if kind is None:
+            entries.append(
+                ctx.unclassified(
+                    "drop_object",
+                    ctx.dotted(".".join(parts)),
+                    "DROP of an object type confiture does not classify",
+                )
+            )
+            continue
+        target = ctx.bare(parts[-1]) if kind in _STANDALONE_DROP_KINDS else ctx.from_parts(parts)
+        entries.append(ctx.entry(kind, target, detail=_detail_for(kind)))
+    return entries
+
+
+def _ast_truncate(node: object, ctx: _Context) -> list[ChangeEntry]:
+    return [
+        ctx.entry("truncate", ctx.qualified(*_rel(relation)), detail="TRUNCATE")
+        for relation in getattr(node, "relations", None) or ()
+    ]
+
+
+def _relation_stmt(kind: str, detail: str):
+    def handler(node: object, ctx: _Context) -> list[ChangeEntry]:
+        schema, name = _rel(getattr(node, "relation", None))
+        return [ctx.entry(kind, ctx.qualified(schema, name), detail=detail)]
+
+    return handler
+
+
+def _ast_view(node: object, ctx: _Context) -> list[ChangeEntry]:
+    schema, name = _rel(getattr(node, "view", None))
+    replace = bool(getattr(node, "replace", False))
+    kind = "replace_view" if replace else "create_view"
+    return [
+        ctx.entry(
+            kind,
+            ctx.qualified(schema, name),
+            detail=_detail_for(kind),
+        )
+    ]
+
+
+def _ast_function(node: object, ctx: _Context) -> list[ChangeEntry]:
+    parts = [str(getattr(part, "sval", part)) for part in getattr(node, "funcname", None) or ()]
+    replace = bool(getattr(node, "replace", False))
+    noun = "procedure" if getattr(node, "is_procedure", False) else "function"
+    kind = f"{'replace' if replace else 'create'}_{noun}"
+    return [ctx.entry(kind, ctx.from_parts(parts), detail=_detail_for(kind))]
+
+
+def _named_stmt(kind: str, attr: str, *, standalone: bool = False):
+    """Handler for a node whose target is a plain name attribute."""
+
+    def handler(node: object, ctx: _Context) -> list[ChangeEntry]:
+        raw = getattr(node, attr, None)
+        if raw is not None and hasattr(raw, "relname"):
+            # CreateSeqStmt.sequence and friends carry a RangeVar, not a string.
+            return [ctx.entry(kind, ctx.qualified(*_rel(raw)), detail=_detail_for(kind))]
+        name = str(raw) if raw is not None else None
+        target = ctx.bare(name) if standalone else ctx.dotted(name)
+        return [ctx.entry(kind, target, detail=_detail_for(kind))]
+
+    return handler
+
+
+def _list_name_stmt(kind: str, attr: str):
+    """Handler for a node whose target is a list of ``String`` name parts."""
+
+    def handler(node: object, ctx: _Context) -> list[ChangeEntry]:
+        parts = [str(getattr(part, "sval", part)) for part in getattr(node, attr, None) or ()]
+        return [ctx.entry(kind, ctx.from_parts(parts), detail=_detail_for(kind))]
+
+    return handler
+
+
+def _ast_grant(node: object, ctx: _Context) -> list[ChangeEntry]:
+    is_grant = bool(getattr(node, "is_grant", True))
+    kind = "grant" if is_grant else "revoke"
+    targets = []
+    for obj in getattr(node, "objects", None) or ():
+        schema, name = _rel(obj)
+        if name:
+            targets.append(ctx.qualified(schema, name))
+    if not targets:
+        targets = [None]
+    return [ctx.entry(kind, target, detail=kind.upper()) for target in targets]
+
+
+def _ast_comment(node: object, ctx: _Context) -> list[ChangeEntry]:
+    parts = _object_names(getattr(node, "object", None))
+    return [ctx.entry("comment", ctx.from_parts(parts), detail="COMMENT ON")]
+
+
+def _ast_simple(kind: str):
+    def handler(node: object, ctx: _Context) -> list[ChangeEntry]:
+        del node
+        return [ctx.entry(kind, None, detail=_detail_for(kind))]
+
+    return handler
+
+
+_AST_HANDLERS: Final[dict[str, Any]] = {
+    "AlterTableStmt": _ast_alter_table,
+    "RenameStmt": _ast_rename,
+    "IndexStmt": _ast_index,
+    "CreateStmt": _ast_create_table,
+    "CreateTableAsStmt": _ast_create_table_as,
+    "DropStmt": _ast_drop,
+    "TruncateStmt": _ast_truncate,
+    "DeleteStmt": _relation_stmt("delete", "DELETE"),
+    "UpdateStmt": _relation_stmt("update", "UPDATE"),
+    "InsertStmt": _relation_stmt("insert", "INSERT"),
+    "ViewStmt": _ast_view,
+    "CreateFunctionStmt": _ast_function,
+    "CreateSeqStmt": _named_stmt("create_sequence", "sequence"),
+    "AlterSeqStmt": _named_stmt("alter_sequence", "sequence"),
+    "CreateSchemaStmt": _named_stmt("create_schema", "schemaname", standalone=True),
+    "CreateExtensionStmt": _named_stmt("create_extension", "extname", standalone=True),
+    "CreateEnumStmt": _list_name_stmt("create_type", "typeName"),
+    "CreateRangeStmt": _list_name_stmt("create_type", "typeName"),
+    "CompositeTypeStmt": _named_stmt("create_type", "typevar"),
+    "CreateDomainStmt": _list_name_stmt("create_domain", "domainname"),
+    "AlterEnumStmt": _list_name_stmt("alter_type", "typeName"),
+    "CreateTrigStmt": _named_stmt("create_trigger", "trigname", standalone=True),
+    "CreatePolicyStmt": _named_stmt("create_policy", "policy_name", standalone=True),
+    "RuleStmt": _named_stmt("create_rule", "rulename", standalone=True),
+    "GrantStmt": _ast_grant,
+    "CommentStmt": _ast_comment,
+    "AlterOwnerStmt": _ast_simple("change_owner"),
+    "AlterDefaultPrivilegesStmt": _ast_simple("alter_default_privileges"),
+    "RefreshMatViewStmt": _relation_stmt("refresh_materialized_view", "REFRESH MATERIALIZED VIEW"),
+    "ClusterStmt": _relation_stmt("cluster", "CLUSTER"),
+    "ReindexStmt": _relation_stmt("reindex", "REINDEX"),
+}
+
+
+# --------------------------------------------------------------------------- #
+# regex backend (fallback / parity)
+# --------------------------------------------------------------------------- #
+
+_IDENT = r'(?:"[^"]+"|[A-Za-z_][\w$]*)(?:\.(?:"[^"]+"|[A-Za-z_][\w$]*))*'
+_DOLLAR_TAG = re.compile(r"\$(?:[A-Za-z_]\w*)?\$")
+
+# Statement heads that change neither schema nor data (the regex twin of _AST_SKIP).
+_RE_SKIP = re.compile(
+    r"^(?:BEGIN|COMMIT|END|ROLLBACK|START\s+TRANSACTION|SAVEPOINT|RELEASE\b|SET\b|RESET\b"
+    r"|SHOW\b|CHECKPOINT|DISCARD\b|LOCK\b|VACUUM\b|ANALYZE\b|ANALYSE\b|LISTEN\b|NOTIFY\b"
+    r"|UNLISTEN\b)",
+    re.IGNORECASE,
+)
+
+_RE_ALTER_TABLE = re.compile(
+    rf"^ALTER\s+(?:TABLE|MATERIALIZED\s+VIEW|VIEW|FOREIGN\s+TABLE)\s+(?:IF\s+EXISTS\s+)?"
+    rf"(?:ONLY\s+)?(?P<table>{_IDENT})\s+(?P<rest>.*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+_RE_AT_ADD_COLUMN = re.compile(
+    rf"^ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<col>{_IDENT})\s+(?P<tail>.*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+_RE_AT_DROP_COLUMN = re.compile(
+    rf"^DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?(?P<col>{_IDENT})", re.IGNORECASE
+)
+_RE_AT_RENAME_COLUMN = re.compile(
+    rf"^RENAME\s+(?:COLUMN\s+)?(?P<old>{_IDENT})\s+TO\s+(?P<new>{_IDENT})", re.IGNORECASE
+)
+_RE_AT_RENAME_TO = re.compile(rf"^RENAME\s+TO\s+(?P<new>{_IDENT})", re.IGNORECASE)
+_RE_AT_ALTER_COLUMN = re.compile(
+    rf"^ALTER\s+(?:COLUMN\s+)?(?P<col>{_IDENT})\s+(?P<action>.*)$", re.IGNORECASE | re.DOTALL
+)
+_RE_AT_ADD_CONSTRAINT = re.compile(
+    rf"^ADD\s+(?:CONSTRAINT\s+(?P<name>{_IDENT})\s+)?"
+    r"(?P<body>(?:PRIMARY\s+KEY|UNIQUE|FOREIGN\s+KEY|CHECK|EXCLUDE).*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+_RE_AT_DROP_CONSTRAINT = re.compile(
+    rf"^DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?(?P<name>{_IDENT})", re.IGNORECASE
+)
+_RE_AT_OWNER = re.compile(r"^OWNER\s+TO\b", re.IGNORECASE)
+_RE_AT_ADD_BARE_COLUMN = re.compile(
+    rf"^ADD\s+(?P<col>{_IDENT})\s+(?P<tail>.*)$", re.IGNORECASE | re.DOTALL
+)
+
+_RE_CREATE_INDEX = re.compile(
+    rf"^CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?P<conc>CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?"
+    rf"(?:(?!ON\s)(?P<idx>{_IDENT})\s+)?ON\s+(?:ONLY\s+)?(?P<table>{_IDENT})",
+    re.IGNORECASE,
+)
+_RE_DROP = re.compile(
+    r"^DROP\s+(?P<what>TABLE|INDEX|MATERIALIZED\s+VIEW|VIEW|SEQUENCE|SCHEMA|TYPE|DOMAIN"
+    r"|FUNCTION|PROCEDURE|TRIGGER|POLICY|RULE|EXTENSION)\s+"
+    r"(?:CONCURRENTLY\s+)?(?:IF\s+EXISTS\s+)?(?P<names>.+)$",
+    re.IGNORECASE | re.DOTALL,
+)
+_RE_TRUNCATE = re.compile(
+    r"^TRUNCATE\s+(?:TABLE\s+)?(?:ONLY\s+)?(?P<names>.+)$", re.IGNORECASE | re.DOTALL
+)
+_RE_GRANT = re.compile(r"^(?P<verb>GRANT|REVOKE)\b", re.IGNORECASE)
+_RE_GRANT_TARGET = re.compile(
+    rf"\bON\s+(?:TABLE\s+|SEQUENCE\s+|SCHEMA\s+)?(?P<obj>{_IDENT})", re.IGNORECASE
+)
+_RE_COMMENT = re.compile(rf"^COMMENT\s+ON\s+(?:\w+\s+)+?(?P<obj>{_IDENT})", re.IGNORECASE)
+
+_DROP_KIND_BY_WORD: Final[dict[str, str]] = {
+    "table": "drop_table",
+    "index": "drop_index",
+    "materialized view": "drop_materialized_view",
+    "view": "drop_view",
+    "sequence": "drop_sequence",
+    "schema": "drop_schema",
+    "type": "drop_type",
+    "domain": "drop_domain",
+    "function": "drop_function",
+    "procedure": "drop_procedure",
+    "trigger": "drop_trigger",
+    "policy": "drop_policy",
+    "rule": "drop_rule",
+    "extension": "drop_extension",
+}
+
+# Simple `head → kind` patterns whose target is the single `name` group.
+_SIMPLE_PATTERNS: Final[tuple[tuple[re.Pattern[str], str, bool], ...]] = (
+    (
+        re.compile(
+            rf"^CREATE\s+(?:GLOBAL\s+|LOCAL\s+)?(?:UNLOGGED\s+|TEMPORARY\s+|TEMP\s+)?TABLE\s+"
+            rf"(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_IDENT})",
+            re.IGNORECASE,
+        ),
+        "create_table",
+        False,
+    ),
+    (
+        re.compile(
+            rf"^CREATE\s+MATERIALIZED\s+VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_IDENT})",
+            re.IGNORECASE,
+        ),
+        "create_materialized_view",
+        False,
+    ),
+    (
+        re.compile(
+            rf"^CREATE\s+OR\s+REPLACE\s+(?:\w+\s+)*?VIEW\s+(?P<name>{_IDENT})", re.IGNORECASE
+        ),
+        "replace_view",
+        False,
+    ),
+    (
+        re.compile(rf"^CREATE\s+(?:\w+\s+)*?VIEW\s+(?P<name>{_IDENT})", re.IGNORECASE),
+        "create_view",
+        False,
+    ),
+    (
+        re.compile(rf"^CREATE\s+OR\s+REPLACE\s+FUNCTION\s+(?P<name>{_IDENT})", re.IGNORECASE),
+        "replace_function",
+        False,
+    ),
+    (
+        re.compile(rf"^CREATE\s+FUNCTION\s+(?P<name>{_IDENT})", re.IGNORECASE),
+        "create_function",
+        False,
+    ),
+    (
+        re.compile(rf"^CREATE\s+OR\s+REPLACE\s+PROCEDURE\s+(?P<name>{_IDENT})", re.IGNORECASE),
+        "replace_procedure",
+        False,
+    ),
+    (
+        re.compile(rf"^CREATE\s+PROCEDURE\s+(?P<name>{_IDENT})", re.IGNORECASE),
+        "create_procedure",
+        False,
+    ),
+    (
+        re.compile(
+            rf"^CREATE\s+SCHEMA\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_IDENT})", re.IGNORECASE
+        ),
+        "create_schema",
+        True,
+    ),
+    (
+        re.compile(
+            rf"^CREATE\s+SEQUENCE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_IDENT})", re.IGNORECASE
+        ),
+        "create_sequence",
+        False,
+    ),
+    (re.compile(rf"^CREATE\s+TYPE\s+(?P<name>{_IDENT})", re.IGNORECASE), "create_type", False),
+    (re.compile(rf"^CREATE\s+DOMAIN\s+(?P<name>{_IDENT})", re.IGNORECASE), "create_domain", False),
+    (
+        re.compile(
+            rf"^CREATE\s+EXTENSION\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_IDENT})", re.IGNORECASE
+        ),
+        "create_extension",
+        True,
+    ),
+    (
+        re.compile(
+            rf"^CREATE\s+(?:CONSTRAINT\s+)?TRIGGER\s+(?P<name>{_IDENT})",
+            re.IGNORECASE,
+        ),
+        "create_trigger",
+        True,
+    ),
+    (re.compile(rf"^CREATE\s+POLICY\s+(?P<name>{_IDENT})", re.IGNORECASE), "create_policy", True),
+    (re.compile(rf"^CREATE\s+RULE\s+(?P<name>{_IDENT})", re.IGNORECASE), "create_rule", True),
+    (
+        re.compile(rf"^DELETE\s+FROM\s+(?:ONLY\s+)?(?P<name>{_IDENT})", re.IGNORECASE),
+        "delete",
+        False,
+    ),
+    (re.compile(rf"^UPDATE\s+(?:ONLY\s+)?(?P<name>{_IDENT})", re.IGNORECASE), "update", False),
+    (re.compile(rf"^INSERT\s+INTO\s+(?P<name>{_IDENT})", re.IGNORECASE), "insert", False),
+    (
+        re.compile(
+            rf"^REFRESH\s+MATERIALIZED\s+VIEW\s+(?:CONCURRENTLY\s+)?(?P<name>{_IDENT})",
+            re.IGNORECASE,
+        ),
+        "refresh_materialized_view",
+        False,
+    ),
+    (re.compile(rf"^CLUSTER\s+(?P<name>{_IDENT})", re.IGNORECASE), "cluster", False),
+    (re.compile(rf"^REINDEX\s+(?:\w+\s+)?(?P<name>{_IDENT})", re.IGNORECASE), "reindex", False),
+    (
+        re.compile(rf"^ALTER\s+SEQUENCE\s+(?:IF\s+EXISTS\s+)?(?P<name>{_IDENT})", re.IGNORECASE),
+        "alter_sequence",
+        False,
+    ),
+    (re.compile(rf"^ALTER\s+TYPE\s+(?P<name>{_IDENT})", re.IGNORECASE), "alter_type", False),
+    (
+        re.compile(r"^ALTER\s+DEFAULT\s+PRIVILEGES\b", re.IGNORECASE),
+        "alter_default_privileges",
+        False,
+    ),
+)
+
+
+def _regex_entries(sql: str, ctx: _Context) -> list[ChangeEntry]:
+    entries: list[ChangeEntry] = []
+    for statement in _split_statements(sql):
+        entries.extend(_regex_one(statement, ctx))
+    return entries
+
+
+def _regex_one(statement: str, ctx: _Context) -> list[ChangeEntry]:
+    text = statement.strip()
+    if not text or _RE_SKIP.match(text):
+        return []
+
+    alter = _RE_ALTER_TABLE.match(text)
+    if alter:
+        return _regex_alter_table(alter, ctx)
+
+    index = _RE_CREATE_INDEX.match(text)
+    if index:
+        concurrently = index.group("conc") is not None
+        return [
+            ctx.entry(
+                "create_index",
+                ctx.dotted(index.group("table"), index.group("idx")),
+                tier=tier_for_create_index(concurrently=concurrently),
+                detail="CREATE INDEX" + (" CONCURRENTLY" if concurrently else " — blocks writes"),
+            )
+        ]
+
+    drop = _RE_DROP.match(text)
+    if drop:
+        return _regex_drop(drop, ctx)
+
+    truncate = _RE_TRUNCATE.match(text)
+    if truncate:
+        return [
+            ctx.entry("truncate", ctx.dotted(name), detail="TRUNCATE")
+            for name in _split_object_list(truncate.group("names"))
+        ]
+
+    grant = _RE_GRANT.match(text)
+    if grant:
+        target = _RE_GRANT_TARGET.search(text)
+        kind = grant.group("verb").lower()
+        return [
+            ctx.entry(
+                kind,
+                ctx.dotted(target.group("obj")) if target else None,
+                detail=kind.upper(),
+            )
+        ]
+
+    comment = _RE_COMMENT.match(text)
+    if comment:
+        return [ctx.entry("comment", ctx.dotted(comment.group("obj")), detail="COMMENT ON")]
+
+    for pattern, kind, standalone in _SIMPLE_PATTERNS:
+        match = pattern.match(text)
+        if match:
+            raw = match.groupdict().get("name")
+            target = (ctx.bare(raw) if standalone else ctx.dotted(raw)) if raw else None
+            return [ctx.entry(kind, target, detail=_detail_for(kind))]
+
+    return [
+        ctx.unclassified(
+            "unclassified",
+            None,
+            f"{_command_prefix(text)} — confiture does not classify this statement",
+        )
+    ]
+
+
+def _regex_alter_table(match: re.Match[str], ctx: _Context) -> list[ChangeEntry]:
+    table = match.group("table")
+    rest = match.group("rest").strip()
+    target = ctx.dotted(table)
+
+    add_column = _RE_AT_ADD_COLUMN.match(rest)
+    if add_column:
+        return [_regex_add_column(add_column, table, ctx)]
+
+    drop_column = _RE_AT_DROP_COLUMN.match(rest)
+    if drop_column:
+        column = drop_column.group("col")
+        return [
+            ctx.entry(
+                "drop_column",
+                ctx.dotted(table, column),
+                detail=f"DROP COLUMN {_ident(column)}",
+            )
+        ]
+
+    rename_to = _RE_AT_RENAME_TO.match(rest)
+    if rename_to:
+        return [
+            ctx.entry("rename_object", target, detail=f"RENAME TO {_ident(rename_to.group('new'))}")
+        ]
+
+    rename = _RE_AT_RENAME_COLUMN.match(rest)
+    if rename:
+        old, new = rename.group("old"), rename.group("new")
+        return [
+            ctx.entry(
+                "rename_column",
+                ctx.dotted(table, old),
+                detail=f"RENAME COLUMN {_ident(old)} TO {_ident(new)} — "
+                "readers on the old name break until they are redeployed",
+            )
+        ]
+
+    alter_column = _RE_AT_ALTER_COLUMN.match(rest)
+    if alter_column:
+        entry = _regex_alter_column(alter_column, table, ctx)
+        if entry is not None:
+            return [entry]
+
+    add_constraint = _RE_AT_ADD_CONSTRAINT.match(rest)
+    if add_constraint:
+        not_valid = "not valid" in add_constraint.group("body").lower()
+        return [
+            ctx.entry(
+                "add_constraint",
+                ctx.dotted(table, add_constraint.group("name")),
+                tier=tier_for_add_constraint(not_valid=not_valid),
+                detail="ADD CONSTRAINT" + (" NOT VALID" if not_valid else ""),
+            )
+        ]
+
+    drop_constraint = _RE_AT_DROP_CONSTRAINT.match(rest)
+    if drop_constraint:
+        name = drop_constraint.group("name")
+        return [
+            ctx.entry(
+                "drop_constraint",
+                ctx.dotted(table, name),
+                detail=f"DROP CONSTRAINT {_ident(name)}",
+            )
+        ]
+
+    if _RE_AT_OWNER.match(rest):
+        return [ctx.entry("change_owner", target, detail="OWNER TO")]
+
+    bare_add = _RE_AT_ADD_BARE_COLUMN.match(rest)
+    if bare_add:
+        return [_regex_add_column(bare_add, table, ctx)]
+
+    return [
+        ctx.unclassified(
+            "alter_table", target, "ALTER TABLE subcommand confiture does not classify"
+        )
+    ]
+
+
+def _regex_add_column(match: re.Match[str], table: str, ctx: _Context) -> ChangeEntry:
+    column = match.group("col")
+    tail = match.group("tail").lower()
+    nullable = "not null" not in tail
+    has_default = "default" in tail
+    return ctx.entry(
+        "add_column",
+        ctx.dotted(table, column),
+        tier=tier_for_add_column(nullable=nullable, has_default=has_default),
+        detail=_add_column_detail(column, nullable=nullable, has_default=has_default),
+    )
+
+
+def _regex_alter_column(match: re.Match[str], table: str, ctx: _Context) -> ChangeEntry | None:
+    column = match.group("col")
+    action = match.group("action").strip().lower()
+    target = ctx.dotted(table, column)
+    if re.match(r"^(?:set\s+data\s+)?type\b", action):
+        return ctx.unclassified(
+            "alter_column_type",
+            target,
+            f"ALTER COLUMN {_ident(column)} TYPE — {_ALTER_COLUMN_TYPE_DETAIL}",
+        )
+    if action.startswith("set default"):
+        return ctx.entry(
+            "set_column_default", target, detail=f"ALTER COLUMN {_ident(column)} SET DEFAULT"
+        )
+    if action.startswith("drop default"):
+        return ctx.entry(
+            "drop_column_default", target, detail=f"ALTER COLUMN {_ident(column)} DROP DEFAULT"
+        )
+    if action.startswith("set not null"):
+        return ctx.entry(
+            "set_not_null",
+            target,
+            detail=f"ALTER COLUMN {_ident(column)} SET NOT NULL — scans the table",
+        )
+    if action.startswith("drop not null"):
+        return ctx.entry(
+            "drop_not_null", target, detail=f"ALTER COLUMN {_ident(column)} DROP NOT NULL"
+        )
+    return None
+
+
+def _regex_drop(match: re.Match[str], ctx: _Context) -> list[ChangeEntry]:
+    word = re.sub(r"\s+", " ", match.group("what")).lower()
+    kind = _DROP_KIND_BY_WORD[word]
+    standalone = kind in _STANDALONE_DROP_KINDS
+    # `DROP TRIGGER t ON tbl` scopes the name to a table; a trailing
+    # CASCADE|RESTRICT belongs to neither.
+    head, _, tail = _partition_on_clause(match.group("names"))
+    relation = _strip_trailing_clause(tail) or None
+    return [
+        ctx.entry(
+            kind,
+            ctx.bare(name)
+            if standalone
+            else (ctx.dotted(relation, name) if relation else ctx.dotted(name)),
+            detail=_detail_for(kind),
+        )
+        for name in _split_object_list(_strip_trailing_clause(head))
+    ]
+
+
+def _partition_on_clause(raw: str) -> tuple[str, str, str]:
+    parts = re.split(r"\bON\b", raw, maxsplit=1, flags=re.IGNORECASE)
+    return (parts[0], "ON", parts[1]) if len(parts) > 1 else (parts[0], "", "")
+
+
+def _strip_trailing_clause(raw: str) -> str:
+    return re.sub(r"\b(?:CASCADE|RESTRICT)\b.*$", "", raw, flags=re.IGNORECASE | re.DOTALL).strip()
+
+
+def _split_object_list(raw: str) -> list[str]:
+    """Split `a, b.c` into names, dropping any argument list or trailing clause."""
+    names = []
+    for chunk in raw.split(","):
+        name = chunk.strip().split("(")[0].strip()
+        name = name.split()[0] if name.split() else ""
+        if name:
+            names.append(name)
+    return names
+
+
+def _split_statements(sql: str) -> list[str]:
+    """Split on top-level ``;``, respecting dollar-quoted bodies, literals and comments.
+
+    The naive ``sql.split(";")`` the replica classifier uses is fine for the
+    single-statement DDL its matrix covers, but it shreds a ``CREATE FUNCTION``
+    body — which this module has to classify as one statement.
+    """
+    statements: list[str] = []
+    buf: list[str] = []
+    index = 0
+    length = len(sql)
+    tag: str | None = None
+
+    while index < length:
+        char = sql[index]
+        if tag is not None:
+            if sql.startswith(tag, index):
+                buf.append(tag)
+                index += len(tag)
+                tag = None
+            else:
+                buf.append(char)
+                index += 1
+            continue
+        if char == "$":
+            opener = _DOLLAR_TAG.match(sql, index)
+            if opener:
+                tag = opener.group(0)
+                buf.append(tag)
+                index += len(tag)
+                continue
+        if char == "'":
+            end = index + 1
+            while end < length:
+                if sql[end] == "'":
+                    if end + 1 < length and sql[end + 1] == "'":
+                        end += 2
+                        continue
+                    end += 1
+                    break
+                end += 1
+            buf.append(sql[index:end])
+            index = end
+            continue
+        if sql.startswith("--", index):
+            newline = sql.find("\n", index)
+            index = length if newline == -1 else newline
+            continue
+        if sql.startswith("/*", index):
+            close = sql.find("*/", index)
+            index = length if close == -1 else close + 2
+            continue
+        if char == ";":
+            statements.append("".join(buf))
+            buf = []
+            index += 1
+            continue
+        buf.append(char)
+        index += 1
+
+    statements.append("".join(buf))
+    return [stripped for stripped in (s.strip() for s in statements) if stripped]

--- a/python/confiture/core/risk_tier.py
+++ b/python/confiture/core/risk_tier.py
@@ -1,0 +1,78 @@
+"""Risk-tier taxonomy for the migration-adapter seam (issue #197).
+
+One tier per schema change, crossing the seam as typed data beside the
+``window_safe`` boolean rather than being recovered by string-matching issue
+codes. The five values, their ``snake_case`` wire form and their severity
+ordering are ratified in fraisier-core's
+``docs/proposals/migration-risk-contract.md`` (contract version 1) and pinned
+from this side by ``tests/unit/test_risk_tier.py``.
+
+Two properties are deliberate and load-bearing:
+
+* **Five tiers, no ``unknown``.** A change confiture cannot classify carries *no*
+  tier at all — the consumer reads that as unclassified and denies. An
+  ``unknown`` member would be a sixth wire value, which the contract makes a
+  ``contract_version`` conversation rather than a silent addition.
+* **The ordering is for picking the worst of a set, not for deciding policy.**
+  Consumers map each tier to an action independently.
+
+This module is pure: no I/O, no database, no parser. That is what the deleted
+``core/risk/`` package (a never-wired DowntimePredictor, removed at ``2bf38f1``)
+was not.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from enum import Enum
+
+__all__ = ["RiskTier", "worst_tier"]
+
+
+class RiskTier(Enum):
+    """What kind of risk a single schema change carries.
+
+    Declared least- to most-severe; :attr:`severity` is the declaration index.
+    """
+
+    ADDITIVE = "additive"
+    """Adds a new object. No existing reader or writer can break."""
+
+    REVERSIBLE = "reversible"
+    """Changes existing state, with a down path that restores it."""
+
+    LOCK_RISKY = "lock_risky"
+    """Semantically safe, but takes a lock that can stall a hot table."""
+
+    DESTRUCTIVE = "destructive"
+    """Destroys data or an object; the loss is bounded and restorable from backup."""
+
+    IRREVERSIBLE = "irreversible"
+    """Destroys data with no down path that can restore it."""
+
+    @property
+    def severity(self) -> int:
+        """Position in ``additive < reversible < lock_risky < destructive < irreversible``.
+
+        Used to pick the worst tier in a change set and to sort a plan render
+        worst-first. It is **not** how policy decisions are made.
+        """
+        return _SEVERITY[self]
+
+
+# Declaration order is the severity order; derived once so the two cannot drift.
+_SEVERITY: dict[RiskTier, int] = {tier: index for index, tier in enumerate(RiskTier)}
+
+
+def worst_tier(tiers: Iterable[RiskTier | None]) -> RiskTier | None:
+    """The most severe tier in ``tiers``, ignoring unclassified (``None``) entries.
+
+    Returns ``None`` when nothing was classifiable. Unclassified entries are
+    skipped rather than dominating: a change set holding one unreadable ``.py``
+    migration *and* a ``DROP TABLE`` must still report the drop, or the more
+    dangerous change hides behind the less informative one.
+    """
+    classified = [tier for tier in tiers if tier is not None]
+    if not classified:
+        return None
+    return max(classified, key=lambda tier: tier.severity)

--- a/tests/contract/test_preflight_change_set_contract.py
+++ b/tests/contract/test_preflight_change_set_contract.py
@@ -1,0 +1,134 @@
+"""The producer half of the risk-tier pact with fraisier-core#44 (#197).
+
+`tests/fixtures/preflight-contract/` holds the same bytes as fraisier-core's
+`crates/fraisier-adapter-confiture/tests/fixtures/preflight/`. Confiture asserts
+it *emits* those shapes; fraisier asserts it *parses* them. Because confiture's
+CI cannot see the sibling repository, this is where producer drift is caught.
+
+`detail` is excluded from the comparison — see the fixture directory's README.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.change_set import CONTRACT_VERSION
+from confiture.core.risk_tier import RiskTier
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "preflight-contract"
+
+# The scenario the fixtures share, as real migration files.
+SCENARIO = {
+    "20260804120000": (
+        "20260804120000_add_nickname.up.sql",
+        "ALTER TABLE tb_user ADD COLUMN nickname text;\n",
+    ),
+    "20260804120050": (
+        "20260804120050_index_placed_at.up.sql",
+        "CREATE INDEX idx_placed_at ON tb_order (placed_at);\n",
+    ),
+    "20260804120100": (
+        "20260804120100_drop_legacy_flag.up.sql",
+        "ALTER TABLE tb_user DROP COLUMN legacy_flag;\n",
+    ),
+    "20260804120300": (
+        "20260804120300_widen_total.up.sql",
+        "ALTER TABLE tb_order ALTER COLUMN total_cents TYPE bigint;\n",
+    ),
+}
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _emit(tmp_path: Path, versions: list[str]) -> dict:
+    """Run the real CLI over the scenario migrations for ``versions``."""
+    migrations = tmp_path / "migrations"
+    migrations.mkdir()
+    for version in versions:
+        filename, body = SCENARIO[version]
+        (migrations / filename).write_text(body)
+
+    result = CliRunner().invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(migrations), "--format", "json"],
+    )
+    assert result.exit_code in (0, 7), result.output
+    return json.loads(result.stdout)
+
+
+def _comparable(change_set: dict) -> dict:
+    """The contract-bearing fields. `detail` is free-form by specification."""
+    return {
+        "contract_version": change_set["contract_version"],
+        "changes": [
+            {key: value for key, value in change.items() if key != "detail"}
+            for change in change_set["changes"]
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "versions"),
+    [
+        ("v1-empty.json", []),
+        ("v1-additive.json", ["20260804120000"]),
+        ("v1-mixed.json", ["20260804120000", "20260804120050", "20260804120100"]),
+        ("v1-missing-tier.json", ["20260804120000", "20260804120300"]),
+    ],
+)
+def test_confiture_emits_the_fixture_shape(fixture_name: str, versions: list[str], tmp_path):
+    payload = _emit(tmp_path, versions)
+    assert _comparable(payload["change_set"]) == _comparable(_fixture(fixture_name)["change_set"])
+
+
+def test_every_emitted_change_has_a_detail_line(tmp_path):
+    """`detail` is not byte-pinned, but it must be there and it must say something."""
+    payload = _emit(tmp_path, list(SCENARIO))
+    for change in payload["change_set"]["changes"]:
+        assert isinstance(change["detail"], str)
+        assert change["detail"].strip()
+
+
+def test_the_emitted_envelope_is_an_object_never_a_bare_array(tmp_path):
+    """`malformed.json` is the shape confiture must never produce."""
+    payload = _emit(tmp_path, ["20260804120000"])
+    assert isinstance(payload["change_set"], dict)
+    assert set(payload["change_set"]) == {"contract_version", "changes"}
+    assert isinstance(payload["change_set"]["changes"], list)
+
+
+def test_confiture_never_emits_a_future_contract_version(tmp_path):
+    """`v2-future.json` exists to pin the consumer's refusal, not the producer's output."""
+    assert CONTRACT_VERSION == 1
+    payload = _emit(tmp_path, ["20260804120100"])
+    assert payload["change_set"]["contract_version"] == 1
+    assert _fixture("v2-future.json")["change_set"]["contract_version"] > CONTRACT_VERSION
+
+
+def test_confiture_never_emits_a_tier_outside_the_five(tmp_path):
+    """`v1-unknown-tier.json`'s `quantum` must be unreachable from this producer."""
+    known = {tier.value for tier in RiskTier}
+    assert known == {"additive", "reversible", "lock_risky", "destructive", "irreversible"}
+
+    unknown = _fixture("v1-unknown-tier.json")["change_set"]["changes"][1]["tier"]
+    assert unknown not in known
+
+    payload = _emit(tmp_path, list(SCENARIO))
+    for change in payload["change_set"]["changes"]:
+        if "tier" in change:
+            assert change["tier"] in known
+
+
+def test_the_pre_contract_payload_still_describes_this_command(tmp_path):
+    """`v0-no-change-set.json` is the back-compat baseline: everything else is unchanged."""
+    baseline = _fixture("v0-no-change-set.json")
+    payload = _emit(tmp_path, ["20260804120000"])
+    assert set(baseline) <= set(payload)
+    assert set(baseline["summary"]) == set(payload["summary"])

--- a/tests/fixtures/preflight-contract/README.md
+++ b/tests/fixtures/preflight-contract/README.md
@@ -1,0 +1,47 @@
+# Preflight golden fixtures — the cross-repo pact (#197 / fraisier-core#44)
+
+**These files are product, not test scaffolding.** They are the shared bytes of
+the migration risk contract: confiture asserts that it *emits* these shapes,
+fraisier asserts that it *parses* them. Changing a fixture changes the contract
+in both repositories at once, so a change here needs a matching change in
+fraisier-core and a `contract_version` decision.
+
+Upstream copy: `crates/fraisier-adapter-confiture/tests/fixtures/preflight/` in
+[fraisier-core](https://github.com/fraiseql/fraisier-core). Specification:
+`docs/proposals/migration-risk-contract.md`, same repo. They are vendored here
+rather than referenced so confiture's CI, which cannot see the sibling
+repository, still fails when the producer drifts from the pact.
+
+| File | Contract state it pins |
+|---|---|
+| `v0-no-change-set.json` | A pre-contract payload — no `change_set` at all. Confiture ≤ 0.42.0. |
+| `v1-empty.json` | Classified, with `changes: []` — *nothing changes*, which is distinct from the file above. |
+| `v1-additive.json` | The simplest classified change. |
+| `v1-mixed.json` | Three tiers in one set, in migration order. |
+| `v1-unknown-tier.json` | A tier string the consumer does not know. **Confiture must never emit this.** |
+| `v1-missing-tier.json` | An entry with no `tier` key — confiture's honest "I cannot classify this". |
+| `v2-future.json` | A `contract_version` from the future. **Confiture must never emit this.** |
+| `malformed.json` | `change_set` as a string. **Confiture must never emit this.** |
+
+## Scenario
+
+The fixtures share one migration set, which
+`tests/contract/test_preflight_change_set_contract.py` reconstructs as real
+migration files and runs `migrate preflight --format json` over:
+
+- `20260804120000` — add `tb_user.nickname` (additive)
+- `20260804120050` — index `tb_order.placed_at` (lock-risky)
+- `20260804120100` — drop `tb_user.legacy_flag` (irreversible)
+- `20260804120300` — widen `tb_order.total_cents` (no tier — see below)
+
+## What the pact pins, and what it does not
+
+`kind`, `object`, `migration` and `tier` are compared **exactly**. `detail` is
+not: the contract defines it as "one human-readable line for the plan render,
+never parsed", and confiture synthesises it from the parsed statement rather
+than echoing the source text, so it carries no column type (`ADD COLUMN nickname
+NULL`, where the fixture reads `ADD COLUMN nickname text NULL`). Echoing source
+text would put arbitrary literals — including credentials in statements such as
+`CREATE USER … PASSWORD …` — into a field that gets rendered to an operator, and
+the contract forbids exactly that. The test asserts `detail` is a non-empty
+string and nothing more.

--- a/tests/fixtures/preflight-contract/malformed.json
+++ b/tests/fixtures/preflight-contract/malformed.json
@@ -1,0 +1,12 @@
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 0,
+    "info": 0,
+    "migrations_checked": 1
+  },
+  "issues": [],
+  "change_set": "additive"
+}

--- a/tests/fixtures/preflight-contract/v0-no-change-set.json
+++ b/tests/fixtures/preflight-contract/v0-no-change-set.json
@@ -1,0 +1,22 @@
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 1,
+    "info": 0,
+    "migrations_checked": 2
+  },
+  "issues": [
+    {
+      "severity": "warning",
+      "code": "PFLIGHT_NON_TRANSACTIONAL",
+      "message": "Migration 20260804120050 contains a non-transactional statement (CREATE INDEX CONCURRENTLY).",
+      "migration": "20260804120050",
+      "file": "migrations/20260804120050_index_placed_at.sql",
+      "line": 1,
+      "actionable": "Run with --allow-non-transactional to apply it in autocommit, or split the statement out of the transactional migration.",
+      "details": {}
+    }
+  ]
+}

--- a/tests/fixtures/preflight-contract/v1-additive.json
+++ b/tests/fixtures/preflight-contract/v1-additive.json
@@ -1,0 +1,23 @@
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 0,
+    "info": 0,
+    "migrations_checked": 1
+  },
+  "issues": [],
+  "change_set": {
+    "contract_version": 1,
+    "changes": [
+      {
+        "kind": "add_column",
+        "object": "public.tb_user.nickname",
+        "migration": "20260804120000",
+        "tier": "additive",
+        "detail": "ADD COLUMN nickname text NULL"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/preflight-contract/v1-empty.json
+++ b/tests/fixtures/preflight-contract/v1-empty.json
@@ -1,0 +1,15 @@
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 0,
+    "info": 0,
+    "migrations_checked": 0
+  },
+  "issues": [],
+  "change_set": {
+    "contract_version": 1,
+    "changes": []
+  }
+}

--- a/tests/fixtures/preflight-contract/v1-missing-tier.json
+++ b/tests/fixtures/preflight-contract/v1-missing-tier.json
@@ -1,0 +1,29 @@
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 0,
+    "info": 0,
+    "migrations_checked": 2
+  },
+  "issues": [],
+  "change_set": {
+    "contract_version": 1,
+    "changes": [
+      {
+        "kind": "add_column",
+        "object": "public.tb_user.nickname",
+        "migration": "20260804120000",
+        "tier": "additive",
+        "detail": "ADD COLUMN nickname text NULL"
+      },
+      {
+        "kind": "alter_column_type",
+        "object": "public.tb_order.total_cents",
+        "migration": "20260804120300",
+        "detail": "ALTER COLUMN total_cents TYPE bigint"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/preflight-contract/v1-mixed.json
+++ b/tests/fixtures/preflight-contract/v1-mixed.json
@@ -1,0 +1,48 @@
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 1,
+    "info": 0,
+    "migrations_checked": 3
+  },
+  "issues": [
+    {
+      "severity": "warning",
+      "code": "PFLIGHT_NON_TRANSACTIONAL",
+      "message": "Migration 20260804120050 contains a non-transactional statement (CREATE INDEX).",
+      "migration": "20260804120050",
+      "file": "migrations/20260804120050_index_placed_at.sql",
+      "line": 1,
+      "actionable": "Run with --allow-non-transactional to apply it in autocommit, or split the statement out of the transactional migration.",
+      "details": {}
+    }
+  ],
+  "change_set": {
+    "contract_version": 1,
+    "changes": [
+      {
+        "kind": "add_column",
+        "object": "public.tb_user.nickname",
+        "migration": "20260804120000",
+        "tier": "additive",
+        "detail": "ADD COLUMN nickname text NULL"
+      },
+      {
+        "kind": "create_index",
+        "object": "public.tb_order.idx_placed_at",
+        "migration": "20260804120050",
+        "tier": "lock_risky",
+        "detail": "CREATE INDEX idx_placed_at ON tb_order (placed_at)"
+      },
+      {
+        "kind": "drop_column",
+        "object": "public.tb_user.legacy_flag",
+        "migration": "20260804120100",
+        "tier": "irreversible",
+        "detail": "DROP COLUMN legacy_flag"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/preflight-contract/v1-unknown-tier.json
+++ b/tests/fixtures/preflight-contract/v1-unknown-tier.json
@@ -1,0 +1,30 @@
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 0,
+    "info": 0,
+    "migrations_checked": 2
+  },
+  "issues": [],
+  "change_set": {
+    "contract_version": 1,
+    "changes": [
+      {
+        "kind": "add_column",
+        "object": "public.tb_user.nickname",
+        "migration": "20260804120000",
+        "tier": "additive",
+        "detail": "ADD COLUMN nickname text NULL"
+      },
+      {
+        "kind": "entangle_column",
+        "object": "public.tb_user.spin_state",
+        "migration": "20260804120200",
+        "tier": "quantum",
+        "detail": "a tier this build of fraisier does not recognise"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/preflight-contract/v2-future.json
+++ b/tests/fixtures/preflight-contract/v2-future.json
@@ -1,0 +1,23 @@
+{
+  "ok": true,
+  "window_safe": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 0,
+    "info": 0,
+    "migrations_checked": 1
+  },
+  "issues": [],
+  "change_set": {
+    "contract_version": 2,
+    "changes": [
+      {
+        "kind": "drop_column",
+        "object": "public.tb_user.legacy_flag",
+        "migration": "20260804120100",
+        "tier": "irreversible",
+        "detail": "DROP COLUMN legacy_flag"
+      }
+    ]
+  }
+}

--- a/tests/unit/json_schemas/test_preflight_schema.py
+++ b/tests/unit/json_schemas/test_preflight_schema.py
@@ -11,7 +11,9 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
 from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT202012
 from typer.testing import CliRunner
@@ -195,3 +197,76 @@ def test_preflight_against_replay_failure_validates(tmp_path, schemas_dir):
     assert replay["severity"] == "error"
     assert replay["migration"] == "20260527000000"
     assert replay["details"]["error"] == 'relation "x" already exists'
+
+
+# ---------------------------------------------------------------------------
+# change_set (#197) — the schema must constrain, not merely accept
+# ---------------------------------------------------------------------------
+
+
+def _validator(schemas_dir):
+    return Draft202012Validator(
+        _load(schemas_dir, PREFLIGHT_SCHEMA), registry=_build_registry(schemas_dir)
+    )
+
+
+def _payload_with(change_set) -> dict:
+    return {
+        "ok": True,
+        "window_safe": True,
+        "summary": {"errors": 0, "warnings": 0, "info": 0, "migrations_checked": 1},
+        "issues": [],
+        "change_set": change_set,
+    }
+
+
+def test_a_real_change_set_validates(tmp_path, schemas_dir):
+    """The emitted payload, straight from the CLI."""
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    (migs / "20260804120100_drop.up.sql").write_text("ALTER TABLE tb_user DROP COLUMN legacy;\n")
+
+    result = CliRunner().invoke(
+        app, ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json"]
+    )
+    payload = json.loads(result.stdout)
+    _validator(schemas_dir).validate(payload)
+    assert payload["change_set"]["changes"][0]["tier"] == "irreversible"
+
+
+def test_an_absent_change_set_still_validates(schemas_dir):
+    """A payload from confiture < 0.43.0 must stay valid — absence is meaningful."""
+    payload = _payload_with(None)
+    del payload["change_set"]
+    _validator(schemas_dir).validate(payload)
+
+
+@pytest.mark.parametrize(
+    "change_set",
+    [
+        pytest.param([], id="bare array instead of the object wrapper"),
+        pytest.param("additive", id="a string, per the malformed.json fixture"),
+        pytest.param({"changes": []}, id="no contract_version"),
+        pytest.param(
+            {"contract_version": 1, "changes": [{"kind": "drop_column"}]},
+            id="entry without an object",
+        ),
+        pytest.param(
+            {
+                "contract_version": 1,
+                "changes": [{"kind": "entangle", "object": "public.t.c", "tier": "quantum"}],
+            },
+            id="a tier outside the five",
+        ),
+        pytest.param(
+            {
+                "contract_version": 1,
+                "changes": [{"kind": "drop_column", "object": "public.t.c", "risk": "high"}],
+            },
+            id="an undeclared entry field",
+        ),
+    ],
+)
+def test_the_schema_rejects_shapes_confiture_must_never_emit(change_set, schemas_dir):
+    with pytest.raises(ValidationError):
+        _validator(schemas_dir).validate(_payload_with(change_set))

--- a/tests/unit/test_change_set.py
+++ b/tests/unit/test_change_set.py
@@ -1,0 +1,307 @@
+"""The preflight change set — per-change risk classification (#197).
+
+The wire shape and the tier boundaries are the ratified cross-repo contract
+(fraisier-core#44, `docs/proposals/migration-risk-contract.md`, contract
+version 1). Two properties matter more than any individual mapping:
+
+* a statement is **never silently dropped** — one confiture cannot classify
+  still produces an entry, with no ``tier``, so the consumer denies;
+* the two parser backends agree, so an install without the ``[ast]`` extra
+  classifies the same way.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.change_set import (
+    CONTRACT_VERSION,
+    ChangeEntry,
+    ChangeSet,
+    build_change_set,
+    classify_statements,
+)
+from confiture.core.risk_tier import RiskTier
+
+# (sql, kind, tier) — the taxonomy, statement by statement.
+_TAXONOMY = [
+    # additive: adds a new object, no existing reader can break
+    ("CREATE TABLE tb_user (id int);", "create_table", RiskTier.ADDITIVE),
+    ("ALTER TABLE tb_user ADD COLUMN nickname text;", "add_column", RiskTier.ADDITIVE),
+    ("CREATE INDEX CONCURRENTLY idx ON tb_order (placed_at);", "create_index", RiskTier.ADDITIVE),
+    ("CREATE VIEW v AS SELECT 1;", "create_view", RiskTier.ADDITIVE),
+    ("CREATE SCHEMA s;", "create_schema", RiskTier.ADDITIVE),
+    ("CREATE SEQUENCE sq;", "create_sequence", RiskTier.ADDITIVE),
+    ("INSERT INTO tb_z (a) VALUES (1);", "insert", RiskTier.ADDITIVE),
+    # reversible: changes existing state, with a down path that restores it
+    ("ALTER TABLE tb_user RENAME COLUMN a TO b;", "rename_column", RiskTier.REVERSIBLE),
+    ("ALTER TABLE t ALTER COLUMN c SET DEFAULT 1;", "set_column_default", RiskTier.REVERSIBLE),
+    ("ALTER TABLE t ALTER COLUMN c DROP DEFAULT;", "drop_column_default", RiskTier.REVERSIBLE),
+    ("ALTER TABLE t ALTER COLUMN c DROP NOT NULL;", "drop_not_null", RiskTier.REVERSIBLE),
+    (
+        "ALTER TABLE t ADD CONSTRAINT ck CHECK (c > 0) NOT VALID;",
+        "add_constraint",
+        RiskTier.REVERSIBLE,
+    ),
+    ("CREATE OR REPLACE VIEW v AS SELECT 1;", "replace_view", RiskTier.REVERSIBLE),
+    ("GRANT SELECT ON tb_z TO r;", "grant", RiskTier.REVERSIBLE),
+    ("REVOKE SELECT ON tb_z FROM r;", "revoke", RiskTier.REVERSIBLE),
+    ("COMMENT ON TABLE tb_z IS 'x';", "comment", RiskTier.REVERSIBLE),
+    # lock_risky: semantically safe, but takes a lock that can stall a hot table
+    ("CREATE INDEX idx ON tb_order (placed_at);", "create_index", RiskTier.LOCK_RISKY),
+    ("ALTER TABLE t ADD COLUMN c text NOT NULL DEFAULT '';", "add_column", RiskTier.LOCK_RISKY),
+    ("ALTER TABLE t ADD COLUMN c text NOT NULL;", "add_column", RiskTier.LOCK_RISKY),
+    ("ALTER TABLE t ADD CONSTRAINT ck CHECK (c > 0);", "add_constraint", RiskTier.LOCK_RISKY),
+    ("ALTER TABLE t ALTER COLUMN c SET NOT NULL;", "set_not_null", RiskTier.LOCK_RISKY),
+    # destructive: destroys data or an object, recoverable from backup
+    ("DROP INDEX idx_x;", "drop_index", RiskTier.DESTRUCTIVE),
+    ("DROP VIEW v;", "drop_view", RiskTier.DESTRUCTIVE),
+    ("ALTER TABLE t DROP CONSTRAINT ck;", "drop_constraint", RiskTier.DESTRUCTIVE),
+    ("TRUNCATE tb_z;", "truncate", RiskTier.DESTRUCTIVE),
+    ("DELETE FROM tb_z WHERE id = 1;", "delete", RiskTier.DESTRUCTIVE),
+    ("UPDATE tb_z SET a = 1;", "update", RiskTier.DESTRUCTIVE),
+    # irreversible: destroys data with no down path that restores it
+    ("ALTER TABLE tb_user DROP COLUMN legacy_flag;", "drop_column", RiskTier.IRREVERSIBLE),
+    ("DROP TABLE tb_old;", "drop_table", RiskTier.IRREVERSIBLE),
+    ("DROP SCHEMA s;", "drop_schema", RiskTier.IRREVERSIBLE),
+    ("DROP SEQUENCE sq;", "drop_sequence", RiskTier.IRREVERSIBLE),
+]
+
+
+@pytest.mark.parametrize(("sql", "kind", "tier"), _TAXONOMY)
+def test_taxonomy_ast(sql: str, kind: str, tier: RiskTier) -> None:
+    (entry,) = classify_statements(sql)
+    assert (entry.kind, entry.tier) == (kind, tier)
+
+
+@pytest.mark.parametrize(("sql", "kind", "tier"), _TAXONOMY)
+def test_taxonomy_regex_backend_agrees(sql: str, kind: str, tier: RiskTier, monkeypatch) -> None:
+    """An install without the [ast] extra must classify identically."""
+    monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    (entry,) = classify_statements(sql)
+    assert (entry.kind, entry.tier) == (kind, tier)
+
+
+@pytest.mark.parametrize("sql", [case[0] for case in _TAXONOMY])
+def test_the_two_backends_produce_identical_entries(sql: str, monkeypatch) -> None:
+    """Parity on the whole entry, not just the tier.
+
+    `object` and `detail` are what the operator reads; an install without the
+    [ast] extra must not render a different plan.
+    """
+    via_ast = classify_statements(sql, migration="20260806120000", source="m.up.sql")
+    monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    via_regex = classify_statements(sql, migration="20260806120000", source="m.up.sql")
+    assert via_ast == via_regex, sql
+
+
+def test_alter_column_type_is_deliberately_unclassified() -> None:
+    """Narrowing is irreversible, widening is reversible, and preflight cannot tell.
+
+    The contract's own `v1-missing-tier.json` fixture uses `alter_column_type`
+    as its no-tier example. Guessing here would ship a confident wrong answer;
+    phase 10's type lattice is what resolves it.
+    """
+    (entry,) = classify_statements("ALTER TABLE t ALTER COLUMN c TYPE bigint;")
+    assert entry.kind == "alter_column_type"
+    assert entry.tier is None
+
+
+@pytest.mark.parametrize("force_regex", [False, True])
+def test_an_unrecognised_statement_still_produces_an_entry(force_regex, monkeypatch) -> None:
+    """Silently dropping a statement would make a dangerous migration read as empty."""
+    if force_regex:
+        monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    entries = classify_statements("DO $$ BEGIN NULL; END $$;")
+    assert entries, "an unclassifiable statement must not vanish"
+    assert all(e.tier is None for e in entries)
+
+
+@pytest.mark.parametrize("force_regex", [False, True])
+@pytest.mark.parametrize(
+    "sql",
+    ["BEGIN;", "COMMIT;", "SET search_path TO public;", "LOCK TABLE t;", "ANALYZE t;"],
+)
+def test_statements_that_change_nothing_are_not_entries(sql, force_regex, monkeypatch) -> None:
+    """Transaction/session control is not a schema change; emitting it would deny every deploy."""
+    if force_regex:
+        monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    assert classify_statements(sql) == []
+
+
+@pytest.mark.parametrize("force_regex", [False, True])
+def test_dollar_quoted_body_is_one_statement(force_regex, monkeypatch) -> None:
+    """A `;` inside a function body must not split the statement (regex backend)."""
+    if force_regex:
+        monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    sql = "CREATE OR REPLACE FUNCTION f() RETURNS int AS $$ SELECT 1; $$ LANGUAGE sql;"
+    entries = classify_statements(sql)
+    assert [(e.kind, e.tier) for e in entries] == [("replace_function", RiskTier.REVERSIBLE)]
+
+
+@pytest.mark.parametrize("force_regex", [False, True])
+def test_object_is_schema_qualified(force_regex, monkeypatch) -> None:
+    if force_regex:
+        monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    (entry,) = classify_statements("ALTER TABLE tb_user ADD COLUMN nickname text;")
+    assert entry.object == "public.tb_user.nickname"
+    (qualified,) = classify_statements("ALTER TABLE app.tb_user DROP COLUMN x;")
+    assert qualified.object == "app.tb_user.x"
+
+
+@pytest.mark.parametrize("force_regex", [False, True])
+def test_create_index_object_names_the_index(force_regex, monkeypatch) -> None:
+    if force_regex:
+        monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    (entry,) = classify_statements("CREATE INDEX idx_placed_at ON tb_order (placed_at);")
+    assert entry.object == "public.tb_order.idx_placed_at"
+
+
+@pytest.mark.parametrize("force_regex", [False, True])
+def test_multiple_objects_in_one_drop_each_get_an_entry(force_regex, monkeypatch) -> None:
+    if force_regex:
+        monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    entries = classify_statements("DROP TABLE a, b;")
+    assert [e.object for e in entries] == ["public.a", "public.b"]
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        ("COMMENT ON COLUMN app.tb_user.nickname IS 'x';", "app.tb_user.nickname"),
+        ("DROP TRIGGER trg ON app.tb_user;", "app.tb_user.trg"),
+        ("DROP FUNCTION app.f(int);", "app.f"),
+        ("DROP SCHEMA app;", "app"),
+    ],
+)
+@pytest.mark.parametrize("force_regex", [False, True])
+def test_three_part_names_keep_their_schema(sql, expected, force_regex, monkeypatch) -> None:
+    """`schema.table.child` must not report the *table* as the schema."""
+    if force_regex:
+        monkeypatch.setattr("confiture.core.change_set._HAS_PGLAST", False)
+    (entry,) = classify_statements(sql)
+    assert entry.object == expected
+
+
+def test_statement_order_is_preserved() -> None:
+    sql = "CREATE TABLE a (id int);\nDROP TABLE b;\nTRUNCATE c;"
+    assert [e.kind for e in classify_statements(sql)] == ["create_table", "drop_table", "truncate"]
+
+
+# --------------------------------------------------------------------------- #
+# Wire shape
+# --------------------------------------------------------------------------- #
+
+
+def test_contract_version_is_one() -> None:
+    assert CONTRACT_VERSION == 1
+    assert ChangeSet(changes=()).to_dict() == {"contract_version": 1, "changes": []}
+
+
+def test_entry_omits_absent_optional_fields() -> None:
+    """An absent `tier` is the contract's "unclassified"; a null would be noise."""
+    entry = ChangeEntry(kind="alter_column_type", object="public.t.c")
+    assert entry.to_dict() == {"kind": "alter_column_type", "object": "public.t.c"}
+
+
+def test_entry_serialises_the_tier_as_its_snake_case_wire_value() -> None:
+    entry = ChangeEntry(
+        kind="drop_column",
+        object="public.tb_user.legacy_flag",
+        migration="20260804120100",
+        tier=RiskTier.IRREVERSIBLE,
+        detail="DROP COLUMN legacy_flag",
+    )
+    assert entry.to_dict() == {
+        "kind": "drop_column",
+        "object": "public.tb_user.legacy_flag",
+        "migration": "20260804120100",
+        "tier": "irreversible",
+        "detail": "DROP COLUMN legacy_flag",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Discovery
+# --------------------------------------------------------------------------- #
+
+
+def test_build_change_set_reads_the_migrations_tree(tmp_path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260804120000_add_nickname.up.sql").write_text(
+        "ALTER TABLE tb_user ADD COLUMN nickname text;\n"
+    )
+    (migs / "20260804120100_drop_legacy.up.sql").write_text(
+        "ALTER TABLE tb_user DROP COLUMN legacy_flag;\n"
+    )
+
+    change_set = build_change_set(migs)
+
+    assert change_set.contract_version == CONTRACT_VERSION
+    assert [(c.kind, c.migration, c.tier) for c in change_set.changes] == [
+        ("add_column", "20260804120000", RiskTier.ADDITIVE),
+        ("drop_column", "20260804120100", RiskTier.IRREVERSIBLE),
+    ]
+
+
+def test_migration_is_the_version_prefix_not_the_filename(tmp_path) -> None:
+    """`issues[].migration` carries the bare version; the two must not disagree."""
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260804120000_add_nickname.up.sql").write_text("CREATE TABLE t (id int);\n")
+    (entry,) = build_change_set(migs).changes
+    assert entry.migration == "20260804120000"
+
+
+def test_python_migrations_are_listed_as_unclassified(tmp_path) -> None:
+    """Omitting them would shrink the set silently — the one failure this must prevent."""
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260804120200_backfill.py").write_text("# opaque to the SQL classifier\n")
+    (migs / "__init__.py").write_text("")
+
+    (entry,) = build_change_set(migs).changes
+
+    assert entry.tier is None
+    assert entry.migration == "20260804120200"
+    assert "20260804120200_backfill.py" in entry.object
+
+
+def test_empty_tree_is_a_classified_empty_set(tmp_path) -> None:
+    """`changes: []` means "looked, nothing to change" — never "did not look"."""
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    assert build_change_set(migs).to_dict() == {"contract_version": 1, "changes": []}
+
+
+def test_missing_tree_is_a_classified_empty_set(tmp_path) -> None:
+    assert build_change_set(tmp_path / "nope").to_dict() == {"contract_version": 1, "changes": []}
+
+
+def test_versions_filter_scopes_the_set(tmp_path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260804120000_a.up.sql").write_text("CREATE TABLE a (id int);\n")
+    (migs / "20260804120100_b.up.sql").write_text("CREATE TABLE b (id int);\n")
+    change_set = build_change_set(migs, versions=["20260804120100"])
+    assert [c.migration for c in change_set.changes] == ["20260804120100"]
+
+
+def test_worst_tier_over_the_set(tmp_path) -> None:
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260804120000_a.up.sql").write_text(
+        "CREATE TABLE a (id int);\nALTER TABLE a DROP COLUMN b;\n"
+    )
+    assert build_change_set(migs).worst_tier is RiskTier.IRREVERSIBLE
+
+
+def test_unreadable_sql_is_an_unclassified_entry_not_an_empty_set(tmp_path) -> None:
+    """A file the parser chokes on must deny, not read as "nothing changes"."""
+    migs = tmp_path / "migrations"
+    migs.mkdir()
+    (migs / "20260804120000_broken.up.sql").write_text("THIS IS NOT SQL AT ALL (((;\n")
+    change_set = build_change_set(migs)
+    assert change_set.changes
+    assert all(c.tier is None for c in change_set.changes)

--- a/tests/unit/test_preflight_change_set.py
+++ b/tests/unit/test_preflight_change_set.py
@@ -152,7 +152,26 @@ def test_text_mode_renders_the_worst_tier(runner, tmp_path):
         },
     )
     result = runner.invoke(runner_app(), ["migrate", "preflight", "--migrations-dir", str(migs)])
+    assert "risk:" in result.output.lower()
     assert "irreversible" in result.output.lower()
+
+
+def test_text_mode_counts_classified_changes_honestly(runner, tmp_path):
+    """Two of three changes carry a tier — saying "3 classified" would be the lie."""
+    migs = _migrations(
+        tmp_path,
+        {
+            "20260804120000_a.up.sql": (
+                "CREATE TABLE tb_new (id int);\n"
+                "ALTER TABLE tb_user DROP COLUMN legacy_flag;\n"
+                "ALTER TABLE tb_order ALTER COLUMN total TYPE bigint;\n"
+            )
+        },
+    )
+    result = runner.invoke(runner_app(), ["migrate", "preflight", "--migrations-dir", str(migs)])
+    output = " ".join(result.output.split())
+    assert "worst of 2 classified change(s) of 3" in output
+    assert "1 change(s) could not be classified" in output
 
 
 def test_the_against_payload_carries_the_change_set_too(runner, tmp_path):

--- a/tests/unit/test_preflight_change_set.py
+++ b/tests/unit/test_preflight_change_set.py
@@ -1,0 +1,197 @@
+"""`migrate preflight` emits the change set across the adapter seam (#197).
+
+The producer half of the cross-repo pact with fraisier-core#44: confiture emits
+the shapes, fraisier parses them. What is pinned here is the *payload* — the
+`change_set` envelope, the tier values, and the fact that adding it left
+`window_safe` (#154) exactly where it was.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.models.results import PreflightAgainstMigration, PreflightAgainstResult
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+def _migrations(tmp_path, files: dict[str, str]):
+    migs = tmp_path / "db" / "migrations"
+    migs.mkdir(parents=True)
+    for name, body in files.items():
+        (migs / name).write_text(body)
+    return migs
+
+
+def _preflight_json(runner, migs, *extra: str) -> dict:
+    result = runner.invoke(
+        runner_app(),
+        ["migrate", "preflight", "--migrations-dir", str(migs), "--format", "json", *extra],
+    )
+    assert result.exit_code in (0, 7), result.output
+    return json.loads(result.stdout)
+
+
+def runner_app():
+    from confiture.cli.main import app
+
+    return app
+
+
+def test_preflight_emits_a_versioned_change_set(runner, tmp_path):
+    migs = _migrations(
+        tmp_path,
+        {
+            "20260804120000_add_nickname.up.sql": "ALTER TABLE tb_user ADD COLUMN nickname text;\n",
+            "20260804120000_add_nickname.down.sql": "ALTER TABLE tb_user DROP COLUMN nickname;\n",
+        },
+    )
+
+    payload = _preflight_json(runner, migs)
+
+    assert payload["change_set"] == {
+        "contract_version": 1,
+        "changes": [
+            {
+                "kind": "add_column",
+                "object": "public.tb_user.nickname",
+                "migration": "20260804120000",
+                "tier": "additive",
+                "detail": "ADD COLUMN nickname NULL",
+            }
+        ],
+    }
+
+
+def test_an_empty_tree_is_a_classified_empty_set(runner, tmp_path):
+    """`changes: []` means "looked, nothing to change" — an absent key would mean "did not look"."""
+    migs = _migrations(tmp_path, {})
+    payload = _preflight_json(runner, migs)
+    assert payload["change_set"] == {"contract_version": 1, "changes": []}
+
+
+def test_a_destructive_change_carries_its_tier(runner, tmp_path):
+    migs = _migrations(
+        tmp_path,
+        {"20260804120100_drop.up.sql": "ALTER TABLE tb_user DROP COLUMN legacy_flag;\n"},
+    )
+    payload = _preflight_json(runner, migs)
+    (change,) = payload["change_set"]["changes"]
+    assert change["tier"] == "irreversible"
+    assert change["object"] == "public.tb_user.legacy_flag"
+
+
+def test_an_unclassifiable_change_omits_the_tier(runner, tmp_path):
+    """Absent is the contract's "unclassified"; the consumer denies on it."""
+    migs = _migrations(
+        tmp_path,
+        {"20260804120300_widen.up.sql": "ALTER TABLE tb_order ALTER COLUMN total TYPE bigint;\n"},
+    )
+    payload = _preflight_json(runner, migs)
+    (change,) = payload["change_set"]["changes"]
+    assert change["kind"] == "alter_column_type"
+    assert "tier" not in change
+
+
+def test_a_python_migration_appears_as_an_unclassified_entry(runner, tmp_path):
+    migs = _migrations(tmp_path, {"20260804120200_backfill.py": "# opaque\n"})
+    payload = _preflight_json(runner, migs)
+    (change,) = payload["change_set"]["changes"]
+    assert change["kind"] == "python_migration"
+    assert "tier" not in change
+    # …and it still trips the pinned window-safety verdict.
+    assert payload["window_safe"] is False
+
+
+def test_changes_stay_in_migration_order(runner, tmp_path):
+    migs = _migrations(
+        tmp_path,
+        {
+            "20260804120000_a.up.sql": "ALTER TABLE tb_user ADD COLUMN nickname text;\n",
+            "20260804120050_b.up.sql": "CREATE INDEX idx_placed_at ON tb_order (placed_at);\n",
+            "20260804120100_c.up.sql": "ALTER TABLE tb_user DROP COLUMN legacy_flag;\n",
+        },
+    )
+    payload = _preflight_json(runner, migs)
+    assert [(c["migration"], c["tier"]) for c in payload["change_set"]["changes"]] == [
+        ("20260804120000", "additive"),
+        ("20260804120050", "lock_risky"),
+        ("20260804120100", "irreversible"),
+    ]
+
+
+def test_change_set_migration_matches_the_issue_migration_format(runner, tmp_path):
+    """Two `migration` fields in one payload disagreeing on format would be a nasty bug."""
+    migs = _migrations(
+        tmp_path,
+        {
+            "20260804120050_idx.up.sql": (
+                "CREATE INDEX CONCURRENTLY idx_placed_at ON tb_order (placed_at);\n"
+            )
+        },
+    )
+    payload = _preflight_json(runner, migs)
+    (change,) = payload["change_set"]["changes"]
+    assert change["migration"] == "20260804120050"
+
+
+def test_text_mode_renders_the_worst_tier(runner, tmp_path):
+    migs = _migrations(
+        tmp_path,
+        {
+            "20260804120000_a.up.sql": (
+                "CREATE TABLE tb_new (id int);\nALTER TABLE tb_user DROP COLUMN legacy_flag;\n"
+            )
+        },
+    )
+    result = runner.invoke(
+        runner_app(), ["migrate", "preflight", "--migrations-dir", str(migs)]
+    )
+    assert "irreversible" in result.output.lower()
+
+
+def test_the_against_payload_carries_the_change_set_too(runner, tmp_path):
+    migs = _migrations(
+        tmp_path,
+        {"20260804120100_drop.up.sql": "ALTER TABLE tb_user DROP COLUMN legacy_flag;\n"},
+    )
+    against_result = PreflightAgainstResult(
+        migrations=[PreflightAgainstMigration("20260804120100", "drop", True)],
+        against_url="postgresql://localhost/preflight",
+    )
+    session = MagicMock()
+    session.__enter__ = lambda s: session
+    session.__exit__ = MagicMock(return_value=False)
+    session.run_against.return_value = against_result
+
+    with patch(
+        "confiture.cli.commands.migrate_analysis.MigratorSession", return_value=session
+    ) as patched:
+        result = runner.invoke(
+            runner_app(),
+            [
+                "migrate",
+                "preflight",
+                "--migrations-dir",
+                str(migs),
+                "--against",
+                "postgresql://localhost/preflight",
+                "--format",
+                "json",
+            ],
+        )
+
+    # A stale patch target does not announce itself: the real session would have
+    # tried a connection and the MagicMock would have read as a clean replay.
+    assert patched.called, "the MigratorSession double was never used"
+    assert result.exit_code in (0, 7), result.output
+    payload = json.loads(result.stdout)
+    (change,) = payload["change_set"]["changes"]
+    assert change["tier"] == "irreversible"

--- a/tests/unit/test_preflight_change_set.py
+++ b/tests/unit/test_preflight_change_set.py
@@ -151,9 +151,7 @@ def test_text_mode_renders_the_worst_tier(runner, tmp_path):
             )
         },
     )
-    result = runner.invoke(
-        runner_app(), ["migrate", "preflight", "--migrations-dir", str(migs)]
-    )
+    result = runner.invoke(runner_app(), ["migrate", "preflight", "--migrations-dir", str(migs)])
     assert "irreversible" in result.output.lower()
 
 

--- a/tests/unit/test_replica_corpus.py
+++ b/tests/unit/test_replica_corpus.py
@@ -3,45 +3,105 @@
 End-to-end through the classifier + verdict, asserting safety, severity (under
 replicas-declared), and multi-step remediation — the regression guard against
 classifier/verdict drift the issue requires.
+
+Since 0.43.0 each row also pins its **risk tier** (#197). The two verdicts answer
+different questions and are deliberately independent: replica safety is
+two-version forward-compatibility, the tier is what the change does to the data.
+`RENAME COLUMN` is the row that shows it — replica-unsafe, yet `reversible`.
+Pinning both here means a change that moves one without the other is visible.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from confiture.core.change_set import classify_statements
 from confiture.core.replica.classifier import OperationClassifier
 from confiture.core.replica.safety import classify_replica_safety, replica_severity
+from confiture.core.risk_tier import RiskTier
 
-# (sql, expected_safety, expected_severity_with_replicas)
+# (sql, expected_safety, expected_severity_with_replicas, expected_risk_tier)
 CORPUS = {
-    "add_column_nullable": ("ALTER TABLE t ADD COLUMN c int;", "safe", None),
+    "add_column_nullable": ("ALTER TABLE t ADD COLUMN c int;", "safe", None, RiskTier.ADDITIVE),
     "add_column_not_null_default": (
         "ALTER TABLE t ADD COLUMN c int NOT NULL DEFAULT 0;",
         "unsafe",
         "error",
+        RiskTier.LOCK_RISKY,
     ),
-    "drop_column": ("ALTER TABLE t DROP COLUMN c;", "unsafe", "error"),
-    "rename_column": ("ALTER TABLE t RENAME COLUMN a TO b;", "unsafe", "error"),
-    "change_type": ("ALTER TABLE t ALTER COLUMN c TYPE bigint;", "unsafe", "error"),
+    "drop_column": ("ALTER TABLE t DROP COLUMN c;", "unsafe", "error", RiskTier.IRREVERSIBLE),
+    "rename_column": (
+        "ALTER TABLE t RENAME COLUMN a TO b;",
+        "unsafe",
+        "error",
+        RiskTier.REVERSIBLE,
+    ),
+    "change_type": ("ALTER TABLE t ALTER COLUMN c TYPE bigint;", "unsafe", "error", None),
     "add_constraint_immediate": (
         "ALTER TABLE t ADD CONSTRAINT ck CHECK (c > 0);",
         "unsafe",
         "error",
+        RiskTier.LOCK_RISKY,
     ),
     "add_constraint_not_valid": (
         "ALTER TABLE t ADD CONSTRAINT ck CHECK (c > 0) NOT VALID;",
         "safe",
         None,
+        RiskTier.REVERSIBLE,
     ),
-    "create_index": ("CREATE INDEX idx ON t (c);", "unsafe", "error"),
-    "create_index_concurrently": ("CREATE INDEX CONCURRENTLY idx ON t (c);", "safe", None),
-    "create_table": ("CREATE TABLE t (id int);", "safe", None),
+    "create_index": ("CREATE INDEX idx ON t (c);", "unsafe", "error", RiskTier.LOCK_RISKY),
+    "create_index_concurrently": (
+        "CREATE INDEX CONCURRENTLY idx ON t (c);",
+        "safe",
+        None,
+        RiskTier.ADDITIVE,
+    ),
+    "create_table": ("CREATE TABLE t (id int);", "safe", None, RiskTier.ADDITIVE),
 }
 
 
 @pytest.mark.parametrize("name", list(CORPUS))
+def test_window_safe_still_derives_only_from_replica_findings(name: str, tmp_path) -> None:
+    """#154's contract, re-proven end-to-end now that `change_set` rides beside it.
+
+    `window_safe` is true iff no ``PFLIGHT_REPLICA_*`` finding is present. Adding
+    the risk tier must not have moved it in either direction — including for
+    `rename_column`, where the tier (`reversible`) and the verdict (unsafe)
+    deliberately disagree.
+    """
+    import json
+
+    from typer.testing import CliRunner
+
+    from confiture.cli.main import app
+
+    sql, safety, _sev, _tier = CORPUS[name]
+    migrations = tmp_path / name
+    migrations.mkdir()
+    (migrations / "20260806120000_case.up.sql").write_text(sql)
+
+    result = CliRunner().invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(migrations), "--format", "json"],
+    )
+    payload = json.loads(result.stdout)
+
+    replica_findings = [i for i in payload["issues"] if i["code"].startswith("PFLIGHT_REPLICA_")]
+    assert payload["window_safe"] is (not replica_findings), name
+    assert payload["window_safe"] is (safety == "safe"), name
+
+
+@pytest.mark.parametrize("name", list(CORPUS))
+def test_corpus_risk_tier(name: str) -> None:
+    """The #197 tier for each matrix row."""
+    sql, _safety, _sev, tier = CORPUS[name]
+    (entry,) = classify_statements(sql)
+    assert entry.tier is tier, name
+
+
+@pytest.mark.parametrize("name", list(CORPUS))
 def test_corpus_row(name: str) -> None:
-    sql, safety, sev = CORPUS[name]
+    sql, safety, sev, _tier = CORPUS[name]
     [op] = OperationClassifier().classify(sql)
     verdict = classify_replica_safety(op)
     assert verdict.safety == safety, name

--- a/tests/unit/test_risk_tier.py
+++ b/tests/unit/test_risk_tier.py
@@ -1,0 +1,58 @@
+"""The risk-tier taxonomy that crosses the migration-adapter seam (#197).
+
+The five tiers, their ``snake_case`` wire values and their severity ordering are
+a ratified cross-repo contract (fraisier-core#44,
+``docs/proposals/migration-risk-contract.md``). These tests pin them from
+confiture's side so a rename fails here rather than silently in the consumer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.risk_tier import RiskTier, worst_tier
+
+
+def test_the_wire_values_are_exactly_the_five_contract_tiers():
+    assert [t.value for t in RiskTier] == [
+        "additive",
+        "reversible",
+        "lock_risky",
+        "destructive",
+        "irreversible",
+    ]
+
+
+def test_the_declaration_order_is_least_to_most_severe():
+    """`additive < reversible < lock_risky < destructive < irreversible`."""
+    ordered = list(RiskTier)
+    assert sorted(ordered, key=lambda t: t.severity) == ordered
+
+
+@pytest.mark.parametrize(
+    ("tiers", "expected"),
+    [
+        ([RiskTier.ADDITIVE, RiskTier.IRREVERSIBLE], RiskTier.IRREVERSIBLE),
+        ([RiskTier.DESTRUCTIVE, RiskTier.LOCK_RISKY], RiskTier.DESTRUCTIVE),
+        ([RiskTier.ADDITIVE], RiskTier.ADDITIVE),
+    ],
+)
+def test_worst_tier_picks_the_most_severe(tiers, expected):
+    assert worst_tier(tiers) is expected
+
+
+def test_worst_tier_of_nothing_is_none():
+    assert worst_tier([]) is None
+
+
+def test_worst_tier_skips_unclassified_entries():
+    """An unclassifiable change must not mask a classified one.
+
+    Per the plan's D4 ruling: `unknown` never dominates the aggregate, or one
+    unreadable `.py` migration would conceal a `DROP TABLE`.
+    """
+    assert worst_tier([None, RiskTier.IRREVERSIBLE, None]) is RiskTier.IRREVERSIBLE
+
+
+def test_worst_tier_of_only_unclassified_is_none():
+    assert worst_tier([None, None]) is None

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql-confiture"
-version = "0.42.0"
+version = "0.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

`migrate preflight` now says **what kind of risk** each pending change carries,
not just whether the migration set is window-safe. The tier crosses the
migration-adapter seam as typed data under the contract ratified with
fraiseql/fraisier-core#44.

```json
"change_set": {
  "contract_version": 1,
  "changes": [
    { "kind": "drop_column", "object": "public.tb_user.legacy_flag",
      "migration": "20260804120100", "tier": "irreversible",
      "detail": "DROP COLUMN legacy_flag" }
  ]
}
```

Five tiers, `snake_case`, least- to most-severe: `additive` < `reversible` <
`lock_risky` < `destructive` < `irreversible`. That order picks the worst tier in
a set and sorts a plan render — it is not how policy decisions are made.

## The three properties that carry the safety

1. **The object wrapper is load-bearing.** `{"changes": []}` means "classified,
   nothing to change"; an *absent* `change_set` means "did not classify" and the
   consumer denies. A bare array conflates the two, and the conflation resolves
   the dangerous way.
2. **No statement is ever dropped.** A statement outside the taxonomy still
   produces an entry with no `tier`. A shorter list of fully-classified changes
   would read as a *cleaner* plan than the truth.
3. **No guessed tiers.** `ALTER COLUMN … TYPE` is reversible when widening and
   irreversible when narrowing; preflight has no connection and cannot tell, so
   it emits no tier. A `.py` migration likewise. The contract's own
   `v1-missing-tier.json` fixture is exactly this case.

## `window_safe` is untouched

It answers a different question, and the two verdicts are independent by design —
`RENAME COLUMN` is replica-*unsafe* and risk-tier `reversible`. Re-proven
end-to-end over the replica corpus, which now pins both verdicts per row.

The change set deliberately does **not** reuse `core/replica/classifier.py`:
that classifier reports only the operations in its safety matrix, and
`classify_replica_safety` returns `depends` for anything else — which yields a
`PFLIGHT_REPLICA_UNCLASSIFIED` finding and flips `window_safe` to false. Widening
it would have moved a pinned cross-repo field as a side effect. `core/change_set.py`
walks the statements itself; the cost is one extra parse of files already read.
ARCHITECTURE.md Decision 9 records the trade.

## Contract surface

- `_preflight_defs.schema.json` gains `ChangeSet` / `SchemaChange`, pinning the
  five tier values and the `contract_version` rule. Negative tests prove the
  schema bites: a bare array, a string envelope, a missing `contract_version`, a
  tier outside the five and an undeclared entry field are all rejected.
- fraisier-core's eight golden fixtures are vendored under
  `tests/fixtures/preflight-contract/` — confiture's CI cannot see the sibling
  repo, so producer drift had nowhere to fail. Confiture emits all four
  producible shapes exactly.
- **No minimum-version floor bump.** `migrate preflight` is on the adapter's
  surface and its shape did move, but the field's absence is meaningful by
  contract, so raising the floor would delete the fail-safe path. The adapter
  gates the `risk_tier` capability on a detected version ≥ 0.43.0 instead —
  recorded in a new capability table.

## Two findings filed, not fixed

- `window_safe` reads `true` for `DROP TABLE`: the replica classifier silently
  drops operations outside its matrix, so no `PFLIGHT_REPLICA_*` finding is
  emitted. Pre-existing; fixing it means changing `window_safe`'s value, which
  this release promised not to do.
- The long-standing local-vs-CI collection gap (~2900 tests) is one module
  parametrizing over every `.sql` file in the working tree, not missing coverage.

## Verification

- 10480 passed / 64 skipped — full suite against a local postgres
- `ruff check` + `ruff format --check` clean, `ty check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- Archaeology grep over `python/` empty

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
