### PR TITLE
0.44.0 — preflight depth (#199) + window_safe fail-open fix (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,92 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-08-06
+
+`migrate preflight` stops certifying migrations it never actually read, and
+starts saying what a change costs in locks and whether it rewrites the table
+(#206, #199).
+
+### Fixed
+
+- ⚠️ **`window_safe` returned `true` for `DROP TABLE`** (#206). The replica
+  classifier mapped four AST node types and returned *nothing* for anything
+  else; the regex backend mirrored it. Because `window_safe` is computed from
+  the *presence* of `PFLIGHT_REPLICA_*` findings, "nothing classified" and
+  "nothing unsafe" were indistinguishable, so `DROP TABLE`, `TRUNCATE`,
+  `DROP VIEW`, `REVOKE`, `SET NOT NULL`, `RENAME TO` and every other statement
+  outside the matrix certified as window-safe.
+
+  An unrecognised statement now falls back to `Other`, which routes to
+  `PFLIGHT_REPLICA_UNCLASSIFIED` — a warning, so opacity denies without
+  hard-blocking — and the matrix was widened in lockstep with the verdict table
+  so the fix does not trade a false-safe for a wave of false-unsafes.
+
+  > **This is a behaviour change to a pinned cross-repo field.** Migrations that
+  > previously reported `window_safe: true` will start reporting `false` if they
+  > contain any of the statement classes above. They were never window-safe. See
+  > the advisory in
+  > [`docs/reference/fraisier-adapter-contract.md`](docs/reference/fraisier-adapter-contract.md);
+  > the `window_safe` capability floor moves to 0.44.0.
+
+  Unlike the pglast-8 defect of the same shape (#192, fixed in 0.39.0), this one
+  was **not conditional** — every release from 0.23.0 to 0.43.0 was affected, on
+  both parser backends.
+
+- The replica classifier's statement splitter was a bare `split(";")` that
+  shredded dollar-quoted function bodies. Harmless while fragments were dropped;
+  once they became `Other` it would have raised a spurious finding per fragment.
+  Both statement walkers now share the dollar-quote-aware splitter in
+  `core/sql_statements.py`.
+
+- `ALTER TYPE … ADD VALUE` is documented as becoming transaction-block-safe in
+  PostgreSQL **12**, not 16.
+
+### Added
+
+- **Seven `PFLIGHT_REPLICA_*` codes** for the newly-classified statements:
+  `DROP_TABLE`, `DROP_OBJECT`, `TRUNCATE`, `REVOKE`, `SET_NOT_NULL`,
+  `RENAME_OBJECT`, `REPLACE_OBJECT`. Additions only — the namespace policy
+  (#154) allows them, and a consumer gating on the prefix needs no change.
+
+- **Lock and rewrite modelling** (#199), `core/lock_profile.py`: each change
+  carries its lock level, whether it rewrites the heap, what it blocks, and a
+  coarse duration class (`metadata` / `seconds` / `minutes+`) — never a
+  predicted number. `migrate preflight`'s text render calls out how many changes
+  rewrite the table and annotates each risky change with its cost.
+
+  The two version-dependent rows are explicit: `ADD COLUMN … DEFAULT` stopped
+  rewriting in PG 11, and PG 12 can prove `SET NOT NULL` from a valid `CHECK`
+  instead of scanning. An unknown server version takes the older reading.
+
+- **Narrowing-vs-widening analysis** (#199), `core/type_lattice.py`: integer and
+  float widths, `varchar`/`char` lengths with `text` at the top, `numeric(p,s)`
+  precision *and* scale, and the temporal ladder. `timestamp` ↔ `timestamptz` is
+  lateral, not a width move. Semantic direction and heap rewrite are answered
+  separately because they disagree — `varchar(50)` → `text` is widening *and*
+  rewrite-free.
+
+- **DB-refined preflight** (#199), `core/schema_facts.py`: `migrate preflight
+  --against` now reads the target's current column types and server version
+  before replaying. That supplies the one fact `ALTER TABLE … ALTER COLUMN …
+  TYPE` never states — the *source* type — so a type change finally gets a tier:
+  narrowing and lateral are `irreversible`, widening is `lock_risky` when it
+  rewrites and `reversible` when it does not. `ADD COLUMN … NOT NULL DEFAULT`
+  drops to `additive` on a known PostgreSQL 11+.
+
+  Strictly additive: collection never raises, and without a reachable target
+  every answer is byte-identical to the filesystem-only path.
+
+### Unchanged
+
+- The `change_set` **wire shape** is untouched. The lock profile is deliberately
+  *not* a new key: the entry shape is the ratified fraisier-core#44 pact, pinned
+  byte-for-byte by golden fixtures in both repositories, and adding a field there
+  is a co-ordinated change with a `contract_version` decision. The lock facts
+  reach an operator through `detail` (free-form by specification) and a library
+  caller through `ChangeEntry.lock`.
+- `contract_version` stays at `1`.
+
 ## [0.43.0] - 2026-08-06
 
 `migrate preflight` now says **what kind of risk** each pending change carries,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ starts saying what a change costs in locks and whether it rewrites the table
   > the advisory in
   > [`docs/reference/fraisier-adapter-contract.md`](docs/reference/fraisier-adapter-contract.md);
   > the `window_safe` capability floor moves to 0.44.0.
+  >
+  > **The highest-volume change in practice is `CREATE OR REPLACE`** of a view,
+  > function or procedure. It now reports `depends` — a warning, never an error,
+  > but enough to make `window_safe` false. Confiture cannot tell whether a
+  > replacement body stays compatible with readers on the old version: a changed
+  > view column list or function return shape breaks them, an identical body does
+  > not, and the statement says which only by being read. That is the contract's
+  > "unsafe **or uninspectable**" case, and claiming otherwise would recreate the
+  > bug class this release fixes. Projects that replace functions on every
+  > migration should expect this and gate on the tier or the issue codes rather
+  > than treating `window_safe` as a build-breaker.
 
   Unlike the pglast-8 defect of the same shape (#192, fixed in 0.39.0), this one
   was **not conditional** — every release from 0.23.0 to 0.43.0 was affected, on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Confiture Development Guide
 
 **Project**: Confiture - PostgreSQL Migrations, Sweetly Done 🍓
-**Version**: 0.43.0
+**Version**: 0.44.0
 **Last Updated**: 2026-08-06
 **Current Status**: Production-Ready
 
@@ -969,7 +969,7 @@ When stuck, ask:
 ---
 
 **Last Updated**: 2026-08-06
-**Version**: 0.43.0
+**Version**: 0.44.0
 
 ---
 

--- a/docs/reference/fraisier-adapter-contract.md
+++ b/docs/reference/fraisier-adapter-contract.md
@@ -27,8 +27,14 @@ a capability the installed binary cannot fulfil turns every deploy into a denial
 
 | Capability | From | Field | Absent means |
 |------------|------|-------|--------------|
-| `window_safe` | 0.23.0 (#154) | top-level `window_safe` on `preflight` | cannot certify → blocked |
-| `risk_tier` | **0.43.0** (#197) | `change_set` on `preflight` | did not classify → denied |
+| `window_safe` | **0.44.0** (#206) | top-level `window_safe` on `preflight` | cannot certify → blocked |
+| `risk_tier` | 0.43.0 (#197) | `change_set` on `preflight` | did not classify → denied |
+
+> The `window_safe` **field** has existed since 0.23.0 (#154) and its shape has
+> not moved. The floor is 0.44.0 because before that release the verdict could be
+> `true` for a migration that is not window-safe — see the advisory under
+> [Typed verdict](#typed-verdict-top-level-window_safe). An older confiture is not
+> *less capable* here, it is *misread*, which is the case a floor exists for.
 
 ## Invocation shape
 
@@ -126,7 +132,18 @@ The complete namespace the lint can emit:
 | `PFLIGHT_REPLICA_CHANGE_TYPE` | `ALTER COLUMN ... TYPE` |
 | `PFLIGHT_REPLICA_ADD_CONSTRAINT` | immediate `ADD CONSTRAINT` |
 | `PFLIGHT_REPLICA_CREATE_INDEX` | non-concurrent `CREATE INDEX` |
+| `PFLIGHT_REPLICA_DROP_TABLE` | `DROP TABLE` (0.44.0) |
+| `PFLIGHT_REPLICA_DROP_OBJECT` | `DROP` of a view, sequence, function, type, schema, extension (0.44.0) |
+| `PFLIGHT_REPLICA_TRUNCATE` | `TRUNCATE` (0.44.0) |
+| `PFLIGHT_REPLICA_REVOKE` | `REVOKE` (0.44.0) |
+| `PFLIGHT_REPLICA_SET_NOT_NULL` | `ALTER COLUMN … SET NOT NULL` (0.44.0) |
+| `PFLIGHT_REPLICA_RENAME_OBJECT` | `RENAME TO` / `ALTER TYPE … RENAME VALUE` (0.44.0) |
+| `PFLIGHT_REPLICA_REPLACE_OBJECT` | `CREATE OR REPLACE` view/function/procedure — always a warning (0.44.0) |
 | `PFLIGHT_REPLICA_UNCLASSIFIED` | dynamic / unparseable DDL (always a warning) |
+
+The seven codes marked 0.44.0 were **added**, which the namespace policy allows;
+nothing was renamed or removed. A consumer gating on the `PFLIGHT_REPLICA_`
+prefix — as fraisier does — needs no change to consume them.
 
 This set is a **stability commitment**: existing codes are **never renamed or
 removed** (that is a breaking change requiring a major version bump and a
@@ -187,8 +204,30 @@ migrate step, before any traffic moves.
 > Fixed in **0.39.0** (#192): the members are resolved by name, a required CI
 > leg runs the classifier suites on both ends of the supported pglast range, and
 > a partially-resolvable enum surface now degrades to the regex backend instead
-> of under-reporting. Consumers relying on `window_safe` as an authoritative
-> allow should be on **≥ 0.39.0**.
+> of under-reporting.
+
+> ⚠️ **Correctness advisory — false `window_safe: true` for whole statement
+> classes before 0.44.0.** The replica classifier mapped four AST node types and
+> returned *nothing* for anything else; the regex backend mirrored it. So
+> `DROP TABLE`, `TRUNCATE`, `DROP VIEW`, `REVOKE`, `SET NOT NULL`, `RENAME TO`
+> and every other statement outside a seven-operation matrix classified to `[]` —
+> **no `PFLIGHT_REPLICA_*` finding was emitted, and `window_safe` came back
+> `true`.**
+>
+> This is the same failure shape as the advisory above, reached a different way,
+> and unlike that one it is **not conditional**: every release from 0.23.0 to
+> 0.43.0 is affected, on both parser backends, on every PostgreSQL version.
+>
+> Fixed in **0.44.0** (#206): an unrecognised statement now falls back to
+> `Other`, which routes to `PFLIGHT_REPLICA_UNCLASSIFIED` and denies. The matrix
+> was widened at the same time so the fix does not trade a false-safe for a wave
+> of false-unsafes — additive statements (`CREATE …`, `GRANT`, `COMMENT`,
+> `ALTER TYPE … ADD VALUE`, DML, `DROP INDEX`) classify as safe and emit nothing.
+>
+> **Expect previously-green migrations to start reporting `window_safe: false`.**
+> That is the correction, not a regression: those migrations were never
+> window-safe. Consumers relying on `window_safe` as an authoritative allow must
+> be on **≥ 0.44.0**.
 
 So `true` means "every pending op is forward-compatible"; `false` means "unsafe
 or uninspectable". The fraisier gate consumes it as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fraiseql-confiture"
-version = "0.43.0"
+version = "0.44.0"
 description = "PostgreSQL schema evolution with built-in multi-agent coordination 🍓"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/confiture/cli/commands/migrate_analysis.py
+++ b/python/confiture/cli/commands/migrate_analysis.py
@@ -31,6 +31,7 @@ from confiture.core.connection import create_connection, load_config, open_conne
 from confiture.core.differ import SchemaDiffer
 from confiture.core.migration_generator import MigrationGenerator
 from confiture.core.migrator import Migrator
+from confiture.core.schema_facts import SchemaFacts
 from confiture.core.validation.context import ValidationContext
 from confiture.core.validation.registry import (
     ValidationCheck,
@@ -1722,6 +1723,35 @@ def _target_tracking_table_state(session: MigratorSession, table: str) -> tuple[
         return (False, True)
 
 
+def _collect_preflight_facts(session: MigratorSession) -> SchemaFacts:
+    """Read the target's column types and server version (#199). Best-effort.
+
+    The ``--against`` database is seeded from the production schema, which makes
+    it the honest source for the *current* type of a column a migration is about
+    to alter — the one fact ``ALTER TABLE … ALTER COLUMN … TYPE`` never states.
+    Read before the replay, so it describes the schema being migrated *from*.
+
+    Any failure yields empty facts and every consumer falls back to the static
+    answer. Losing the refinement is acceptable; failing a preflight over it is
+    not.
+    """
+    import contextlib
+
+    from confiture.core.schema_facts import collect_schema_facts  # noqa: PLC0415
+
+    conn = getattr(session, "_conn", None)
+    if conn is None:
+        return SchemaFacts()
+    try:
+        facts = collect_schema_facts(conn)
+    except Exception:  # noqa: BLE001 — best-effort; never fail preflight for a refinement
+        facts = SchemaFacts()
+    # Leave no aborted transaction behind for run_against.
+    with contextlib.suppress(Exception):
+        conn.rollback()
+    return facts
+
+
 def _preflight_replica_policy(config: Path | None, env_name: str | None) -> tuple[bool, bool]:
     """Best-effort (has_replicas, bypass) for the replica lint, never connects.
 
@@ -1828,11 +1858,36 @@ def _display_change_set(change_set: Any, cons: Any) -> None:
             f"  [yellow]⚠️  {unclassified} change(s) could not be classified — "
             "a consumer gating on risk will refuse them[/yellow]"
         )
+    # #199: a full-table rewrite is the thing that turns a deploy into an
+    # outage, and it is not recoverable from the tier — an `additive`
+    # `ADD COLUMN … DEFAULT` rewrites below PG 11, a `destructive` `DROP INDEX`
+    # does not. Called out separately for that reason.
+    rewrites = [c for c in change_set.changes if c.lock is not None and c.lock.rewrites_table]
+    if rewrites:
+        cons.print(
+            f"  [yellow]⏳ {len(rewrites)} change(s) rewrite the table[/yellow] — "
+            "plan for a maintenance window proportional to its size"
+        )
+
     for change in change_set.changes:
         if change.tier is None or change.tier.severity == 0:
             continue  # additive changes are the floor; they do not need a line
         color = _CHANGE_SET_TIER_COLOR.get(change.tier.value, "yellow")
-        cons.print(f"  [{color}]{change.tier.value}[/{color}] {change.kind} {change.object}")
+        cost = _lock_annotation(change.lock)
+        cons.print(f"  [{color}]{change.tier.value}[/{color}] {change.kind} {change.object}{cost}")
+
+
+def _lock_annotation(lock: Any) -> str:
+    """`  [rewrite, minutes+]` — what the change costs, or nothing if unknown (#199)."""
+    if lock is None:
+        return ""
+    parts = ["rewrite"] if lock.rewrites_table else []
+    if lock.blocks_writes and not lock.blocks_reads:
+        parts.append("blocks writes")
+    elif lock.blocks_reads:
+        parts.append("blocks reads+writes")
+    parts.append(lock.duration.value)
+    return f"  [dim]({', '.join(parts)})[/dim]"
 
 
 def _display_against_result(
@@ -2293,6 +2348,8 @@ def migrate_preflight(
 
     target_tracking_empty = False
     target_tracking_exists = True
+    # Empty unless the --against connection yields facts (#199).
+    schema_facts = SchemaFacts()
     # Resolved once and threaded through the override, the probe and the hint
     # (#190) — three sites that previously each spelled the default by hand.
     target_tracking_table = _preflight_tracking_table(config)
@@ -2311,6 +2368,11 @@ def migrate_preflight(
             target_tracking_exists, target_tracking_empty = _target_tracking_table_state(
                 session, target_tracking_table
             )
+            # #199: read the current column types and server version BEFORE the
+            # replay, so `ALTER COLUMN … TYPE` can be reasoned about as widening
+            # or narrowing. Strictly additive — failure leaves `schema_facts`
+            # empty and every answer falls back to the static one.
+            schema_facts = _collect_preflight_facts(session)
             against_result = session.run_against(
                 pending_files,
                 against_url=against,
@@ -2368,7 +2430,7 @@ def migrate_preflight(
     }
     exit_code = preflight_exit_code(summary, strict=strict)
 
-    change_set = build_change_set(migrations_dir)
+    change_set = build_change_set(migrations_dir, facts=schema_facts)
 
     if format_type == "json":
         payload: dict[str, Any] = {
@@ -2377,8 +2439,10 @@ def migrate_preflight(
             "window_safe": is_window_safe(all_issues),
             "summary": summary,
             "issues": [i.to_dict() for i in all_issues],
-            # #197: same change set as the no-`--against` path — it is static
-            # analysis, so replaying against a database does not change it.
+            # #197: the same change set as the no-`--against` path, plus the
+            # #199 refinements the target database made possible (current column
+            # types, server version). Absent those, byte-identical to the static
+            # path.
             "change_set": change_set.to_dict(),
         }
         if dependent_report is not None:

--- a/python/confiture/core/_pglast_enums.py
+++ b/python/confiture/core/_pglast_enums.py
@@ -71,6 +71,7 @@ REQUIRED_MEMBERS: Final[dict[str, tuple[str, ...]]] = {
         "OBJECT_POLICY",
         "OBJECT_EXTENSION",
         "OBJECT_DOMAIN",
+        "OBJECT_RULE",
     ),
 }
 

--- a/python/confiture/core/change_set.py
+++ b/python/confiture/core/change_set.py
@@ -37,6 +37,7 @@ from confiture.core._pglast_enums import enums_are_usable
 from confiture.core._pglast_enums import member as _pg_member
 from confiture.core.idempotency.ast_detector import is_pglast_available
 from confiture.core.risk_tier import RiskTier, worst_tier
+from confiture.core.sql_statements import split_statements
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -1324,64 +1325,5 @@ def _split_object_list(raw: str) -> list[str]:
 
 
 def _split_statements(sql: str) -> list[str]:
-    """Split on top-level ``;``, respecting dollar-quoted bodies, literals and comments.
-
-    The naive ``sql.split(";")`` the replica classifier uses is fine for the
-    single-statement DDL its matrix covers, but it shreds a ``CREATE FUNCTION``
-    body — which this module has to classify as one statement.
-    """
-    statements: list[str] = []
-    buf: list[str] = []
-    index = 0
-    length = len(sql)
-    tag: str | None = None
-
-    while index < length:
-        char = sql[index]
-        if tag is not None:
-            if sql.startswith(tag, index):
-                buf.append(tag)
-                index += len(tag)
-                tag = None
-            else:
-                buf.append(char)
-                index += 1
-            continue
-        if char == "$":
-            opener = _DOLLAR_TAG.match(sql, index)
-            if opener:
-                tag = opener.group(0)
-                buf.append(tag)
-                index += len(tag)
-                continue
-        if char == "'":
-            end = index + 1
-            while end < length:
-                if sql[end] == "'":
-                    if end + 1 < length and sql[end + 1] == "'":
-                        end += 2
-                        continue
-                    end += 1
-                    break
-                end += 1
-            buf.append(sql[index:end])
-            index = end
-            continue
-        if sql.startswith("--", index):
-            newline = sql.find("\n", index)
-            index = length if newline == -1 else newline
-            continue
-        if sql.startswith("/*", index):
-            close = sql.find("*/", index)
-            index = length if close == -1 else close + 2
-            continue
-        if char == ";":
-            statements.append("".join(buf))
-            buf = []
-            index += 1
-            continue
-        buf.append(char)
-        index += 1
-
-    statements.append("".join(buf))
-    return [stripped for stripped in (s.strip() for s in statements) if stripped]
+    """Top-level split, shared with ``core/replica/classifier.py``."""
+    return split_statements(sql)

--- a/python/confiture/core/change_set.py
+++ b/python/confiture/core/change_set.py
@@ -36,8 +36,20 @@ from typing import TYPE_CHECKING, Any, Final
 from confiture.core._pglast_enums import enums_are_usable
 from confiture.core._pglast_enums import member as _pg_member
 from confiture.core.idempotency.ast_detector import is_pglast_available
+from confiture.core.lock_profile import (
+    FAST_DEFAULT_SINCE,
+    LockProfile,
+    profile_for_kind,
+)
 from confiture.core.risk_tier import RiskTier, worst_tier
+from confiture.core.schema_facts import SchemaFacts
 from confiture.core.sql_statements import split_statements
+from confiture.core.type_lattice import (
+    TypeChange,
+    canonical_type,
+    changes_rewrite_table,
+    compare_types,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -83,6 +95,17 @@ class ChangeEntry:
 
     detail: str | None = None
     """One human-readable line for the plan render. Never parsed, never a credential."""
+
+    lock: LockProfile | None = None
+    """What the change costs in locking terms (#199), or ``None`` when confiture
+    has no statement to cost — a ``.py`` migration.
+
+    **Deliberately not on the wire.** The change-set entry shape is the ratified
+    fraisier-core#44 pact, pinned byte-for-byte by golden fixtures in both
+    repositories; adding a key there is a co-ordinated change with a
+    ``contract_version`` decision, not a free addition. Until that is agreed, the
+    lock facts reach an operator through :attr:`detail`, which the contract
+    defines as free-form, and reach a library caller through this field."""
 
     def to_dict(self) -> dict[str, Any]:
         """Wire form. Absent optional fields are omitted, not emitted as ``null``."""
@@ -215,17 +238,37 @@ _ALTER_COLUMN_TYPE_DETAIL: Final = (
 )
 
 
-def tier_for_add_column(*, nullable: bool, has_default: bool) -> RiskTier:
+# A narrowing loses data with no down path; a lateral move reinterprets every
+# stored value, which is the same loss wearing a different hat. A widening is
+# safe for the data but still pays for the rewrite when there is one.
+_TIER_BY_DIRECTION: Final[dict[TypeChange, RiskTier]] = {
+    TypeChange.NARROWING: RiskTier.IRREVERSIBLE,
+    TypeChange.LATERAL: RiskTier.IRREVERSIBLE,
+    TypeChange.WIDENING: RiskTier.REVERSIBLE,
+    TypeChange.IDENTICAL: RiskTier.REVERSIBLE,
+}
+
+
+def tier_for_add_column(
+    *, nullable: bool, has_default: bool, server_version: int | None = None
+) -> RiskTier:
     """`ADD COLUMN`: additive when nullable, otherwise a lock risk.
 
-    ``NOT NULL DEFAULT`` rewrites the table on PostgreSQL below 11 and takes an
-    ACCESS EXCLUSIVE lock on every version; ``NOT NULL`` without a default aborts
-    outright on a non-empty table. Neither destroys data, and preflight has no
-    connection with which to check the server version, so both take the more
-    severe of the two readings available to it.
+    ``NOT NULL DEFAULT`` rewrites the table on PostgreSQL below 11; ``NOT NULL``
+    without a default aborts outright on a non-empty table. Neither destroys
+    data.
+
+    With no ``server_version`` — the filesystem-only default — both NOT NULL
+    forms take the more severe of the two readings available. When a database has
+    said it is PostgreSQL 11 or newer, the ``DEFAULT`` form is a catalog write
+    (#199) and drops to additive; the no-default form is a hard failure rather
+    than a lock risk on every version, so it does not move.
     """
-    del has_default  # both NOT NULL forms are lock-risky; named for the call sites
-    return RiskTier.ADDITIVE if nullable else RiskTier.LOCK_RISKY
+    if nullable:
+        return RiskTier.ADDITIVE
+    if has_default and server_version is not None and server_version >= FAST_DEFAULT_SINCE:
+        return RiskTier.ADDITIVE
+    return RiskTier.LOCK_RISKY
 
 
 def tier_for_create_index(*, concurrently: bool) -> RiskTier:
@@ -250,6 +293,13 @@ class _Context:
     migration: str | None = None
     source: str | None = None
     default_schema: str = _DEFAULT_SCHEMA
+    facts: SchemaFacts | None = None
+    """What a live database told us, when one was reachable (#199). Absent on the
+    filesystem-only path, where every refinement falls back to its static answer."""
+
+    @property
+    def server_version(self) -> int | None:
+        return self.facts.server_version if self.facts else None
 
     def entry(
         self,
@@ -258,14 +308,21 @@ class _Context:
         *,
         detail: str | None = None,
         tier: RiskTier | None = None,
+        **lock_attrs: bool,
     ) -> ChangeEntry:
-        """Build an entry, defaulting the tier from :data:`_TIER_BY_KIND`."""
+        """Build an entry, defaulting the tier from :data:`_TIER_BY_KIND`.
+
+        ``lock_attrs`` are the statement attributes the lock table needs for the
+        kinds whose cost is not decided by the kind alone (``concurrently``,
+        ``not_valid``, ``has_default``).
+        """
         return ChangeEntry(
             kind=kind,
             object=obj or self.source or "unknown",
             migration=self.migration,
             tier=tier if tier is not None else _TIER_BY_KIND.get(kind),
             detail=detail,
+            lock=profile_for_kind(kind, server_version=self.server_version, **lock_attrs),
         )
 
     def unclassified(self, kind: str, obj: str | None, detail: str) -> ChangeEntry:
@@ -276,6 +333,58 @@ class _Context:
             migration=self.migration,
             tier=None,
             detail=detail,
+            lock=profile_for_kind(kind, server_version=self.server_version),
+        )
+
+    def alter_column_type(
+        self, target: str | None, column: str | None, new_type: str | None
+    ) -> ChangeEntry:
+        """`ALTER COLUMN … TYPE`, tiered only when the *current* type is known.
+
+        SQL states the target and never the source, so the direction is knowable
+        only from a live database (or a differ). Without it the entry stays
+        tier-less, exactly as it was before #199 — an honest absence rather than a
+        confident guess in either direction.
+        """
+        old_type = self.facts.column_type(target) if self.facts else None
+        direction = compare_types(old_type, new_type)
+        rewrites = changes_rewrite_table(old_type, new_type) if old_type else None
+        lock = profile_for_kind(
+            "alter_column_type", rewrites=rewrites, server_version=self.server_version
+        )
+        label = f"ALTER COLUMN {_ident(column)} TYPE"
+
+        if direction in (TypeChange.UNKNOWN, TypeChange.IDENTICAL) and old_type is None:
+            return ChangeEntry(
+                kind="alter_column_type",
+                object=target or self.source or "unknown",
+                migration=self.migration,
+                tier=None,
+                detail=f"{label} — {_ALTER_COLUMN_TYPE_DETAIL}",
+                lock=lock,
+            )
+        if direction is TypeChange.UNKNOWN:
+            return ChangeEntry(
+                kind="alter_column_type",
+                object=target or self.source or "unknown",
+                migration=self.migration,
+                tier=None,
+                detail=f"{label} {old_type} → {new_type} — confiture does not model one of "
+                "these types, so the direction is unknown",
+                lock=lock,
+            )
+        rewrite_note = "rewrites the table" if lock.rewrites_table else "no rewrite"
+        tier = _TIER_BY_DIRECTION[direction]
+        if tier is RiskTier.REVERSIBLE and lock.rewrites_table:
+            # Safe for the data, but an ACCESS EXCLUSIVE heap rewrite all the same.
+            tier = RiskTier.LOCK_RISKY
+        return ChangeEntry(
+            kind="alter_column_type",
+            object=target or self.source or "unknown",
+            migration=self.migration,
+            tier=tier,
+            detail=f"{label} {old_type} → {new_type} — {direction.value}, {rewrite_note}",
+            lock=lock,
         )
 
     def qualified(self, schema: str | None, name: str | None, child: str | None = None) -> str:
@@ -360,6 +469,7 @@ def build_change_set(
     *,
     versions: list[str] | None = None,
     default_schema: str = _DEFAULT_SCHEMA,
+    facts: SchemaFacts | None = None,
 ) -> ChangeSet:
     """Classify every change in ``migrations_dir``.
 
@@ -385,6 +495,7 @@ def build_change_set(
                 migration=version,
                 source=up_file.name,
                 default_schema=default_schema,
+                facts=facts,
             )
         )
 
@@ -414,6 +525,7 @@ def classify_statements(
     migration: str | None = None,
     source: str | None = None,
     default_schema: str = _DEFAULT_SCHEMA,
+    facts: SchemaFacts | None = None,
 ) -> list[ChangeEntry]:
     """Classify every statement in ``sql``.
 
@@ -422,7 +534,7 @@ def classify_statements(
     rather than an empty list, so a broken migration denies instead of reading as
     "nothing changes".
     """
-    ctx = _Context(migration=migration, source=source, default_schema=default_schema)
+    ctx = _Context(migration=migration, source=source, default_schema=default_schema, facts=facts)
     if _use_ast():
         try:
             return _ast_entries(sql, ctx)
@@ -580,7 +692,11 @@ def _rel(relation: object) -> tuple[str | None, str | None]:
 def _ast_alter_table(node: object, ctx: _Context) -> list[ChangeEntry]:
     # `core/replica/classifier.py` owns the column-attribute helpers; reusing
     # them keeps the two surfaces agreeing on what "nullable" means.
-    from confiture.core.replica.classifier import _column_has_default, _column_is_not_null
+    from confiture.core.replica.classifier import (
+        _column_has_default,
+        _column_is_not_null,
+        _type_name,
+    )
 
     schema, table = _rel(getattr(node, "relation", None))
     target = ctx.qualified(schema, table)
@@ -598,8 +714,14 @@ def _ast_alter_table(node: object, ctx: _Context) -> list[ChangeEntry]:
                 ctx.entry(
                     "add_column",
                     ctx.qualified(schema, table, column),
-                    tier=tier_for_add_column(nullable=nullable, has_default=has_default),
+                    tier=tier_for_add_column(
+                        nullable=nullable,
+                        has_default=has_default,
+                        server_version=ctx.server_version,
+                    ),
                     detail=_add_column_detail(column, nullable=nullable, has_default=has_default),
+                    has_default=has_default,
+                    nullable=nullable,
                 )
             )
         elif subtype == _AT_DROP_COLUMN:
@@ -612,10 +734,10 @@ def _ast_alter_table(node: object, ctx: _Context) -> list[ChangeEntry]:
             )
         elif subtype == _AT_ALTER_COLUMN_TYPE:
             entries.append(
-                ctx.unclassified(
-                    "alter_column_type",
+                ctx.alter_column_type(
                     ctx.qualified(schema, table, name),
-                    f"ALTER COLUMN {_ident(name)} TYPE — {_ALTER_COLUMN_TYPE_DETAIL}",
+                    name,
+                    canonical_type(_type_name(getattr(cmd.def_, "typeName", None))),
                 )
             )
         elif subtype == _AT_ADD_CONSTRAINT:
@@ -628,6 +750,7 @@ def _ast_alter_table(node: object, ctx: _Context) -> list[ChangeEntry]:
                     ctx.qualified(schema, table, conname),
                     tier=tier_for_add_constraint(not_valid=not_valid),
                     detail="ADD CONSTRAINT" + (" NOT VALID" if not_valid else ""),
+                    not_valid=not_valid,
                 )
             )
         elif subtype == _AT_DROP_CONSTRAINT:
@@ -719,6 +842,7 @@ def _ast_index(node: object, ctx: _Context) -> list[ChangeEntry]:
             ctx.qualified(schema, table, idxname),
             tier=tier_for_create_index(concurrently=concurrently),
             detail="CREATE INDEX" + (" CONCURRENTLY" if concurrently else " — blocks writes"),
+            concurrently=concurrently,
         )
     ]
 
@@ -1113,6 +1237,7 @@ def _regex_one(statement: str, ctx: _Context) -> list[ChangeEntry]:
                 ctx.dotted(index.group("table"), index.group("idx")),
                 tier=tier_for_create_index(concurrently=concurrently),
                 detail="CREATE INDEX" + (" CONCURRENTLY" if concurrently else " — blocks writes"),
+                concurrently=concurrently,
             )
         ]
 
@@ -1212,6 +1337,7 @@ def _regex_alter_table(match: re.Match[str], ctx: _Context) -> list[ChangeEntry]
                 ctx.dotted(table, add_constraint.group("name")),
                 tier=tier_for_add_constraint(not_valid=not_valid),
                 detail="ADD CONSTRAINT" + (" NOT VALID" if not_valid else ""),
+                not_valid=not_valid,
             )
         ]
 
@@ -1248,8 +1374,12 @@ def _regex_add_column(match: re.Match[str], table: str, ctx: _Context) -> Change
     return ctx.entry(
         "add_column",
         ctx.dotted(table, column),
-        tier=tier_for_add_column(nullable=nullable, has_default=has_default),
+        tier=tier_for_add_column(
+            nullable=nullable, has_default=has_default, server_version=ctx.server_version
+        ),
         detail=_add_column_detail(column, nullable=nullable, has_default=has_default),
+        has_default=has_default,
+        nullable=nullable,
     )
 
 
@@ -1258,11 +1388,10 @@ def _regex_alter_column(match: re.Match[str], table: str, ctx: _Context) -> Chan
     action = match.group("action").strip().lower()
     target = ctx.dotted(table, column)
     if re.match(r"^(?:set\s+data\s+)?type\b", action):
-        return ctx.unclassified(
-            "alter_column_type",
-            target,
-            f"ALTER COLUMN {_ident(column)} TYPE — {_ALTER_COLUMN_TYPE_DETAIL}",
+        raw_type = re.sub(
+            r"^(?:set\s+data\s+)?type\s+", "", match.group("action").strip(), flags=re.IGNORECASE
         )
+        return ctx.alter_column_type(target, column, canonical_type(_first_type_token(raw_type)))
     if action.startswith("set default"):
         return ctx.entry(
             "set_column_default", target, detail=f"ALTER COLUMN {_ident(column)} SET DEFAULT"
@@ -1282,6 +1411,15 @@ def _regex_alter_column(match: re.Match[str], table: str, ctx: _Context) -> Chan
             "drop_not_null", target, detail=f"ALTER COLUMN {_ident(column)} DROP NOT NULL"
         )
     return None
+
+
+def _first_type_token(raw: str) -> str | None:
+    """The type at the head of an `ALTER COLUMN … TYPE <type> [USING …]` tail."""
+    text = re.split(r"\b(?:USING|COLLATE|NOT|NULL|DEFAULT)\b", raw, flags=re.IGNORECASE)[0]
+    match = re.match(r"\s*([A-Za-z_][\w ]*?)\s*(\(\s*\d+\s*(?:,\s*\d+\s*)?\))?\s*$", text)
+    if not match:
+        return text.strip() or None
+    return f"{match.group(1).strip()}{match.group(2) or ''}"
 
 
 def _regex_drop(match: re.Match[str], ctx: _Context) -> list[ChangeEntry]:

--- a/python/confiture/core/linting/libraries/replica.py
+++ b/python/confiture/core/linting/libraries/replica.py
@@ -39,6 +39,16 @@ REPLICA_CODE_BY_OP = {
     "ChangeColumnType": "PFLIGHT_REPLICA_CHANGE_TYPE",
     "AddConstraint": "PFLIGHT_REPLICA_ADD_CONSTRAINT",
     "CreateIndex": "PFLIGHT_REPLICA_CREATE_INDEX",
+    # Widened in 0.44.0 (#206). Additions to this namespace are allowed by #154;
+    # renames and removals are not. Operations that classify **safe** — `Benign`,
+    # `AddEnumValue` — emit no finding, so they need no code here.
+    "DropTable": "PFLIGHT_REPLICA_DROP_TABLE",
+    "DropObject": "PFLIGHT_REPLICA_DROP_OBJECT",
+    "ReplaceObject": "PFLIGHT_REPLICA_REPLACE_OBJECT",
+    "Truncate": "PFLIGHT_REPLICA_TRUNCATE",
+    "Revoke": "PFLIGHT_REPLICA_REVOKE",
+    "SetNotNull": "PFLIGHT_REPLICA_SET_NOT_NULL",
+    "RenameObject": "PFLIGHT_REPLICA_RENAME_OBJECT",
     "Other": "PFLIGHT_REPLICA_UNCLASSIFIED",
 }
 

--- a/python/confiture/core/lock_profile.py
+++ b/python/confiture/core/lock_profile.py
@@ -55,11 +55,20 @@ from confiture.core.replica.classifier import (
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-__all__ = ["Duration", "LockLevel", "LockProfile", "lock_profile", "worst_profile"]
+__all__ = [
+    "FAST_DEFAULT_SINCE",
+    "NOT_NULL_FROM_CHECK_SINCE",
+    "Duration",
+    "LockLevel",
+    "LockProfile",
+    "lock_profile",
+    "profile_for_kind",
+    "worst_profile",
+]
 
 # The PostgreSQL release each version-dependent row changed in.
-_FAST_DEFAULT_SINCE = 11
-_NOT_NULL_FROM_CHECK_SINCE = 12
+FAST_DEFAULT_SINCE = 11
+NOT_NULL_FROM_CHECK_SINCE = 12
 
 
 class LockLevel(Enum):
@@ -170,28 +179,38 @@ _NO_LOCK = LockProfile(
 )
 
 
-def lock_profile(op: DdlOperation, *, server_version: int | None = None) -> LockProfile:
-    """The lock and rewrite cost of ``op``.
+def profile_for_kind(
+    kind: str | None,
+    *,
+    has_default: bool = False,
+    nullable: bool = True,
+    concurrently: bool = False,
+    not_valid: bool = False,
+    rewrites: bool | None = None,
+    server_version: int | None = None,
+) -> LockProfile:
+    """The lock and rewrite cost of a change of ``kind``.
+
+    ``kind`` is the vocabulary ``core/change_set.py`` emits, which is also what
+    crosses the adapter seam. :func:`lock_profile` is the twin keyed on a typed
+    :class:`~confiture.core.replica.classifier.DdlOperation`; both read this one
+    table, so the two surfaces cannot disagree about what an operation costs.
 
     ``server_version`` is the PostgreSQL **major** (``16``, not ``160004``). When
     it is ``None`` — the filesystem-only default — every version-dependent row
-    answers with its pre-improvement reading.
+    answers with its pre-improvement reading. ``rewrites`` overrides the heap
+    verdict for ``alter_column_type``, where only the type lattice knows.
     """
-    if isinstance(op, AddColumn):
-        return _add_column(op, server_version)
-    if isinstance(op, SetNotNull):
-        return _set_not_null(server_version)
-    if isinstance(op, ChangeColumnType):
-        return LockProfile(
-            lock=LockLevel.ACCESS_EXCLUSIVE,
-            rewrites_table=True,
-            blocks_reads=True,
-            blocks_writes=True,
-            duration=Duration.MINUTES_PLUS,
-            note="rewrites the heap and every index on the column",
+    if kind == "add_column":
+        return _add_column(
+            has_default=has_default, nullable=nullable, server_version=server_version
         )
-    if isinstance(op, AddConstraint):
-        if op.not_valid:
+    if kind == "set_not_null":
+        return _set_not_null(server_version)
+    if kind == "alter_column_type":
+        return _alter_column_type(rewrites)
+    if kind == "add_constraint":
+        if not_valid:
             return _METADATA_ALTER
         return LockProfile(
             lock=LockLevel.ACCESS_EXCLUSIVE,
@@ -201,8 +220,8 @@ def lock_profile(op: DdlOperation, *, server_version: int | None = None) -> Lock
             duration=Duration.MINUTES_PLUS,
             note="validates against every existing row; ADD … NOT VALID defers the scan",
         )
-    if isinstance(op, CreateIndex):
-        if op.concurrently:
+    if kind == "create_index":
+        if concurrently:
             return LockProfile(
                 lock=LockLevel.SHARE_UPDATE_EXCLUSIVE,
                 rewrites_table=False,
@@ -219,30 +238,24 @@ def lock_profile(op: DdlOperation, *, server_version: int | None = None) -> Lock
             duration=Duration.MINUTES_PLUS,
             note="blocks writes for the whole build; use CONCURRENTLY on a hot table",
         )
-    if isinstance(op, (DropColumn, RenameColumn, RenameObject, DropTable, Truncate)):
-        # All catalog-only. DROP COLUMN marks the attribute dropped rather than
-        # rewriting; TRUNCATE swaps in a new heap file.
-        return _METADATA_ALTER
-    if isinstance(op, (CreateTable, AddEnumValue, Revoke, DropObject, ReplaceObject)):
+    profile = _PROFILE_BY_KIND.get(kind or "")
+    if profile is not None:
+        return profile
+    if kind and kind.startswith("create_"):
         return _NO_LOCK
-    if isinstance(op, Benign):
-        return _BENIGN_PROFILES.get(op.kind or "", _NO_LOCK)
     return _UNKNOWN
 
 
-def _add_column(op: AddColumn, server_version: int | None) -> LockProfile:
-    """`ADD COLUMN` is metadata-only, except for a pre-PG-11 non-null default."""
-    if not op.has_default:
-        return _METADATA_ALTER
-    if server_version is not None and server_version >= _FAST_DEFAULT_SINCE:
+def _alter_column_type(rewrites: bool | None) -> LockProfile:
+    """A type change rewrites unless the lattice proves the coercion is binary."""
+    if rewrites is False:
         return LockProfile(
             lock=LockLevel.ACCESS_EXCLUSIVE,
             rewrites_table=False,
             blocks_reads=True,
             blocks_writes=True,
             duration=Duration.METADATA,
-            since_version=_FAST_DEFAULT_SINCE,
-            note="PostgreSQL 11+ stores the default in the catalog instead of rewriting",
+            note="binary-coercible: PostgreSQL updates the catalog without a rewrite",
         )
     return LockProfile(
         lock=LockLevel.ACCESS_EXCLUSIVE,
@@ -250,53 +263,49 @@ def _add_column(op: AddColumn, server_version: int | None) -> LockProfile:
         blocks_reads=True,
         blocks_writes=True,
         duration=Duration.MINUTES_PLUS,
-        since_version=_FAST_DEFAULT_SINCE,
-        note=(
-            "rewrites the whole table below PostgreSQL 11; the server version is "
-            "unknown here, so the older reading stands"
-            if server_version is None
-            else "rewrites the whole table below PostgreSQL 11"
-        ),
+        note="rewrites the heap and every index on the column",
     )
 
 
-def _set_not_null(server_version: int | None) -> LockProfile:
-    """`SET NOT NULL` scans, unless PG 12+ can prove it from a valid CHECK."""
-    if server_version is not None and server_version >= _NOT_NULL_FROM_CHECK_SINCE:
-        return LockProfile(
-            lock=LockLevel.ACCESS_EXCLUSIVE,
-            rewrites_table=False,
-            blocks_reads=True,
-            blocks_writes=True,
-            duration=Duration.SECONDS,
-            since_version=_NOT_NULL_FROM_CHECK_SINCE,
-            note=(
-                "PostgreSQL 12+ skips the scan when a valid CHECK (col IS NOT NULL) "
-                "already exists; without one it still scans"
-            ),
-        )
-    return LockProfile(
-        lock=LockLevel.ACCESS_EXCLUSIVE,
-        rewrites_table=False,
-        blocks_reads=True,
-        blocks_writes=True,
-        duration=Duration.MINUTES_PLUS,
-        since_version=_NOT_NULL_FROM_CHECK_SINCE,
-        note="scans every row to prove no NULL is present",
-    )
-
-
-# `Benign` carries a kind rather than a class, so its costs live in one table.
-_BENIGN_PROFILES: dict[str, LockProfile] = {
+# Kinds whose cost depends on nothing but the kind itself.
+_PROFILE_BY_KIND: dict[str, LockProfile] = {
+    # Catalog-only ALTER TABLE forms. DROP COLUMN marks the attribute dropped
+    # rather than rewriting; TRUNCATE swaps in a new heap file.
+    "drop_column": _METADATA_ALTER,
+    "rename_column": _METADATA_ALTER,
+    "rename_object": _METADATA_ALTER,
+    "drop_table": _METADATA_ALTER,
+    "truncate": _METADATA_ALTER,
+    "drop_constraint": _METADATA_ALTER,
+    "set_column_default": _METADATA_ALTER,
+    "drop_column_default": _METADATA_ALTER,
+    "column_default": _METADATA_ALTER,
+    "drop_not_null": _METADATA_ALTER,
+    "change_owner": _METADATA_ALTER,
     "drop_index": _METADATA_ALTER,
     "drop_trigger": _METADATA_ALTER,
     "drop_policy": _METADATA_ALTER,
     "drop_rule": _METADATA_ALTER,
-    "drop_constraint": _METADATA_ALTER,
-    "drop_not_null": _METADATA_ALTER,
-    "column_default": _METADATA_ALTER,
-    "change_owner": _METADATA_ALTER,
-    "create_table": _NO_LOCK,
+    # Objects whose removal or replacement touches no heap.
+    "drop_view": _NO_LOCK,
+    "drop_materialized_view": _NO_LOCK,
+    "drop_sequence": _NO_LOCK,
+    "drop_schema": _NO_LOCK,
+    "drop_type": _NO_LOCK,
+    "drop_domain": _NO_LOCK,
+    "drop_function": _NO_LOCK,
+    "drop_procedure": _NO_LOCK,
+    "drop_extension": _NO_LOCK,
+    "replace_view": _NO_LOCK,
+    "replace_function": _NO_LOCK,
+    "replace_procedure": _NO_LOCK,
+    "grant": _NO_LOCK,
+    "revoke": _NO_LOCK,
+    "comment": _NO_LOCK,
+    "select": _NO_LOCK,
+    "alter_type": _NO_LOCK,
+    "alter_sequence": _NO_LOCK,
+    "alter_default_privileges": _NO_LOCK,
     "cluster": LockProfile(
         lock=LockLevel.ACCESS_EXCLUSIVE,
         rewrites_table=True,
@@ -345,6 +354,100 @@ _BENIGN_PROFILES: dict[str, LockProfile] = {
         note="row locks scale with the number of rows matched",
     ),
 }
+
+# DdlOperation class → the kind naming the same change. The typed classifier and
+# the change-set vocabulary meet here and nowhere else.
+_KIND_BY_OP: dict[type[DdlOperation], str] = {
+    AddColumn: "add_column",
+    DropColumn: "drop_column",
+    RenameColumn: "rename_column",
+    RenameObject: "rename_object",
+    ChangeColumnType: "alter_column_type",
+    AddConstraint: "add_constraint",
+    CreateIndex: "create_index",
+    CreateTable: "create_table",
+    DropTable: "drop_table",
+    Truncate: "truncate",
+    Revoke: "revoke",
+    SetNotNull: "set_not_null",
+    AddEnumValue: "alter_type",
+}
+
+
+def lock_profile(op: DdlOperation, *, server_version: int | None = None) -> LockProfile:
+    """The lock and rewrite cost of a typed operation. See :func:`profile_for_kind`."""
+    if isinstance(op, Benign):
+        return profile_for_kind(op.kind, server_version=server_version)
+    if isinstance(op, (DropObject, ReplaceObject)):
+        return _NO_LOCK
+    kind = _KIND_BY_OP.get(type(op))
+    if kind is None:
+        return _UNKNOWN
+    return profile_for_kind(
+        kind,
+        has_default=getattr(op, "has_default", False),
+        nullable=getattr(op, "nullable", True),
+        concurrently=getattr(op, "concurrently", False),
+        not_valid=getattr(op, "not_valid", False),
+        server_version=server_version,
+    )
+
+
+def _add_column(*, has_default: bool, nullable: bool, server_version: int | None) -> LockProfile:
+    """`ADD COLUMN` is metadata-only, except for a pre-PG-11 non-null default."""
+    del nullable  # named for the call sites; both NOT NULL forms cost the same
+    if not has_default:
+        return _METADATA_ALTER
+    if server_version is not None and server_version >= FAST_DEFAULT_SINCE:
+        return LockProfile(
+            lock=LockLevel.ACCESS_EXCLUSIVE,
+            rewrites_table=False,
+            blocks_reads=True,
+            blocks_writes=True,
+            duration=Duration.METADATA,
+            since_version=FAST_DEFAULT_SINCE,
+            note="PostgreSQL 11+ stores the default in the catalog instead of rewriting",
+        )
+    return LockProfile(
+        lock=LockLevel.ACCESS_EXCLUSIVE,
+        rewrites_table=True,
+        blocks_reads=True,
+        blocks_writes=True,
+        duration=Duration.MINUTES_PLUS,
+        since_version=FAST_DEFAULT_SINCE,
+        note=(
+            "rewrites the whole table below PostgreSQL 11; the server version is "
+            "unknown here, so the older reading stands"
+            if server_version is None
+            else "rewrites the whole table below PostgreSQL 11"
+        ),
+    )
+
+
+def _set_not_null(server_version: int | None) -> LockProfile:
+    """`SET NOT NULL` scans, unless PG 12+ can prove it from a valid CHECK."""
+    if server_version is not None and server_version >= NOT_NULL_FROM_CHECK_SINCE:
+        return LockProfile(
+            lock=LockLevel.ACCESS_EXCLUSIVE,
+            rewrites_table=False,
+            blocks_reads=True,
+            blocks_writes=True,
+            duration=Duration.SECONDS,
+            since_version=NOT_NULL_FROM_CHECK_SINCE,
+            note=(
+                "PostgreSQL 12+ skips the scan when a valid CHECK (col IS NOT NULL) "
+                "already exists; without one it still scans"
+            ),
+        )
+    return LockProfile(
+        lock=LockLevel.ACCESS_EXCLUSIVE,
+        rewrites_table=False,
+        blocks_reads=True,
+        blocks_writes=True,
+        duration=Duration.MINUTES_PLUS,
+        since_version=NOT_NULL_FROM_CHECK_SINCE,
+        note="scans every row to prove no NULL is present",
+    )
 
 
 def worst_profile(profiles: Iterable[LockProfile]) -> LockProfile | None:

--- a/python/confiture/core/lock_profile.py
+++ b/python/confiture/core/lock_profile.py
@@ -1,0 +1,360 @@
+"""What lock a DDL operation takes, and whether it rewrites the heap (issue #199).
+
+Preflight's only size-awareness used to be ``TableSizeEstimator``'s row-count
+hint, surfaced as ``migrate up --batched``. That says nothing about *which* lock a
+statement takes or *whether* it rewrites the table — and those two facts, not row
+count, are what separate a metadata blip from a multi-minute outage. A
+``DROP COLUMN`` on a billion-row table is instant; an ``ALTER COLUMN … TYPE`` on a
+small one still rewrites it.
+
+Three properties are deliberate:
+
+* **Pure lookup.** No SQL, no connection, no parser. Preflight is a
+  filesystem-only check by design, so the static answer is the primary one and
+  anything a database could add is strictly additive.
+* **Version-dependent rows are explicit.** Two rows changed with a PostgreSQL
+  release — ``ADD COLUMN … DEFAULT`` stopped rewriting in PG 11, and PG 12 can
+  prove ``SET NOT NULL`` from a valid ``CHECK`` instead of scanning. Each carries
+  :attr:`LockProfile.since_version`, and an unknown server version takes the
+  **worse** of the two readings rather than the newer one.
+* **Duration is a class, not a number.** ``metadata`` / ``seconds`` /
+  ``minutes+``. A predicted duration in seconds is a promise the operator will
+  hold confiture to and that no static analysis can keep.
+
+The lock names are PostgreSQL's own, and the table holds for the versions cited
+per row (baseline: PostgreSQL 17 documentation, "Explicit Locking" and
+"ALTER TABLE").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from confiture.core.replica.classifier import (
+    AddColumn,
+    AddConstraint,
+    AddEnumValue,
+    Benign,
+    ChangeColumnType,
+    CreateIndex,
+    CreateTable,
+    DdlOperation,
+    DropColumn,
+    DropObject,
+    DropTable,
+    RenameColumn,
+    RenameObject,
+    ReplaceObject,
+    Revoke,
+    SetNotNull,
+    Truncate,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+__all__ = ["Duration", "LockLevel", "LockProfile", "lock_profile", "worst_profile"]
+
+# The PostgreSQL release each version-dependent row changed in.
+_FAST_DEFAULT_SINCE = 11
+_NOT_NULL_FROM_CHECK_SINCE = 12
+
+
+class LockLevel(Enum):
+    """The PostgreSQL table-level lock mode an operation acquires."""
+
+    NONE = "none"
+    """Touches no table — a catalog- or type-level change."""
+
+    SHARE_UPDATE_EXCLUSIVE = "share_update_exclusive"
+    """Concurrent index builds and ``VACUUM``; blocks neither reads nor writes."""
+
+    SHARE = "share"
+    """A plain ``CREATE INDEX``; blocks writes, allows reads."""
+
+    ACCESS_EXCLUSIVE = "access_exclusive"
+    """Most ``ALTER TABLE`` forms; blocks everything, including reads."""
+
+
+class Duration(Enum):
+    """How long the lock is plausibly held. A class, never a prediction.
+
+    Ordered least- to most-severe; comparison is the declaration index, so
+    ``Duration.METADATA < Duration.MINUTES_PLUS``.
+    """
+
+    METADATA = "metadata"
+    """A catalog write. Held for microseconds, independent of table size."""
+
+    SECONDS = "seconds"
+    """Bounded work — an index-supported check, a small scan."""
+
+    MINUTES_PLUS = "minutes+"
+    """A full scan or heap rewrite. Scales with the table."""
+
+    @property
+    def severity(self) -> int:
+        return _DURATION_SEVERITY[self]
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Duration):
+            return NotImplemented
+        return self.severity < other.severity
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, Duration):
+            return NotImplemented
+        return self.severity <= other.severity
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, Duration):
+            return NotImplemented
+        return self.severity > other.severity
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, Duration):
+            return NotImplemented
+        return self.severity >= other.severity
+
+
+_DURATION_SEVERITY: dict[Duration, int] = {d: i for i, d in enumerate(Duration)}
+
+
+@dataclass(frozen=True)
+class LockProfile:
+    """What one operation costs in locking terms."""
+
+    lock: LockLevel
+    rewrites_table: bool
+    blocks_reads: bool
+    blocks_writes: bool
+    duration: Duration
+    since_version: int | None = None
+    """The PostgreSQL major this row's *favourable* reading starts at, when the
+    answer is version-dependent. ``None`` means the row holds on every version."""
+
+    note: str | None = None
+    """One line naming the caveat, when a row has one."""
+
+
+# The conservative answer for an operation with no row: assume the worst. An
+# operation confiture cannot cost must not read as cheap — that is #206's lesson
+# applied to this table.
+_UNKNOWN = LockProfile(
+    lock=LockLevel.ACCESS_EXCLUSIVE,
+    rewrites_table=True,
+    blocks_reads=True,
+    blocks_writes=True,
+    duration=Duration.MINUTES_PLUS,
+    note="operation not in the lock table; assumed to be the worst case",
+)
+
+# A brief catalog-only ALTER TABLE: ACCESS EXCLUSIVE, but held for microseconds.
+_METADATA_ALTER = LockProfile(
+    lock=LockLevel.ACCESS_EXCLUSIVE,
+    rewrites_table=False,
+    blocks_reads=True,
+    blocks_writes=True,
+    duration=Duration.METADATA,
+)
+
+# Touches no table at all.
+_NO_LOCK = LockProfile(
+    lock=LockLevel.NONE,
+    rewrites_table=False,
+    blocks_reads=False,
+    blocks_writes=False,
+    duration=Duration.METADATA,
+)
+
+
+def lock_profile(op: DdlOperation, *, server_version: int | None = None) -> LockProfile:
+    """The lock and rewrite cost of ``op``.
+
+    ``server_version`` is the PostgreSQL **major** (``16``, not ``160004``). When
+    it is ``None`` — the filesystem-only default — every version-dependent row
+    answers with its pre-improvement reading.
+    """
+    if isinstance(op, AddColumn):
+        return _add_column(op, server_version)
+    if isinstance(op, SetNotNull):
+        return _set_not_null(server_version)
+    if isinstance(op, ChangeColumnType):
+        return LockProfile(
+            lock=LockLevel.ACCESS_EXCLUSIVE,
+            rewrites_table=True,
+            blocks_reads=True,
+            blocks_writes=True,
+            duration=Duration.MINUTES_PLUS,
+            note="rewrites the heap and every index on the column",
+        )
+    if isinstance(op, AddConstraint):
+        if op.not_valid:
+            return _METADATA_ALTER
+        return LockProfile(
+            lock=LockLevel.ACCESS_EXCLUSIVE,
+            rewrites_table=False,
+            blocks_reads=True,
+            blocks_writes=True,
+            duration=Duration.MINUTES_PLUS,
+            note="validates against every existing row; ADD … NOT VALID defers the scan",
+        )
+    if isinstance(op, CreateIndex):
+        if op.concurrently:
+            return LockProfile(
+                lock=LockLevel.SHARE_UPDATE_EXCLUSIVE,
+                rewrites_table=False,
+                blocks_reads=False,
+                blocks_writes=False,
+                duration=Duration.MINUTES_PLUS,
+                note="online, but takes two table scans and cannot run in a transaction",
+            )
+        return LockProfile(
+            lock=LockLevel.SHARE,
+            rewrites_table=False,
+            blocks_reads=False,
+            blocks_writes=True,
+            duration=Duration.MINUTES_PLUS,
+            note="blocks writes for the whole build; use CONCURRENTLY on a hot table",
+        )
+    if isinstance(op, (DropColumn, RenameColumn, RenameObject, DropTable, Truncate)):
+        # All catalog-only. DROP COLUMN marks the attribute dropped rather than
+        # rewriting; TRUNCATE swaps in a new heap file.
+        return _METADATA_ALTER
+    if isinstance(op, (CreateTable, AddEnumValue, Revoke, DropObject, ReplaceObject)):
+        return _NO_LOCK
+    if isinstance(op, Benign):
+        return _BENIGN_PROFILES.get(op.kind or "", _NO_LOCK)
+    return _UNKNOWN
+
+
+def _add_column(op: AddColumn, server_version: int | None) -> LockProfile:
+    """`ADD COLUMN` is metadata-only, except for a pre-PG-11 non-null default."""
+    if not op.has_default:
+        return _METADATA_ALTER
+    if server_version is not None and server_version >= _FAST_DEFAULT_SINCE:
+        return LockProfile(
+            lock=LockLevel.ACCESS_EXCLUSIVE,
+            rewrites_table=False,
+            blocks_reads=True,
+            blocks_writes=True,
+            duration=Duration.METADATA,
+            since_version=_FAST_DEFAULT_SINCE,
+            note="PostgreSQL 11+ stores the default in the catalog instead of rewriting",
+        )
+    return LockProfile(
+        lock=LockLevel.ACCESS_EXCLUSIVE,
+        rewrites_table=True,
+        blocks_reads=True,
+        blocks_writes=True,
+        duration=Duration.MINUTES_PLUS,
+        since_version=_FAST_DEFAULT_SINCE,
+        note=(
+            "rewrites the whole table below PostgreSQL 11; the server version is "
+            "unknown here, so the older reading stands"
+            if server_version is None
+            else "rewrites the whole table below PostgreSQL 11"
+        ),
+    )
+
+
+def _set_not_null(server_version: int | None) -> LockProfile:
+    """`SET NOT NULL` scans, unless PG 12+ can prove it from a valid CHECK."""
+    if server_version is not None and server_version >= _NOT_NULL_FROM_CHECK_SINCE:
+        return LockProfile(
+            lock=LockLevel.ACCESS_EXCLUSIVE,
+            rewrites_table=False,
+            blocks_reads=True,
+            blocks_writes=True,
+            duration=Duration.SECONDS,
+            since_version=_NOT_NULL_FROM_CHECK_SINCE,
+            note=(
+                "PostgreSQL 12+ skips the scan when a valid CHECK (col IS NOT NULL) "
+                "already exists; without one it still scans"
+            ),
+        )
+    return LockProfile(
+        lock=LockLevel.ACCESS_EXCLUSIVE,
+        rewrites_table=False,
+        blocks_reads=True,
+        blocks_writes=True,
+        duration=Duration.MINUTES_PLUS,
+        since_version=_NOT_NULL_FROM_CHECK_SINCE,
+        note="scans every row to prove no NULL is present",
+    )
+
+
+# `Benign` carries a kind rather than a class, so its costs live in one table.
+_BENIGN_PROFILES: dict[str, LockProfile] = {
+    "drop_index": _METADATA_ALTER,
+    "drop_trigger": _METADATA_ALTER,
+    "drop_policy": _METADATA_ALTER,
+    "drop_rule": _METADATA_ALTER,
+    "drop_constraint": _METADATA_ALTER,
+    "drop_not_null": _METADATA_ALTER,
+    "column_default": _METADATA_ALTER,
+    "change_owner": _METADATA_ALTER,
+    "create_table": _NO_LOCK,
+    "cluster": LockProfile(
+        lock=LockLevel.ACCESS_EXCLUSIVE,
+        rewrites_table=True,
+        blocks_reads=True,
+        blocks_writes=True,
+        duration=Duration.MINUTES_PLUS,
+        note="rewrites the table in index order",
+    ),
+    "reindex": LockProfile(
+        lock=LockLevel.ACCESS_EXCLUSIVE,
+        rewrites_table=False,
+        blocks_reads=True,
+        blocks_writes=True,
+        duration=Duration.MINUTES_PLUS,
+        note="REINDEX CONCURRENTLY avoids the exclusive lock",
+    ),
+    "refresh_materialized_view": LockProfile(
+        lock=LockLevel.ACCESS_EXCLUSIVE,
+        rewrites_table=True,
+        blocks_reads=True,
+        blocks_writes=True,
+        duration=Duration.MINUTES_PLUS,
+        note="REFRESH … CONCURRENTLY keeps the view readable, but needs a unique index",
+    ),
+    "insert": LockProfile(
+        lock=LockLevel.SHARE_UPDATE_EXCLUSIVE,
+        rewrites_table=False,
+        blocks_reads=False,
+        blocks_writes=False,
+        duration=Duration.SECONDS,
+    ),
+    "update": LockProfile(
+        lock=LockLevel.SHARE_UPDATE_EXCLUSIVE,
+        rewrites_table=False,
+        blocks_reads=False,
+        blocks_writes=False,
+        duration=Duration.MINUTES_PLUS,
+        note="row locks scale with the number of rows matched",
+    ),
+    "delete": LockProfile(
+        lock=LockLevel.SHARE_UPDATE_EXCLUSIVE,
+        rewrites_table=False,
+        blocks_reads=False,
+        blocks_writes=False,
+        duration=Duration.MINUTES_PLUS,
+        note="row locks scale with the number of rows matched",
+    ),
+}
+
+
+def worst_profile(profiles: Iterable[LockProfile]) -> LockProfile | None:
+    """The most expensive profile in ``profiles`` — the one that decides a window.
+
+    Ranked by duration first, then by whether the operation rewrites the heap.
+    Returns ``None`` for an empty set.
+    """
+    ranked = sorted(
+        profiles,
+        key=lambda p: (p.duration.severity, p.rewrites_table, p.blocks_reads, p.blocks_writes),
+    )
+    return ranked[-1] if ranked else None

--- a/python/confiture/core/migration_analyzer.py
+++ b/python/confiture/core/migration_analyzer.py
@@ -113,7 +113,10 @@ class MigrationAnalyzer:
             elif node_type == "DropStmt" and getattr(stmt, "concurrent", False):
                 results.append("DROP INDEX CONCURRENTLY")
 
-            # ALTER TYPE ... ADD VALUE (non-transactional in PG < 16)
+            # ALTER TYPE ... ADD VALUE — could not run inside a transaction block
+            # before PostgreSQL 12. From 12 it can, provided the new value is not
+            # *used* until the transaction commits, so it is still reported: the
+            # restriction moved, it did not disappear.
             elif node_type == "AlterEnumStmt":
                 type_name = getattr(stmt, "typeName", None)
                 if type_name:

--- a/python/confiture/core/replica/classifier.py
+++ b/python/confiture/core/replica/classifier.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
+from typing import Any
 
 from confiture.core._pglast_enums import enums_are_usable
 from confiture.core._pglast_enums import member as _pg_member
 from confiture.core.idempotency.ast_detector import is_pglast_available
+from confiture.core.sql_statements import split_statements
 
 # pglast availability, resolved at import (tests monkeypatch this to force the
 # regex backend, mirroring the idempotency CONFITURE_IDEMPOTENCY_FORCE_REGEX
@@ -29,6 +31,95 @@ _AT_ADD_COLUMN = _pg_member("AlterTableType", "AT_AddColumn")
 _AT_DROP_COLUMN = _pg_member("AlterTableType", "AT_DropColumn")
 _AT_ALTER_COLUMN_TYPE = _pg_member("AlterTableType", "AT_AlterColumnType")
 _AT_ADD_CONSTRAINT = _pg_member("AlterTableType", "AT_AddConstraint")
+_AT_DROP_CONSTRAINT = _pg_member("AlterTableType", "AT_DropConstraint")
+_AT_CHANGE_OWNER = _pg_member("AlterTableType", "AT_ChangeOwner")
+_AT_COLUMN_DEFAULT = _pg_member("AlterTableType", "AT_ColumnDefault")
+_AT_SET_NOT_NULL = _pg_member("AlterTableType", "AT_SetNotNull")
+_AT_DROP_NOT_NULL = _pg_member("AlterTableType", "AT_DropNotNull")
+
+# ALTER TABLE subcommands that change nothing an N-1 reader can observe.
+_AT_BENIGN = {
+    _AT_DROP_CONSTRAINT: "drop_constraint",
+    _AT_CHANGE_OWNER: "change_owner",
+    _AT_COLUMN_DEFAULT: "column_default",
+    _AT_DROP_NOT_NULL: "drop_not_null",
+}
+
+# DropStmt.removeType → the object noun, for objects whose removal breaks a
+# reader still on the old version.
+_DROP_UNSAFE_KIND = {
+    _pg_member("ObjectType", "OBJECT_VIEW"): "view",
+    _pg_member("ObjectType", "OBJECT_MATVIEW"): "materialized view",
+    _pg_member("ObjectType", "OBJECT_SEQUENCE"): "sequence",
+    _pg_member("ObjectType", "OBJECT_SCHEMA"): "schema",
+    _pg_member("ObjectType", "OBJECT_TYPE"): "type",
+    _pg_member("ObjectType", "OBJECT_DOMAIN"): "domain",
+    _pg_member("ObjectType", "OBJECT_FUNCTION"): "function",
+    _pg_member("ObjectType", "OBJECT_PROCEDURE"): "procedure",
+    _pg_member("ObjectType", "OBJECT_EXTENSION"): "extension",
+}
+
+# Dropping these changes query *plans* or side effects, never whether an N-1
+# reader's SQL still resolves.
+_DROP_BENIGN_KIND = {
+    _pg_member("ObjectType", "OBJECT_INDEX"): "drop_index",
+    _pg_member("ObjectType", "OBJECT_TRIGGER"): "drop_trigger",
+    _pg_member("ObjectType", "OBJECT_POLICY"): "drop_policy",
+    _pg_member("ObjectType", "OBJECT_RULE"): "drop_rule",
+}
+
+_OBJECT_TABLE = _pg_member("ObjectType", "OBJECT_TABLE")
+
+# Statement types that change neither schema nor data, so they produce no
+# operation at all — emitting one would make every migration with a `BEGIN;`
+# report as unclassified.
+_AST_SKIP = frozenset(
+    {
+        "TransactionStmt",
+        "VariableSetStmt",
+        "VariableShowStmt",
+        "CheckPointStmt",
+        "DiscardStmt",
+        "LockStmt",
+        "VacuumStmt",
+        "ConstraintsSetStmt",
+        "NotifyStmt",
+        "ListenStmt",
+        "UnlistenStmt",
+    }
+)
+
+# Node types that are additive or reader-invisible, mapped to the kind recorded
+# on the resulting :class:`Benign` operation.
+_AST_BENIGN = {
+    "CreateStmt": "create_table",
+    "CreateTableAsStmt": "create_table_as",
+    "CreateSeqStmt": "create_sequence",
+    "AlterSeqStmt": "alter_sequence",
+    "CreateSchemaStmt": "create_schema",
+    "CreateExtensionStmt": "create_extension",
+    "CreateEnumStmt": "create_type",
+    "CreateRangeStmt": "create_type",
+    "CompositeTypeStmt": "create_type",
+    "CreateDomainStmt": "create_domain",
+    "CreateTrigStmt": "create_trigger",
+    "CreatePolicyStmt": "create_policy",
+    "RuleStmt": "create_rule",
+    "CommentStmt": "comment",
+    "AlterOwnerStmt": "change_owner",
+    "AlterDefaultPrivilegesStmt": "alter_default_privileges",
+    "RefreshMatViewStmt": "refresh_materialized_view",
+    "ClusterStmt": "cluster",
+    "ReindexStmt": "reindex",
+    "InsertStmt": "insert",
+    "UpdateStmt": "update",
+    "DeleteStmt": "delete",
+    # A bare SELECT reads; it cannot change what an N-1 reader resolves. DDL run
+    # inside a function it calls is invisible here — the same blind spot that
+    # makes a `.py` migration UNCLASSIFIED, and not one a statement classifier
+    # can close. `SELECT … INTO` creates a table, which is additive either way.
+    "SelectStmt": "select",
+}
 
 _CONSTR_NOTNULL = _pg_member("ConstrType", "CONSTR_NOTNULL")
 _CONSTR_DEFAULT = _pg_member("ConstrType", "CONSTR_DEFAULT")
@@ -96,8 +187,79 @@ class CreateTable(DdlOperation):
 
 
 @dataclass(frozen=True)
+class DropTable(DdlOperation):
+    """``DROP TABLE`` — readers on the old version still SELECT from it."""
+
+
+@dataclass(frozen=True)
+class DropObject(DdlOperation):
+    """``DROP`` of a non-table object an N-1 reader may still reference."""
+
+    kind: str | None = None
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class ReplaceObject(DdlOperation):
+    """``CREATE OR REPLACE`` — the new body may or may not stay reader-compatible."""
+
+    kind: str | None = None
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class Truncate(DdlOperation):
+    """``TRUNCATE`` — the rows readers expect are gone."""
+
+
+@dataclass(frozen=True)
+class Revoke(DdlOperation):
+    """``REVOKE`` — a privilege an N-1 reader still relies on may disappear."""
+
+
+@dataclass(frozen=True)
+class SetNotNull(DdlOperation):
+    """``ALTER COLUMN … SET NOT NULL`` — an N-1 writer inserting NULL starts failing."""
+
+    column: str | None = None
+
+
+@dataclass(frozen=True)
+class RenameObject(DdlOperation):
+    """``RENAME TO`` / ``RENAME VALUE`` — the name an N-1 reader uses disappears."""
+
+    kind: str | None = None
+    old: str | None = None
+    new: str | None = None
+
+
+@dataclass(frozen=True)
+class AddEnumValue(DdlOperation):
+    """``ALTER TYPE … ADD VALUE`` — additive; non-transactional below PG 12."""
+
+    type_name: str | None = None
+    value: str | None = None
+
+
+@dataclass(frozen=True)
+class Benign(DdlOperation):
+    """An operation with no replica forward-compatibility impact.
+
+    Carried as a typed operation rather than dropped: the difference between
+    "classified, and it is fine" and "never looked" is the whole of #206.
+    """
+
+    kind: str | None = None
+
+
+@dataclass(frozen=True)
 class Other(DdlOperation):
-    """An operation the classifier could not map (e.g. dynamic SQL)."""
+    """An operation the classifier could not map (e.g. dynamic SQL).
+
+    The fallback for every unrecognised statement, in both backends. It routes to
+    ``PFLIGHT_REPLICA_UNCLASSIFIED`` — a warning, so opacity never hard-blocks —
+    and flips ``window_safe`` to false, which is the fail-safe direction.
+    """
 
     reason: str | None = None
 
@@ -153,7 +315,39 @@ class OperationClassifier:
                 )
             elif name == "CreateStmt":
                 ops.append(CreateTable(table=_relname(node.relation)))
+            elif name not in _AST_SKIP:
+                ops.extend(self._ast_wider(node, name))
         return ops
+
+    def _ast_wider(self, node: object, name: str) -> list[DdlOperation]:
+        """Classify a statement outside the original seven-operation matrix (#206).
+
+        Everything that reaches here either maps to a typed operation or becomes
+        :class:`Other`. Returning an empty list is what made ``DROP TABLE``
+        certify as window-safe, so this method never does.
+        """
+        if name == "DropStmt":
+            return _ast_drop(node)
+        if name == "TruncateStmt":
+            return [
+                Truncate(table=_relname(relation))
+                for relation in getattr(node, "relations", None) or ()
+            ] or [Truncate()]
+        if name == "GrantStmt":
+            if getattr(node, "is_grant", True):
+                return [Benign(kind="grant")]
+            return [Revoke(table=_first_relname(getattr(node, "objects", None)))]
+        if name == "AlterEnumStmt":
+            return [_ast_alter_enum(node)]
+        if name == "ViewStmt":
+            return [_replace_or_benign(node, "view", _relname(getattr(node, "view", None)))]
+        if name == "CreateFunctionStmt":
+            noun = "procedure" if getattr(node, "is_procedure", False) else "function"
+            return [_replace_or_benign(node, noun, _name_parts(getattr(node, "funcname", None)))]
+        benign = _AST_BENIGN.get(name)
+        if benign is not None:
+            return [Benign(table=_relname(getattr(node, "relation", None)), kind=benign)]
+        return [Other(reason=_readable_node(name))]
 
     def _ast_alter_table(self, node: object) -> list[DdlOperation]:
         table = _relname(getattr(node, "relation", None))
@@ -179,13 +373,25 @@ class OperationClassifier:
                 kind = _CONSTR_KIND.get(_enum_int(getattr(constraint, "contype", None)) or -1)
                 not_valid = bool(getattr(constraint, "skip_validation", False))
                 ops.append(AddConstraint(table=table, kind=kind, not_valid=not_valid))
+            elif subtype == _AT_SET_NOT_NULL:
+                ops.append(SetNotNull(table=table, column=cmd.name))
+            elif subtype in _AT_BENIGN:
+                ops.append(Benign(table=table, kind=_AT_BENIGN[subtype]))
+            else:
+                ops.append(Other(table=table, reason="ALTER TABLE subcommand"))
         return ops
 
     def _ast_rename(self, node: object) -> DdlOperation | None:
-        if _enum_int(getattr(node, "renameType", None)) != _RENAME_COLUMN:
-            return None
-        return RenameColumn(
+        if _enum_int(getattr(node, "renameType", None)) == _RENAME_COLUMN:
+            return RenameColumn(
+                table=_relname(getattr(node, "relation", None)),
+                old=getattr(node, "subname", None),
+                new=getattr(node, "newname", None),
+            )
+        # Renaming any other object still retires the name an N-1 reader uses.
+        return RenameObject(
             table=_relname(getattr(node, "relation", None)),
+            kind="object",
             old=getattr(node, "subname", None),
             new=getattr(node, "newname", None),
         )
@@ -197,10 +403,67 @@ class OperationClassifier:
     def _classify_regex(self, sql: str) -> list[DdlOperation]:
         ops: list[DdlOperation] = []
         for stmt in _split_statements(sql):
+            if not stmt.strip() or _RE_SKIP.match(stmt.strip()):
+                continue
             op = self._regex_one(stmt)
-            if op is not None:
-                ops.append(op)
+            ops.append(op if op is not None else self._regex_wider(stmt))
         return ops
+
+    def _regex_wider(self, stmt: str) -> DdlOperation:
+        """The regex twin of :meth:`_ast_wider` — never returns ``None`` (#206)."""
+        s = stmt.strip()
+
+        m = _RE_DROP.match(s)
+        if m:
+            word = re.sub(r"\s+", " ", m.group("what")).lower()
+            name = _norm(_split_names(m.group("names"))[0])
+            if word == "table":
+                return DropTable(table=name)
+            if word in _DROP_UNSAFE_WORDS:
+                return DropObject(table=name, kind=word, name=name)
+            return Benign(table=name, kind=f"drop_{word.replace(' ', '_')}")
+        m = _RE_TRUNCATE.match(s)
+        if m:
+            return Truncate(table=_norm(_split_names(m.group("names"))[0]))
+        m = _RE_REVOKE.match(s)
+        if m:
+            target = _RE_GRANT_TARGET.search(s)
+            return Revoke(table=_norm(target.group("obj")) if target else None)
+        m = _RE_ALTER_ENUM.match(s)
+        if m:
+            type_name = _norm(m.group("type"))
+            if m.group("verb").lower() == "add":
+                return AddEnumValue(table=type_name, type_name=type_name, value=m.group("val"))
+            return RenameObject(table=type_name, kind="enum value", new=m.group("val"))
+        m = _RE_ALTER_TABLE_SUB.match(s)
+        if m:
+            return self._regex_alter_sub(_norm(m.group("table")), m.group("rest").strip())
+        m = _RE_REPLACE_OBJECT.match(s)
+        if m:
+            noun = re.sub(r"\s+", " ", m.group("what")).lower()
+            return ReplaceObject(
+                table=_norm(m.group("name")), kind=noun, name=_norm(m.group("name"))
+            )
+        for pattern, kind in _RE_BENIGN:
+            m = pattern.match(s)
+            if m:
+                return Benign(table=_norm(m.groupdict().get("name")), kind=kind)
+        return Other(reason=_command_head(s))
+
+    def _regex_alter_sub(self, table: str | None, rest: str) -> DdlOperation:
+        """An ALTER TABLE subcommand the matrix patterns did not match."""
+        low = rest.lower()
+        if _RE_AT_SET_NOT_NULL.match(rest):
+            m = _RE_AT_ALTER_COLUMN.match(rest)
+            return SetNotNull(table=table, column=_norm(m.group("col")) if m else None)
+        if _RE_AT_RENAME_TO.match(rest):
+            return RenameObject(table=table, kind="object", new=_norm(rest.split()[-1]))
+        for pattern, kind in _RE_AT_BENIGN:
+            if pattern.match(rest):
+                return Benign(table=table, kind=kind)
+        if low.startswith("owner to"):
+            return Benign(table=table, kind="change_owner")
+        return Other(table=table, reason="ALTER TABLE subcommand")
 
     def _regex_one(self, stmt: str) -> DdlOperation | None:
         s = stmt.strip()
@@ -282,6 +545,69 @@ def _enum_int(value: object) -> int | None:
         return None
 
 
+def _readable_node(node_name: str) -> str:
+    """`CreateStatsStmt` → `create stats statement`, for the finding's reason."""
+    words = re.findall(r"[A-Z][a-z0-9]*|[a-z0-9]+", node_name)
+    return " ".join(word.lower() for word in words) or node_name
+
+
+def _name_parts(raw: Any) -> str | None:
+    """Join a pglast list of ``String`` name parts into a dotted identifier."""
+    parts = [str(getattr(part, "sval", part)) for part in raw or ()]
+    return ".".join(part.lower() for part in parts if part) or None
+
+
+def _first_relname(objects: Any) -> str | None:
+    for obj in objects or ():
+        name = _relname(obj)
+        if name:
+            return name
+    return None
+
+
+def _ast_drop(node: object) -> list[DdlOperation]:
+    """One operation per dropped object, never an empty list."""
+    remove_type = _enum_int(getattr(node, "removeType", None))
+    names = [_object_name(obj) for obj in getattr(node, "objects", None) or ()] or [None]
+    if remove_type == _OBJECT_TABLE:
+        return [DropTable(table=name) for name in names]
+    if remove_type in _DROP_UNSAFE_KIND:
+        kind = _DROP_UNSAFE_KIND[remove_type]
+        return [DropObject(table=name, kind=kind, name=name) for name in names]
+    if remove_type in _DROP_BENIGN_KIND:
+        kind = _DROP_BENIGN_KIND[remove_type]
+        return [Benign(table=name, kind=kind) for name in names]
+    return [Other(table=name, reason="DROP of an unclassified object type") for name in names]
+
+
+def _object_name(obj: object) -> str | None:
+    """Flatten one ``DropStmt.objects`` element into a dotted identifier."""
+    inner = getattr(obj, "objname", obj)  # ObjectWithArgs → its name
+    sval = getattr(inner, "sval", None)
+    if sval is not None:
+        return str(sval).lower()
+    if isinstance(inner, (list, tuple)):
+        return _name_parts(inner)
+    return _norm(str(inner)) if inner is not None else None
+
+
+def _ast_alter_enum(node: object) -> DdlOperation:
+    """`ADD VALUE` is additive; `RENAME VALUE` retires a value readers match on."""
+    type_name = _name_parts(getattr(node, "typeName", None))
+    old = getattr(node, "oldVal", None)
+    new = getattr(node, "newVal", None)
+    if old is None:
+        return AddEnumValue(table=type_name, type_name=type_name, value=new)
+    return RenameObject(table=type_name, kind="enum value", old=old, new=new)
+
+
+def _replace_or_benign(node: object, noun: str, name: str | None) -> DdlOperation:
+    """`CREATE OR REPLACE` is a body swap confiture cannot judge; plain CREATE is additive."""
+    if bool(getattr(node, "replace", False)):
+        return ReplaceObject(table=name, kind=noun, name=name)
+    return Benign(table=name, kind=f"create_{noun.replace(' ', '_')}")
+
+
 def _column_is_not_null(coldef: object) -> bool:
     if bool(getattr(coldef, "is_not_null", False)):
         return True
@@ -314,10 +640,13 @@ def _constraint_kind_from_text(stmt: str) -> str | None:
 
 
 def _split_statements(sql: str) -> list[str]:
-    """Naive top-level split on ';' (regex fallback only)."""
-    # Strip line comments to avoid splitting on ';' inside them.
-    no_comments = re.sub(r"--[^\n]*", "", sql)
-    return no_comments.split(";")
+    """Top-level split, shared with ``core/change_set.py``.
+
+    Must stay dollar-quote aware: a naive ``split(";")`` shreds a ``CREATE
+    FUNCTION`` body, and since #206 each fragment would surface as a spurious
+    UNCLASSIFIED finding rather than being silently dropped.
+    """
+    return split_statements(sql)
 
 
 _RE_ADD_COLUMN = re.compile(
@@ -368,3 +697,176 @@ _RE_CREATE_TABLE = re.compile(
     + _IDENT.format(name="table"),
     re.IGNORECASE,
 )
+
+# --------------------------------------------------------------------------- #
+# Widened regex surface (#206) — the twin of the _ast_wider tables above.
+# --------------------------------------------------------------------------- #
+
+_ANY = r'(?:"[^"]+"|[A-Za-z_][\w$]*)(?:\.(?:"[^"]+"|[A-Za-z_][\w$]*))*'
+
+# Statement heads that change neither schema nor data (the regex twin of _AST_SKIP).
+_RE_SKIP = re.compile(
+    r"^(?:BEGIN|COMMIT|END|ROLLBACK|START\s+TRANSACTION|SAVEPOINT|RELEASE\b|SET\b|RESET\b"
+    r"|SHOW\b|CHECKPOINT|DISCARD\b|LOCK\b|VACUUM\b|ANALYZE\b|ANALYSE\b|LISTEN\b|NOTIFY\b"
+    r"|UNLISTEN\b)",
+    re.IGNORECASE,
+)
+
+_RE_DROP = re.compile(
+    r"^DROP\s+(?P<what>TABLE|INDEX|MATERIALIZED\s+VIEW|VIEW|SEQUENCE|SCHEMA|TYPE|DOMAIN"
+    r"|FUNCTION|PROCEDURE|TRIGGER|POLICY|RULE|EXTENSION)\s+"
+    r"(?:CONCURRENTLY\s+)?(?:IF\s+EXISTS\s+)?(?P<names>.+)$",
+    re.IGNORECASE | re.DOTALL,
+)
+# Dropping any of these retires a name an N-1 reader may still resolve.
+_DROP_UNSAFE_WORDS = frozenset(
+    {
+        "view",
+        "materialized view",
+        "sequence",
+        "schema",
+        "type",
+        "domain",
+        "function",
+        "procedure",
+        "extension",
+    }
+)
+
+_RE_TRUNCATE = re.compile(
+    r"^TRUNCATE\s+(?:TABLE\s+)?(?:ONLY\s+)?(?P<names>.+)$", re.IGNORECASE | re.DOTALL
+)
+_RE_REVOKE = re.compile(r"^REVOKE\b", re.IGNORECASE)
+_RE_GRANT_TARGET = re.compile(
+    rf"\bON\s+(?:TABLE\s+|SEQUENCE\s+|SCHEMA\s+)?(?P<obj>{_ANY})", re.IGNORECASE
+)
+_RE_ALTER_ENUM = re.compile(
+    rf"^ALTER\s+TYPE\s+(?P<type>{_ANY})\s+(?P<verb>ADD|RENAME)\s+VALUE\s+"
+    r"(?:IF\s+NOT\s+EXISTS\s+)?'(?P<val>[^']*)'",
+    re.IGNORECASE,
+)
+_RE_ALTER_TABLE_SUB = re.compile(
+    rf"^ALTER\s+(?:TABLE|MATERIALIZED\s+VIEW|VIEW|FOREIGN\s+TABLE)\s+(?:IF\s+EXISTS\s+)?"
+    rf"(?:ONLY\s+)?(?P<table>{_ANY})\s+(?P<rest>.*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+_RE_REPLACE_OBJECT = re.compile(
+    rf"^CREATE\s+OR\s+REPLACE\s+(?P<what>VIEW|MATERIALIZED\s+VIEW|FUNCTION|PROCEDURE)\s+"
+    rf"(?P<name>{_ANY})",
+    re.IGNORECASE,
+)
+
+_RE_AT_SET_NOT_NULL = re.compile(
+    rf"^ALTER\s+(?:COLUMN\s+)?{_ANY}\s+SET\s+NOT\s+NULL", re.IGNORECASE
+)
+_RE_AT_ALTER_COLUMN = re.compile(rf"^ALTER\s+(?:COLUMN\s+)?(?P<col>{_ANY})", re.IGNORECASE)
+_RE_AT_RENAME_TO = re.compile(r"^RENAME\s+TO\b", re.IGNORECASE)
+_RE_AT_BENIGN: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(rf"^ALTER\s+(?:COLUMN\s+)?{_ANY}\s+DROP\s+NOT\s+NULL", re.IGNORECASE),
+        "drop_not_null",
+    ),
+    (
+        re.compile(rf"^ALTER\s+(?:COLUMN\s+)?{_ANY}\s+SET\s+DEFAULT", re.IGNORECASE),
+        "column_default",
+    ),
+    (
+        re.compile(rf"^ALTER\s+(?:COLUMN\s+)?{_ANY}\s+DROP\s+DEFAULT", re.IGNORECASE),
+        "column_default",
+    ),
+    (re.compile(r"^DROP\s+CONSTRAINT\b", re.IGNORECASE), "drop_constraint"),
+)
+
+# `head → kind` for statements that are additive or invisible to an N-1 reader.
+_RE_BENIGN: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            rf"^CREATE\s+MATERIALIZED\s+VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_ANY})",
+            re.IGNORECASE,
+        ),
+        "create_materialized_view",
+    ),
+    (re.compile(rf"^CREATE\s+(?:\w+\s+)*?VIEW\s+(?P<name>{_ANY})", re.IGNORECASE), "create_view"),
+    (re.compile(rf"^CREATE\s+FUNCTION\s+(?P<name>{_ANY})", re.IGNORECASE), "create_function"),
+    (re.compile(rf"^CREATE\s+PROCEDURE\s+(?P<name>{_ANY})", re.IGNORECASE), "create_procedure"),
+    (
+        re.compile(rf"^CREATE\s+SCHEMA\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_ANY})", re.IGNORECASE),
+        "create_schema",
+    ),
+    (
+        re.compile(
+            rf"^CREATE\s+SEQUENCE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_ANY})", re.IGNORECASE
+        ),
+        "create_sequence",
+    ),
+    (re.compile(rf"^CREATE\s+TYPE\s+(?P<name>{_ANY})", re.IGNORECASE), "create_type"),
+    (re.compile(rf"^CREATE\s+DOMAIN\s+(?P<name>{_ANY})", re.IGNORECASE), "create_domain"),
+    (
+        re.compile(
+            rf"^CREATE\s+EXTENSION\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_ANY})", re.IGNORECASE
+        ),
+        "create_extension",
+    ),
+    (
+        re.compile(rf"^CREATE\s+(?:CONSTRAINT\s+)?TRIGGER\s+(?P<name>{_ANY})", re.IGNORECASE),
+        "create_trigger",
+    ),
+    (re.compile(rf"^CREATE\s+POLICY\s+(?P<name>{_ANY})", re.IGNORECASE), "create_policy"),
+    (re.compile(rf"^CREATE\s+RULE\s+(?P<name>{_ANY})", re.IGNORECASE), "create_rule"),
+    (re.compile(r"^GRANT\b", re.IGNORECASE), "grant"),
+    (re.compile(rf"^COMMENT\s+ON\s+(?:\w+\s+)+?(?P<name>{_ANY})", re.IGNORECASE), "comment"),
+    (re.compile(rf"^INSERT\s+INTO\s+(?P<name>{_ANY})", re.IGNORECASE), "insert"),
+    (re.compile(rf"^UPDATE\s+(?:ONLY\s+)?(?P<name>{_ANY})", re.IGNORECASE), "update"),
+    (re.compile(rf"^DELETE\s+FROM\s+(?:ONLY\s+)?(?P<name>{_ANY})", re.IGNORECASE), "delete"),
+    (
+        re.compile(
+            rf"^REFRESH\s+MATERIALIZED\s+VIEW\s+(?:CONCURRENTLY\s+)?(?P<name>{_ANY})", re.IGNORECASE
+        ),
+        "refresh_materialized_view",
+    ),
+    (re.compile(rf"^CLUSTER\s+(?P<name>{_ANY})", re.IGNORECASE), "cluster"),
+    (re.compile(rf"^REINDEX\s+(?:\w+\s+)?(?P<name>{_ANY})", re.IGNORECASE), "reindex"),
+    (
+        re.compile(rf"^ALTER\s+SEQUENCE\s+(?:IF\s+EXISTS\s+)?(?P<name>{_ANY})", re.IGNORECASE),
+        "alter_sequence",
+    ),
+    (re.compile(r"^ALTER\s+DEFAULT\s+PRIVILEGES\b", re.IGNORECASE), "alter_default_privileges"),
+    (re.compile(r"^(?:SELECT|TABLE|VALUES|WITH)\b", re.IGNORECASE), "select"),
+    (
+        re.compile(
+            rf"^CREATE\s+(?:GLOBAL\s+|LOCAL\s+)?(?:UNLOGGED\s+|TEMPORARY\s+|TEMP\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<name>{_ANY})\s+AS\b",
+            re.IGNORECASE,
+        ),
+        "create_table_as",
+    ),
+)
+
+
+def _split_names(raw: str) -> list[str]:
+    """Split `a, b.c` into names, dropping any argument list or trailing clause."""
+    names = []
+    for chunk in re.sub(
+        r"\b(?:CASCADE|RESTRICT)\b.*$", "", raw, flags=re.IGNORECASE | re.DOTALL
+    ).split(","):
+        name = chunk.strip().split("(")[0].strip()
+        name = name.split()[0] if name.split() else ""
+        if name:
+            names.append(name)
+    return names or [""]
+
+
+def _command_head(statement: str, *, words: int = 4) -> str:
+    """The leading keywords of a statement, with every literal stripped.
+
+    The reason reaches an operator, and an unclassified statement is exactly the
+    kind that might carry a credential (``CREATE USER … PASSWORD 'x'``). Only bare
+    word tokens survive.
+    """
+    tokens: list[str] = []
+    for token in statement.split():
+        if not re.fullmatch(r"[A-Za-z_][\w$.]*", token):
+            break
+        tokens.append(token.lower())
+        if len(tokens) >= words:
+            break
+    return " ".join(tokens) or "statement"

--- a/python/confiture/core/replica/classifier.py
+++ b/python/confiture/core/replica/classifier.py
@@ -17,6 +17,7 @@ from confiture.core._pglast_enums import enums_are_usable
 from confiture.core._pglast_enums import member as _pg_member
 from confiture.core.idempotency.ast_detector import is_pglast_available
 from confiture.core.sql_statements import split_statements
+from confiture.core.type_lattice import canonical_type
 
 # pglast availability, resolved at import (tests monkeypatch this to force the
 # regex backend, mirroring the idempotency CONFITURE_IDEMPOTENCY_FORCE_REGEX
@@ -168,6 +169,15 @@ class RenameColumn(DdlOperation):
 @dataclass(frozen=True)
 class ChangeColumnType(DdlOperation):
     column: str | None = None
+
+    new_type: str | None = None
+    """The target type, as written in the statement."""
+
+    old_type: str | None = None
+    """The current type. **Never present from SQL** — ``ALTER TABLE … ALTER COLUMN
+    … TYPE`` states only the target — so it is filled in from the differ or a live
+    database, and stays ``None`` otherwise. Without it the direction is unknown,
+    which is why the risk tier for a type change is absent by default."""
 
 
 @dataclass(frozen=True)
@@ -367,7 +377,13 @@ class OperationClassifier:
             elif subtype == _AT_DROP_COLUMN:
                 ops.append(DropColumn(table=table, column=cmd.name))
             elif subtype == _AT_ALTER_COLUMN_TYPE:
-                ops.append(ChangeColumnType(table=table, column=cmd.name))
+                ops.append(
+                    ChangeColumnType(
+                        table=table,
+                        column=cmd.name,
+                        new_type=canonical_type(_type_name(getattr(cmd.def_, "typeName", None))),
+                    )
+                )
             elif subtype == _AT_ADD_CONSTRAINT:
                 constraint = cmd.def_
                 kind = _CONSTR_KIND.get(_enum_int(getattr(constraint, "contype", None)) or -1)
@@ -492,7 +508,11 @@ class OperationClassifier:
             )
         m = _RE_ALTER_TYPE.match(s)
         if m:
-            return ChangeColumnType(table=_norm(m.group("table")), column=_norm(m.group("col")))
+            return ChangeColumnType(
+                table=_norm(m.group("table")),
+                column=_norm(m.group("col")),
+                new_type=canonical_type(_clean_type(m.group("newtype"))),
+            )
         m = _RE_ADD_CONSTRAINT.match(s)
         if m:
             return AddConstraint(
@@ -555,6 +575,39 @@ def _name_parts(raw: Any) -> str | None:
     """Join a pglast list of ``String`` name parts into a dotted identifier."""
     parts = [str(getattr(part, "sval", part)) for part in raw or ()]
     return ".".join(part.lower() for part in parts if part) or None
+
+
+def _clean_type(raw: str | None) -> str | None:
+    """Trim a type captured from SQL, dropping a trailing `USING`/`NOT NULL` tail."""
+    if not raw:
+        return None
+    text = re.sub(r"\s+", " ", raw).strip().rstrip(",;")
+    text = re.split(r"\b(?:USING|COLLATE|NOT|NULL|DEFAULT)\b", text, flags=re.IGNORECASE)[0]
+    return text.strip() or None
+
+
+def _type_name(type_node: Any) -> str | None:
+    """Render a pglast ``TypeName`` back to ``varchar(50)`` / ``numeric(10,2)``.
+
+    The ``pg_catalog`` qualifier the parser adds is dropped; the internal spelling
+    (``int8``) is left alone, since :mod:`confiture.core.type_lattice` aliases it.
+    """
+    if type_node is None:
+        return None
+    parts = [str(getattr(part, "sval", part)) for part in getattr(type_node, "names", None) or ()]
+    names = [part for part in parts if part and part != "pg_catalog"]
+    if not names:
+        return None
+    name = ".".join(names)
+    mods = [
+        str(ival)
+        for ival in (
+            getattr(getattr(mod, "val", None), "ival", None)
+            for mod in getattr(type_node, "typmods", None) or ()
+        )
+        if ival is not None
+    ]
+    return f"{name}({', '.join(mods)})" if mods else name
 
 
 def _first_relname(objects: Any) -> str | None:
@@ -678,7 +731,7 @@ _RE_ALTER_TYPE = re.compile(
     + _IDENT.format(name="table")
     + r"\s+ALTER\s+COLUMN\s+"
     + _IDENT.format(name="col")
-    + r"\s+(?:SET\s+DATA\s+)?TYPE\s+",
+    + r"\s+(?:SET\s+DATA\s+)?TYPE\s+(?P<newtype>[\w ]+(?:\(\s*\d+\s*(?:,\s*\d+\s*)?\))?)",
     re.IGNORECASE,
 )
 _RE_ADD_CONSTRAINT = re.compile(

--- a/python/confiture/core/replica/safety.py
+++ b/python/confiture/core/replica/safety.py
@@ -13,13 +13,22 @@ from dataclasses import dataclass
 from confiture.core.replica.classifier import (
     AddColumn,
     AddConstraint,
+    AddEnumValue,
+    Benign,
     ChangeColumnType,
     CreateIndex,
     CreateTable,
     DdlOperation,
     DropColumn,
+    DropObject,
+    DropTable,
     Other,
     RenameColumn,
+    RenameObject,
+    ReplaceObject,
+    Revoke,
+    SetNotNull,
+    Truncate,
 )
 
 # Severity policy threshold: replicas declared → unsafe ops are errors.
@@ -86,6 +95,55 @@ def classify_replica_safety(op: DdlOperation) -> ReplicaVerdict:
             multi_step="use CREATE INDEX CONCURRENTLY in its own non-transactional migration",
         )
     if isinstance(op, CreateTable):
+        return ReplicaVerdict("safe")
+    if isinstance(op, DropTable):
+        return ReplicaVerdict(
+            "unsafe",
+            reason="readers on the old version still SELECT from the table",
+            multi_step="stop reading the table → wait one release → drop it",
+        )
+    if isinstance(op, DropObject):
+        return ReplicaVerdict(
+            "unsafe",
+            reason=f"readers on the old version still reference the {op.kind or 'object'}",
+            multi_step=f"stop using the {op.kind or 'object'} → wait one release → drop it",
+        )
+    if isinstance(op, Truncate):
+        return ReplicaVerdict(
+            "unsafe",
+            reason="the rows readers on the old version expect are removed",
+            multi_step="stop reading the table → wait one release → truncate it",
+        )
+    if isinstance(op, Revoke):
+        return ReplicaVerdict(
+            "unsafe",
+            reason="a privilege readers on the old version still rely on may be withdrawn",
+            multi_step="migrate readers off the privilege → wait one release → revoke it",
+        )
+    if isinstance(op, SetNotNull):
+        return ReplicaVerdict(
+            "unsafe",
+            reason="writers on the old version still insert NULL into the column",
+            multi_step="backfill → migrate writers → SET NOT NULL in a later release",
+        )
+    if isinstance(op, RenameObject):
+        return ReplicaVerdict(
+            "unsafe",
+            reason=f"readers reference the old {op.kind or 'object'} name during the lag window",
+            multi_step="add the new name → migrate readers → retire the old name",
+        )
+    if isinstance(op, ReplaceObject):
+        # A replacement body can be identical, additive, or a signature change;
+        # nothing in the statement says which, so this is `depends` (a warning)
+        # rather than a guess in either direction.
+        return ReplicaVerdict(
+            "depends",
+            reason=(
+                f"CREATE OR REPLACE {op.kind or 'object'}: confiture cannot tell whether the "
+                "new definition stays compatible with readers on the old version; review manually"
+            ),
+        )
+    if isinstance(op, (AddEnumValue, Benign)):
         return ReplicaVerdict("safe")
     if isinstance(op, Other):
         return ReplicaVerdict(

--- a/python/confiture/core/schema_facts.py
+++ b/python/confiture/core/schema_facts.py
@@ -1,0 +1,124 @@
+"""What a live database can tell preflight that migration files cannot (issue #199).
+
+Preflight is a filesystem-only check by design, and that stays the primary path:
+everything here is **strictly additive**. Two facts are worth a connection when
+one is already open, because neither is recoverable from the migration SQL:
+
+* **The current column type.** ``ALTER TABLE … ALTER COLUMN … TYPE bigint`` names
+  the target and never the source, so without the database confiture cannot tell
+  a widening from a narrowing — and so, honestly, emits no risk tier at all.
+* **The server version.** Two rows of the lock table changed with a PostgreSQL
+  release. Knowing the version turns the conservative reading into the true one.
+
+Collection never raises: a database that refuses the introspection query yields
+empty facts, and every consumer degrades to the static answer. Losing the
+refinement is acceptable; failing a preflight because of it is not.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ["SchemaFacts", "collect_schema_facts"]
+
+# Columns of interest live in user schemas; the catalogs never do.
+_COLUMN_TYPE_SQL = """
+SELECT n.nspname, c.relname, a.attname, format_type(a.atttypid, a.atttypmod)
+FROM pg_attribute a
+JOIN pg_class c ON c.oid = a.attrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE a.attnum > 0
+  AND NOT a.attisdropped
+  AND c.relkind IN ('r', 'p', 'm', 'v', 'f')
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+  AND n.nspname NOT LIKE 'pg_toast%'
+"""
+
+
+@dataclass(frozen=True)
+class SchemaFacts:
+    """Facts read from a live database, all optional.
+
+    An empty instance is the "no database" case and must produce exactly the
+    static answer everywhere it is consulted.
+    """
+
+    server_version: int | None = None
+    """The PostgreSQL **major** (``16``), or ``None`` when it was not read."""
+
+    column_types: Mapping[str, str] = field(default_factory=dict)
+    """``schema.table.column`` (case-folded) → the column's current type."""
+
+    def column_type(self, qualified: str | None) -> str | None:
+        """The current type of ``schema.table.column``, or ``None`` if unknown."""
+        if not qualified:
+            return None
+        return self.column_types.get(qualified.lower())
+
+    def __bool__(self) -> bool:
+        """False when nothing was learned, so callers can skip the refined path."""
+        return self.server_version is not None or bool(self.column_types)
+
+
+def collect_schema_facts(conn: Any) -> SchemaFacts:
+    """Read the facts above from an open connection. Never raises.
+
+    ``conn`` is a psycopg connection, typed loosely so this module stays
+    importable on the no-database path without dragging psycopg in with it.
+    """
+    return SchemaFacts(
+        server_version=_server_version(conn),
+        column_types=_column_types(conn),
+    )
+
+
+def _server_version(conn: Any) -> int | None:
+    """The server *major* version.
+
+    Prefers the connection's own attribute (no round trip); falls back to
+    ``SHOW server_version_num``. psycopg reports ``160004`` for 16.4, and 90603
+    for the 9.x scheme — both floor-divide to the major by the same rule only
+    above 10, so the 9.x case is handled explicitly.
+    """
+    raw = getattr(getattr(conn, "info", None), "server_version", None)
+    if raw is None:
+        raw = _scalar(conn, "SHOW server_version_num")
+    try:
+        number = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number // 10000 if number >= 100000 else number // 10000 or number // 100 % 100
+
+
+def _column_types(conn: Any) -> dict[str, str]:
+    try:
+        with conn.cursor() as cur:
+            cur.execute(_COLUMN_TYPE_SQL)
+            rows = cur.fetchall()
+    except Exception:  # noqa: BLE001 — refinement is optional; never fail preflight for it
+        return {}
+    types: dict[str, str] = {}
+    for row in rows or ():
+        try:
+            schema, table, column, data_type = row[0], row[1], row[2], row[3]
+        except (IndexError, TypeError):
+            continue
+        if schema and table and column and data_type:
+            types[f"{schema}.{table}.{column}".lower()] = str(data_type)
+    return types
+
+
+def _scalar(conn: Any, sql: str) -> object | None:
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            row = cur.fetchone()
+    except Exception:  # noqa: BLE001 — see above
+        return None
+    return row[0] if row else None

--- a/python/confiture/core/sql_statements.py
+++ b/python/confiture/core/sql_statements.py
@@ -1,0 +1,84 @@
+"""Split a SQL script into top-level statements.
+
+Shared by the two statement walkers — ``core/change_set.py`` (risk tiers, #197)
+and ``core/replica/classifier.py`` (the ``window_safe`` verdict, #154). Both
+previously carried their own splitter, and the replica one was a bare
+``sql.split(";")`` that shredded a dollar-quoted function body into fragments.
+That was invisible while unrecognised fragments were silently dropped; once they
+became ``Other`` (#206) each fragment would have raised a spurious
+``PFLIGHT_REPLICA_UNCLASSIFIED`` finding.
+
+The splitter is deliberately lexical rather than a parser: it runs on the regex
+fallback path, where pglast is unavailable by definition.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["split_statements"]
+
+_DOLLAR_TAG = re.compile(r"\$(?:[A-Za-z_]\w*)?\$")
+
+
+def split_statements(sql: str) -> list[str]:
+    """Split on top-level ``;``, respecting dollar-quoted bodies, literals and comments.
+
+    Returns the non-empty statements, stripped. A trailing ``;`` yields no empty
+    final element.
+    """
+    statements: list[str] = []
+    buf: list[str] = []
+    index = 0
+    length = len(sql)
+    tag: str | None = None
+
+    while index < length:
+        char = sql[index]
+        if tag is not None:
+            if sql.startswith(tag, index):
+                buf.append(tag)
+                index += len(tag)
+                tag = None
+            else:
+                buf.append(char)
+                index += 1
+            continue
+        if char == "$":
+            opener = _DOLLAR_TAG.match(sql, index)
+            if opener:
+                tag = opener.group(0)
+                buf.append(tag)
+                index += len(tag)
+                continue
+        if char == "'":
+            end = index + 1
+            while end < length:
+                if sql[end] == "'":
+                    if end + 1 < length and sql[end + 1] == "'":
+                        end += 2
+                        continue
+                    end += 1
+                    break
+                end += 1
+            buf.append(sql[index:end])
+            index = end
+            continue
+        if sql.startswith("--", index):
+            newline = sql.find("\n", index)
+            index = length if newline == -1 else newline
+            continue
+        if sql.startswith("/*", index):
+            close = sql.find("*/", index)
+            index = length if close == -1 else close + 2
+            continue
+        if char == ";":
+            statements.append("".join(buf))
+            buf = []
+            index += 1
+            continue
+        buf.append(char)
+        index += 1
+
+    statements.append("".join(buf))
+    return [stripped for stripped in (s.strip() for s in statements) if stripped]

--- a/python/confiture/core/type_lattice.py
+++ b/python/confiture/core/type_lattice.py
@@ -1,0 +1,265 @@
+"""Is an `ALTER COLUMN … TYPE` widening or narrowing (issue #199)?
+
+`bigint`→`integer` silently loses data or aborts mid-migration; `integer`→`bigint`
+cannot. `ChangeColumnType` carried only the table and column, so preflight had to
+treat both alike — and, having no honest answer, emitted no risk tier at all.
+
+Two questions are answered separately because their answers differ:
+
+* :func:`compare_types` — the **semantic** direction. Drives the risk tier:
+  narrowing destroys data with no down path.
+* :func:`changes_rewrite_table` — whether PostgreSQL **rewrites the heap**.
+  Drives the lock cost. `varchar(50)`→`text` is widening *and* rewrite-free;
+  `integer`→`bigint` is widening but still rewrites every page.
+
+Only the rewrite exemptions PostgreSQL documents are claimed: a rewrite is
+skipped when the old type is binary-coercible to the new one, which for the types
+here means the unconstrained-length string cases. Everything else — including
+`numeric(10,2)`→`numeric(12,2)`, which merely *looks* free — is reported as a
+rewrite. Guessing in the cheap direction is the failure this module exists to
+prevent.
+
+An unrecognised or user-defined type is :attr:`TypeChange.UNKNOWN`, never
+optimistic. The old type is absent from `ALTER TABLE … ALTER COLUMN … TYPE`
+altogether — SQL states only the target — so it has to come from the differ or a
+live database, and when it does not, the answer stays UNKNOWN.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = [
+    "SqlType",
+    "canonical_type",
+    "TypeChange",
+    "changes_rewrite_table",
+    "compare_types",
+    "parse_type",
+]
+
+
+class TypeChange(Enum):
+    """The direction of a column type change."""
+
+    IDENTICAL = "identical"
+    """The same type. Nothing to reason about."""
+
+    WIDENING = "widening"
+    """Every value of the old type is representable in the new one."""
+
+    NARROWING = "narrowing"
+    """Values can be lost, truncated, or rejected outright."""
+
+    LATERAL = "lateral"
+    """Same family or cross-family with a meaning change, not a pure width move."""
+
+    UNKNOWN = "unknown"
+    """A type confiture does not model, or a missing side. Never treated as safe."""
+
+
+@dataclass(frozen=True)
+class SqlType:
+    """A parsed SQL type name with its typmod, normalised to a canonical spelling."""
+
+    name: str
+    precision: int | None = None
+    scale: int | None = None
+
+
+# Aliases → the canonical name used throughout the lattice.
+_ALIASES = {
+    "int": "integer",
+    "int4": "integer",
+    "int2": "smallint",
+    "int8": "bigint",
+    "serial": "integer",
+    "bigserial": "bigint",
+    "smallserial": "smallint",
+    "bool": "boolean",
+    "character varying": "varchar",
+    "character": "char",
+    "bpchar": "char",
+    "decimal": "numeric",
+    "float4": "real",
+    "float8": "double precision",
+    "double": "double precision",
+    "timestamp without time zone": "timestamp",
+    "timestamp with time zone": "timestamptz",
+    "time without time zone": "time",
+    "time with time zone": "timetz",
+}
+
+# Ordered families: a later member represents every value of an earlier one.
+_INTEGER_WIDTHS = {"smallint": 16, "integer": 32, "bigint": 64}
+_FLOAT_WIDTHS = {"real": 24, "double precision": 53}
+_TEMPORAL_WIDTHS = {"date": 1, "timestamp": 2}
+
+_EXACT_NUMERIC = frozenset({*_INTEGER_WIDTHS, "numeric"})
+_STRING = frozenset({"varchar", "text", "char"})
+
+_TYPE_RE = re.compile(
+    r"^\s*(?P<name>[A-Za-z_][\w ]*?)\s*(?:\(\s*(?P<p>\d+)\s*(?:,\s*(?P<s>\d+)\s*)?\))?\s*"
+    r"(?:\[\s*\])?\s*$"
+)
+
+
+def parse_type(raw: str | None) -> SqlType | None:
+    """Parse ``varchar(50)`` / ``numeric(10,2)`` / ``bigint`` into a :class:`SqlType`.
+
+    Returns ``None`` when ``raw`` is empty or not a plain type reference.
+    """
+    if not raw:
+        return None
+    match = _TYPE_RE.match(raw)
+    if not match:
+        return None
+    name = re.sub(r"\s+", " ", match.group("name")).strip().lower()
+    name = _ALIASES.get(name, name)
+    precision = int(match.group("p")) if match.group("p") else None
+    scale = int(match.group("s")) if match.group("s") else None
+    return SqlType(name=name, precision=precision, scale=scale)
+
+
+def compare_types(old: str | None, new: str | None) -> TypeChange:
+    """The semantic direction of ``old`` → ``new``.
+
+    Either side missing yields :attr:`TypeChange.UNKNOWN`: the old type is not in
+    the SQL, and a missing side must never read as safe.
+    """
+    old_type, new_type = parse_type(old), parse_type(new)
+    if old_type is None or new_type is None:
+        return TypeChange.UNKNOWN
+    if old_type == new_type:
+        return TypeChange.IDENTICAL
+    if not _is_modelled(old_type) or not _is_modelled(new_type):
+        return TypeChange.UNKNOWN
+    if old_type.name == new_type.name:
+        return _same_name(old_type, new_type)
+    return _cross_name(old_type, new_type)
+
+
+def _is_modelled(sql_type: SqlType) -> bool:
+    return (
+        sql_type.name in _EXACT_NUMERIC
+        or sql_type.name in _FLOAT_WIDTHS
+        or sql_type.name in _STRING
+        or sql_type.name in _TEMPORAL_WIDTHS
+        or sql_type.name == "timestamptz"
+    )
+
+
+def _same_name(old: SqlType, new: SqlType) -> TypeChange:
+    """Same type name, different typmod."""
+    if old.name in {"varchar", "char"}:
+        return _compare_lengths(old.precision, new.precision)
+    if old.name == "numeric":
+        return _compare_numeric(old, new)
+    return TypeChange.IDENTICAL
+
+
+def _compare_lengths(old_len: int | None, new_len: int | None) -> TypeChange:
+    """``None`` length is unconstrained — the widest a string type can be."""
+    if old_len == new_len:
+        return TypeChange.IDENTICAL
+    if old_len is None:
+        return TypeChange.NARROWING  # unconstrained → constrained
+    if new_len is None:
+        return TypeChange.WIDENING  # constrained → unconstrained
+    return TypeChange.WIDENING if new_len > old_len else TypeChange.NARROWING
+
+
+def _compare_numeric(old: SqlType, new: SqlType) -> TypeChange:
+    """`numeric(p,s)` widens when both the scale and the integral digits grow."""
+    if old.precision is None:
+        # Unconstrained numeric holds more than any constrained one.
+        return TypeChange.IDENTICAL if new.precision is None else TypeChange.NARROWING
+    if new.precision is None:
+        return TypeChange.WIDENING
+    old_scale, new_scale = old.scale or 0, new.scale or 0
+    old_integral = old.precision - old_scale
+    new_integral = new.precision - new_scale
+    if new_scale >= old_scale and new_integral >= old_integral:
+        return TypeChange.WIDENING
+    return TypeChange.NARROWING
+
+
+def _cross_name(old: SqlType, new: SqlType) -> TypeChange:
+    """Different type names."""
+    # Integers and numeric form one exact-numeric ladder.
+    if old.name in _EXACT_NUMERIC and new.name in _EXACT_NUMERIC:
+        if old.name in _INTEGER_WIDTHS and new.name in _INTEGER_WIDTHS:
+            return (
+                TypeChange.WIDENING
+                if _INTEGER_WIDTHS[new.name] > _INTEGER_WIDTHS[old.name]
+                else TypeChange.NARROWING
+            )
+        # numeric holds any integer; the reverse loses the fractional part.
+        return TypeChange.NARROWING if new.name in _INTEGER_WIDTHS else TypeChange.WIDENING
+    if old.name in _FLOAT_WIDTHS and new.name in _FLOAT_WIDTHS:
+        return (
+            TypeChange.WIDENING
+            if _FLOAT_WIDTHS[new.name] > _FLOAT_WIDTHS[old.name]
+            else TypeChange.NARROWING
+        )
+    if old.name in _STRING and new.name in _STRING:
+        return _compare_lengths(_string_length(old), _string_length(new))
+    if old.name in _TEMPORAL_WIDTHS and new.name in _TEMPORAL_WIDTHS:
+        return (
+            TypeChange.WIDENING
+            if _TEMPORAL_WIDTHS[new.name] > _TEMPORAL_WIDTHS[old.name]
+            else TypeChange.NARROWING
+        )
+    # `timestamp` ↔ `timestamptz` reinterprets every stored value against the
+    # session time zone. Not a width move in either direction.
+    if {old.name, new.name} <= {"timestamp", "timestamptz", "date"}:
+        return TypeChange.LATERAL
+    return TypeChange.LATERAL
+
+
+def _string_length(sql_type: SqlType) -> int | None:
+    """`text` is unconstrained; `varchar`/`char` carry their declared length."""
+    return None if sql_type.name == "text" else sql_type.precision
+
+
+# The binary-coercible cases PostgreSQL documents as skipping the heap rewrite.
+# Deliberately short: an unlisted pair rewrites.
+def changes_rewrite_table(old: str | None, new: str | None) -> bool:
+    """Whether PostgreSQL rewrites the heap for ``old`` → ``new``.
+
+    ``True`` whenever confiture cannot prove otherwise, including for an unknown
+    or missing type.
+    """
+    old_type, new_type = parse_type(old), parse_type(new)
+    if old_type is None or new_type is None:
+        return True
+    if old_type == new_type:
+        return False
+    # varchar(n) → varchar(m>n) and varchar/char → text are binary coercible.
+    if old_type.name in {"varchar", "char"} and new_type.name == "text":
+        return False
+    return not (
+        old_type.name == new_type.name == "varchar"
+        and _compare_lengths(old_type.precision, new_type.precision) is TypeChange.WIDENING
+    )
+
+
+def canonical_type(raw: str | None) -> str | None:
+    """The canonical spelling of ``raw`` — aliases resolved, typmod normalised.
+
+    pglast reports PostgreSQL's internal names (``int8``) while the regex backend
+    reports what the migration author wrote (``bigint``). Both classifiers run
+    the captured type through this so the two backends stay byte-identical, which
+    ``test_pglast_and_regex_agree`` requires. An unparseable type is returned
+    lowercased rather than dropped.
+    """
+    parsed = parse_type(raw)
+    if parsed is None:
+        return raw.strip().lower() or None if raw else None
+    if parsed.precision is None:
+        return parsed.name
+    if parsed.scale is None:
+        return f"{parsed.name}({parsed.precision})"
+    return f"{parsed.name}({parsed.precision},{parsed.scale})"

--- a/tests/contract/test_fraisier_adapter_surface.py
+++ b/tests/contract/test_fraisier_adapter_surface.py
@@ -83,6 +83,17 @@ EXPECTED_REPLICA_CODES = frozenset(
         "PFLIGHT_REPLICA_DROP_COLUMN",
         "PFLIGHT_REPLICA_RENAME_COLUMN",
         "PFLIGHT_REPLICA_UNCLASSIFIED",
+        # Added in 0.44.0 (#206), when the classifier stopped silently dropping
+        # statements outside its original seven-operation matrix. Additive, so
+        # no major bump: fraisier gates on the presence of any code in the
+        # namespace, and every one of these means the same thing to it.
+        "PFLIGHT_REPLICA_DROP_OBJECT",
+        "PFLIGHT_REPLICA_DROP_TABLE",
+        "PFLIGHT_REPLICA_RENAME_OBJECT",
+        "PFLIGHT_REPLICA_REPLACE_OBJECT",
+        "PFLIGHT_REPLICA_REVOKE",
+        "PFLIGHT_REPLICA_SET_NOT_NULL",
+        "PFLIGHT_REPLICA_TRUNCATE",
     }
 )
 

--- a/tests/integration/test_preflight_schema_facts.py
+++ b/tests/integration/test_preflight_schema_facts.py
@@ -1,0 +1,132 @@
+"""DB-refined preflight against a real database (issue #199, cycle 6).
+
+`ALTER TABLE … ALTER COLUMN … TYPE bigint` names the target and never the source,
+so the direction of a type change is knowable only from the database being
+migrated. `--against` points at a copy of that schema, which makes it the honest
+place to read the current type from — before the replay, so it describes the
+schema being migrated *from*.
+
+The static path must be untouched: without a reachable target, the same
+migrations must produce the same tier-less entry they always did.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import psycopg
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.schema_facts import collect_schema_facts
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def target_schema(clean_test_db: psycopg.Connection) -> psycopg.Connection:
+    """A table whose column types the preflight target will report."""
+    with clean_test_db.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS tb_widget CASCADE")
+        cur.execute(
+            "CREATE TABLE tb_widget ("
+            "  id bigint PRIMARY KEY,"
+            "  label varchar(50) NOT NULL,"
+            "  quantity integer NOT NULL"
+            ")"
+        )
+    clean_test_db.commit()
+    return clean_test_db
+
+
+def _preflight(migrations: Path, dsn: str) -> dict:
+    result = CliRunner().invoke(
+        app,
+        [
+            "migrate",
+            "preflight",
+            "--migrations-dir",
+            str(migrations),
+            "--against",
+            dsn,
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code in (0, 7), result.output
+    return json.loads(result.stdout)
+
+
+def _entry(payload: dict, kind: str) -> dict:
+    matches = [c for c in payload["change_set"]["changes"] if c["kind"] == kind]
+    assert matches, payload["change_set"]
+    return matches[0]
+
+
+def test_collect_schema_facts_reads_types_and_version(
+    target_schema: psycopg.Connection,
+) -> None:
+    facts = collect_schema_facts(target_schema)
+
+    assert facts.column_type("public.tb_widget.id") == "bigint"
+    assert facts.column_type("public.tb_widget.label") == "character varying(50)"
+    assert facts.server_version is not None
+    assert facts.server_version >= 9
+
+
+def test_narrowing_is_irreversible_against_a_real_target(
+    target_schema: psycopg.Connection, test_db_url: str, tmp_path: Path
+) -> None:
+    """`bigint`→`integer` loses data; the tier must say so."""
+    migrations = tmp_path / "narrow"
+    migrations.mkdir()
+    (migrations / "20260806120000_narrow.up.sql").write_text(
+        "ALTER TABLE tb_widget ALTER COLUMN id TYPE integer;\n"
+    )
+    (migrations / "20260806120000_narrow.down.sql").write_text(
+        "ALTER TABLE tb_widget ALTER COLUMN id TYPE bigint;\n"
+    )
+
+    entry = _entry(_preflight(migrations, test_db_url), "alter_column_type")
+    assert entry["tier"] == "irreversible"
+    assert "narrowing" in entry["detail"]
+
+
+def test_widening_without_a_rewrite_is_reversible_against_a_real_target(
+    target_schema: psycopg.Connection, test_db_url: str, tmp_path: Path
+) -> None:
+    """`varchar(50)`→`text` is binary coercible: safe, and no heap rewrite."""
+    migrations = tmp_path / "widen"
+    migrations.mkdir()
+    (migrations / "20260806120000_widen.up.sql").write_text(
+        "ALTER TABLE tb_widget ALTER COLUMN label TYPE text;\n"
+    )
+    (migrations / "20260806120000_widen.down.sql").write_text(
+        "ALTER TABLE tb_widget ALTER COLUMN label TYPE varchar(50);\n"
+    )
+
+    entry = _entry(_preflight(migrations, test_db_url), "alter_column_type")
+    assert entry["tier"] == "reversible"
+    assert "no rewrite" in entry["detail"]
+
+
+def test_static_path_is_unchanged_without_a_target(tmp_path: Path) -> None:
+    """No connection ⇒ the honest tier-less entry, exactly as before #199."""
+    migrations = tmp_path / "static"
+    migrations.mkdir()
+    (migrations / "20260806120000_narrow.up.sql").write_text(
+        "ALTER TABLE tb_widget ALTER COLUMN id TYPE integer;\n"
+    )
+    (migrations / "20260806120000_narrow.down.sql").write_text(
+        "ALTER TABLE tb_widget ALTER COLUMN id TYPE bigint;\n"
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(migrations), "--format", "json"],
+    )
+    payload = json.loads(result.stdout)
+    entry = _entry(payload, "alter_column_type")
+    assert "tier" not in entry

--- a/tests/unit/test_change_set_lock_and_types.py
+++ b/tests/unit/test_change_set_lock_and_types.py
@@ -1,0 +1,158 @@
+"""Lock cost and DB-refined type direction on the change set (issue #199, cycles 5-6).
+
+Two things reach the change set that could not before:
+
+* Every entry carries what the operation costs in locking terms, so a catalog
+  write is distinguishable from a full-table rewrite without re-deriving it from
+  ``kind``. It rides as a typed field and in ``detail``, **not** on the wire —
+  the entry shape is the ratified fraisier-core#44 pact.
+* When a database is reachable, the *current* column type is known, so
+  ``ALTER COLUMN … TYPE`` finally gets a direction and therefore a tier.
+
+The static path must be unchanged by all of this: preflight is a filesystem-only
+check by design, and the DB layer is strictly additive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.change_set import build_change_set, classify_statements
+from confiture.core.lock_profile import Duration
+from confiture.core.risk_tier import RiskTier
+from confiture.core.schema_facts import SchemaFacts
+
+# --------------------------------------------------------------------------- #
+# Cycle 5: the lock profile rides on the entry
+# --------------------------------------------------------------------------- #
+
+
+def test_entry_carries_lock_profile() -> None:
+    (entry,) = classify_statements("ALTER TABLE t ADD COLUMN c int;")
+    assert entry.lock is not None
+    assert entry.lock.rewrites_table is False
+    assert entry.lock.duration is Duration.METADATA
+
+
+def test_rewrite_is_distinguishable_from_metadata() -> None:
+    """#199's headline criterion, as two entries that must not look alike."""
+    (cheap,) = classify_statements("ALTER TABLE t DROP COLUMN c;")
+    (expensive,) = classify_statements("ALTER TABLE t ALTER COLUMN c TYPE bigint;")
+
+    assert cheap.lock.rewrites_table is False
+    assert cheap.lock.duration is Duration.METADATA
+    assert expensive.lock.rewrites_table is True
+    assert expensive.lock.duration is Duration.MINUTES_PLUS
+
+
+def test_lock_stays_off_the_wire() -> None:
+    """The entry shape is the ratified fraisier-core#44 pact, pinned byte-for-byte.
+
+    Adding a key is a co-ordinated cross-repo change with a `contract_version`
+    decision, so the lock facts travel through `detail` (free-form by
+    specification) and the typed field, not the wire.
+    """
+    (entry,) = classify_statements("CREATE INDEX idx ON t (c);")
+    assert entry.lock is not None
+    assert "lock" not in entry.to_dict()
+    assert set(entry.to_dict()) <= {"kind", "object", "migration", "tier", "detail"}
+
+
+def test_python_migration_has_no_lock(tmp_path) -> None:
+    """No statement to cost ⇒ no profile, rather than a fabricated cheap one."""
+    migrations = tmp_path / "m"
+    migrations.mkdir()
+    (migrations / "20260806120000_a.py").write_text("def up(conn):\n    pass\n")
+    change_set = build_change_set(migrations)
+    (entry,) = change_set.changes
+    assert entry.kind == "python_migration"
+    assert entry.lock is None
+
+
+# --------------------------------------------------------------------------- #
+# Cycle 6: DB-refined answers
+# --------------------------------------------------------------------------- #
+
+
+def test_alter_column_type_is_unclassified_without_facts() -> None:
+    """Today's behaviour, unchanged: no old type ⇒ no tier."""
+    (entry,) = classify_statements("ALTER TABLE public.t ALTER COLUMN c TYPE integer;")
+    assert entry.tier is None
+
+
+def test_narrowing_is_irreversible_with_facts() -> None:
+    facts = SchemaFacts(column_types={"public.t.c": "bigint"})
+    (entry,) = classify_statements("ALTER TABLE public.t ALTER COLUMN c TYPE integer;", facts=facts)
+    assert entry.tier is RiskTier.IRREVERSIBLE
+    assert "narrow" in (entry.detail or "").lower()
+
+
+def test_widening_that_rewrites_is_lock_risky() -> None:
+    facts = SchemaFacts(column_types={"public.t.c": "integer"})
+    (entry,) = classify_statements("ALTER TABLE public.t ALTER COLUMN c TYPE bigint;", facts=facts)
+    assert entry.tier is RiskTier.LOCK_RISKY
+
+
+def test_widening_without_a_rewrite_is_reversible() -> None:
+    """`varchar(50)`→`text` is binary coercible: no rewrite, no lock risk."""
+    facts = SchemaFacts(column_types={"public.t.c": "varchar(50)"})
+    (entry,) = classify_statements("ALTER TABLE public.t ALTER COLUMN c TYPE text;", facts=facts)
+    assert entry.tier is RiskTier.REVERSIBLE
+    assert entry.lock.rewrites_table is False
+
+
+def test_unmodelled_type_stays_unclassified_even_with_facts() -> None:
+    facts = SchemaFacts(column_types={"public.t.c": "mood"})
+    (entry,) = classify_statements("ALTER TABLE public.t ALTER COLUMN c TYPE text;", facts=facts)
+    assert entry.tier is None
+
+
+@pytest.mark.parametrize(
+    ("server_version", "expected"),
+    [
+        (None, RiskTier.LOCK_RISKY),
+        (10, RiskTier.LOCK_RISKY),
+        (11, RiskTier.ADDITIVE),
+        (16, RiskTier.ADDITIVE),
+    ],
+)
+def test_add_column_default_refines_with_server_version(
+    server_version: int | None, expected: RiskTier
+) -> None:
+    """PG 11's fast default turns the rewrite into a catalog write.
+
+    Unknown version keeps the conservative reading, so the no-connection default
+    is byte-identical to before.
+    """
+    facts = SchemaFacts(server_version=server_version) if server_version else None
+    (entry,) = classify_statements(
+        "ALTER TABLE t ADD COLUMN c int NOT NULL DEFAULT 0;", facts=facts
+    )
+    assert entry.tier is expected
+
+
+def test_facts_do_not_change_unrelated_entries() -> None:
+    """The DB layer is additive: an entry it says nothing about is untouched."""
+    sql = "DROP TABLE t; CREATE TABLE u (id int);"
+    without = classify_statements(sql)
+    with_facts = classify_statements(sql, facts=SchemaFacts(server_version=16))
+    assert [e.kind for e in without] == [e.kind for e in with_facts]
+    assert [e.tier for e in without] == [e.tier for e in with_facts]
+
+
+def test_build_change_set_threads_facts(tmp_path) -> None:
+    migrations = tmp_path / "m"
+    migrations.mkdir()
+    (migrations / "20260806120000_a.up.sql").write_text(
+        "ALTER TABLE public.t ALTER COLUMN c TYPE integer;"
+    )
+
+    facts = SchemaFacts(column_types={"public.t.c": "bigint"})
+    change_set = build_change_set(migrations, facts=facts)
+    assert change_set.worst_tier is RiskTier.IRREVERSIBLE
+
+
+def test_schema_facts_lookup_is_case_folded() -> None:
+    facts = SchemaFacts(column_types={"public.t.c": "bigint"})
+    assert facts.column_type("PUBLIC.T.C") == "bigint"
+    assert facts.column_type("public.other.c") is None

--- a/tests/unit/test_lock_profile.py
+++ b/tests/unit/test_lock_profile.py
@@ -1,0 +1,161 @@
+"""Operation → lock level and rewrite cost (issue #199).
+
+The lock a statement takes and whether it rewrites the heap are properties of the
+*operation class*, largely independent of table size, and they are what separate a
+metadata blip from a multi-minute outage. Two rows are version-dependent and must
+answer conservatively when the server version is unknown.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.lock_profile import Duration, LockLevel, lock_profile
+from confiture.core.replica.classifier import (
+    AddColumn,
+    AddConstraint,
+    AddEnumValue,
+    ChangeColumnType,
+    CreateIndex,
+    CreateTable,
+    DropColumn,
+    DropTable,
+    Other,
+    RenameColumn,
+    SetNotNull,
+    Truncate,
+)
+
+
+def test_add_column_nullable_is_metadata_only() -> None:
+    profile = lock_profile(AddColumn(table="t", column="c", nullable=True))
+    assert profile.rewrites_table is False
+    assert profile.duration is Duration.METADATA
+    assert profile.lock is LockLevel.ACCESS_EXCLUSIVE
+
+
+def test_create_index_blocks_writes_but_not_reads() -> None:
+    profile = lock_profile(CreateIndex(table="t", concurrently=False))
+    assert profile.blocks_writes is True
+    assert profile.blocks_reads is False
+    assert profile.lock is LockLevel.SHARE
+
+
+def test_create_index_concurrently_blocks_neither() -> None:
+    profile = lock_profile(CreateIndex(table="t", concurrently=True))
+    assert profile.blocks_writes is False
+    assert profile.blocks_reads is False
+    assert profile.lock is LockLevel.SHARE_UPDATE_EXCLUSIVE
+
+
+def test_alter_column_type_rewrites() -> None:
+    profile = lock_profile(ChangeColumnType(table="t", column="c"))
+    assert profile.rewrites_table is True
+    assert profile.duration is Duration.MINUTES_PLUS
+
+
+def test_add_enum_value_takes_no_table_lock() -> None:
+    """`ALTER TYPE … ADD VALUE` touches the type catalog, not the heap."""
+    profile = lock_profile(AddEnumValue(table="mood", value="ok"))
+    assert profile.rewrites_table is False
+    assert profile.blocks_reads is False
+    assert profile.blocks_writes is False
+    assert profile.duration is Duration.METADATA
+
+
+@pytest.mark.parametrize(
+    ("op", "rewrites"),
+    [
+        (DropColumn(table="t", column="c"), False),
+        (RenameColumn(table="t", old="a", new="b"), False),
+        (DropTable(table="t"), False),
+        (Truncate(table="t"), False),
+        (CreateTable(table="t"), False),
+        (ChangeColumnType(table="t", column="c"), True),
+    ],
+)
+def test_rewrite_flags(op, rewrites: bool) -> None:
+    assert lock_profile(op).rewrites_table is rewrites
+
+
+# --------------------------------------------------------------------------- #
+# Version-dependent rows
+# --------------------------------------------------------------------------- #
+
+
+def test_add_column_default_rewrites_below_pg11() -> None:
+    op = AddColumn(table="t", column="c", nullable=False, has_default=True)
+    assert lock_profile(op, server_version=10).rewrites_table is True
+    assert lock_profile(op, server_version=10).duration is Duration.MINUTES_PLUS
+
+
+def test_add_column_default_does_not_rewrite_from_pg11() -> None:
+    """PG 11's fast default turns the rewrite into a catalog write."""
+    op = AddColumn(table="t", column="c", nullable=False, has_default=True)
+    profile = lock_profile(op, server_version=11)
+    assert profile.rewrites_table is False
+    assert profile.duration is Duration.METADATA
+
+
+def test_unknown_version_answers_conservatively() -> None:
+    """No connection ⇒ assume the worse of the two readings."""
+    op = AddColumn(table="t", column="c", nullable=False, has_default=True)
+    unknown = lock_profile(op)
+    assert unknown.rewrites_table is True
+    assert unknown == lock_profile(op, server_version=None)
+    assert unknown.since_version == 11
+
+
+def test_set_not_null_scans_below_pg12() -> None:
+    profile = lock_profile(SetNotNull(table="t", column="c"), server_version=11)
+    assert profile.duration is Duration.MINUTES_PLUS
+    assert profile.blocks_reads is True
+
+
+def test_set_not_null_can_skip_the_scan_from_pg12() -> None:
+    """PG 12 can prove NOT NULL from a valid CHECK instead of scanning."""
+    profile = lock_profile(SetNotNull(table="t", column="c"), server_version=12)
+    assert profile.duration is Duration.SECONDS
+    assert profile.note
+
+
+def test_add_constraint_not_valid_defers_the_scan() -> None:
+    immediate = lock_profile(AddConstraint(table="t", kind="check", not_valid=False))
+    deferred = lock_profile(AddConstraint(table="t", kind="check", not_valid=True))
+    assert immediate.duration is Duration.MINUTES_PLUS
+    assert deferred.duration is Duration.METADATA
+
+
+# --------------------------------------------------------------------------- #
+# Totality
+# --------------------------------------------------------------------------- #
+
+
+def test_unclassified_operation_gets_the_conservative_profile() -> None:
+    """An operation with no row must not read as cheap (the #206 lesson)."""
+    profile = lock_profile(Other(reason="dynamic sql"))
+    assert profile.rewrites_table is True
+    assert profile.blocks_reads is True
+    assert profile.blocks_writes is True
+    assert profile.duration is Duration.MINUTES_PLUS
+
+
+def test_every_operation_class_has_a_profile() -> None:
+    """Totality guard: a new DdlOperation subclass must not fall off the table."""
+    import inspect
+
+    from confiture.core.replica import classifier as mod
+    from confiture.core.replica.classifier import DdlOperation
+
+    subclasses = [
+        obj
+        for _name, obj in inspect.getmembers(mod, inspect.isclass)
+        if issubclass(obj, DdlOperation) and obj is not DdlOperation
+    ]
+    assert subclasses
+    for cls in subclasses:
+        assert lock_profile(cls()) is not None, cls.__name__
+
+
+def test_duration_orders_metadata_below_minutes() -> None:
+    assert Duration.METADATA < Duration.SECONDS < Duration.MINUTES_PLUS

--- a/tests/unit/test_operation_classifier.py
+++ b/tests/unit/test_operation_classifier.py
@@ -26,7 +26,12 @@ _COLUMN_CASES = [
     ),
     ("ALTER TABLE t DROP COLUMN c;", DropColumn(table="t", column="c")),
     ("ALTER TABLE t RENAME COLUMN a TO b;", RenameColumn(table="t", old="a", new="b")),
-    ("ALTER TABLE t ALTER COLUMN c TYPE bigint;", ChangeColumnType(table="t", column="c")),
+    (
+        "ALTER TABLE t ALTER COLUMN c TYPE bigint;",
+        # `new_type` is canonicalised so pglast's `int8` and the regex backend's
+        # `bigint` compare equal (#199); `old_type` is never in the SQL.
+        ChangeColumnType(table="t", column="c", new_type="bigint"),
+    ),
 ]
 
 _OTHER_CASES = [

--- a/tests/unit/test_replica_statement_coverage.py
+++ b/tests/unit/test_replica_statement_coverage.py
@@ -1,0 +1,171 @@
+"""Every statement reaches a verdict — nothing is silently dropped (issue #206).
+
+`window_safe` is computed from the *presence* of ``PFLIGHT_REPLICA_*`` findings,
+so a statement the classifier does not recognise is indistinguishable from a
+statement it recognised as safe. Before 0.44.0 both backends returned nothing for
+anything outside a seven-operation matrix, which certified `DROP TABLE` as
+window-safe.
+
+The guard is structural rather than per-statement: the classifier must return at
+least one operation for every statement that changes schema or data, and the
+fallback for a statement it cannot map is :class:`Other` — which routes to
+``PFLIGHT_REPLICA_UNCLASSIFIED``, a warning, so opacity never hard-blocks.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from confiture.cli.main import app
+from confiture.core.replica.classifier import OperationClassifier, Other
+from confiture.core.replica.safety import classify_replica_safety
+
+# (sql, expected_safety) — one row per statement class outside the original
+# seven-operation matrix. "safe" rows must not emit a finding, or widening the
+# classifier would trade a false-safe for a wave of false-unsafes.
+COVERAGE = {
+    # destructive: an N-1 reader still references the object
+    "drop_table": ("DROP TABLE tb_user;", "unsafe"),
+    "drop_view": ("DROP VIEW v_user;", "unsafe"),
+    "drop_matview": ("DROP MATERIALIZED VIEW mv_user;", "unsafe"),
+    "drop_sequence": ("DROP SEQUENCE seq_user;", "unsafe"),
+    "drop_schema": ("DROP SCHEMA app;", "unsafe"),
+    "drop_function": ("DROP FUNCTION fn_user();", "unsafe"),
+    "drop_type": ("DROP TYPE mood;", "unsafe"),
+    "drop_extension": ("DROP EXTENSION hstore;", "unsafe"),
+    "truncate": ("TRUNCATE tb_user;", "unsafe"),
+    "revoke": ("REVOKE SELECT ON tb_user FROM app_reader;", "unsafe"),
+    "set_not_null": ("ALTER TABLE tb_user ALTER COLUMN email SET NOT NULL;", "unsafe"),
+    "rename_table": ("ALTER TABLE tb_user RENAME TO tb_account;", "unsafe"),
+    "rename_enum_value": ("ALTER TYPE mood RENAME VALUE 'ok' TO 'fine';", "unsafe"),
+    # replacement: confiture cannot tell whether the new body stays compatible
+    "replace_view": ("CREATE OR REPLACE VIEW v_user AS SELECT 1 AS a;", "depends"),
+    "replace_function": (
+        "CREATE OR REPLACE FUNCTION fn_user() RETURNS int AS $$ SELECT 1 $$ LANGUAGE sql;",
+        "depends",
+    ),
+    # additive or reader-invisible: must stay window-safe
+    "add_enum_value": ("ALTER TYPE mood ADD VALUE 'ok';", "safe"),
+    "create_view": ("CREATE VIEW v_user AS SELECT 1 AS a;", "safe"),
+    "create_sequence": ("CREATE SEQUENCE seq_user;", "safe"),
+    "create_schema": ("CREATE SCHEMA app;", "safe"),
+    "create_type": ("CREATE TYPE mood AS ENUM ('ok');", "safe"),
+    "create_extension": ("CREATE EXTENSION hstore;", "safe"),
+    "create_function": (
+        "CREATE FUNCTION fn_user() RETURNS int AS $$ SELECT 1 $$ LANGUAGE sql;",
+        "safe",
+    ),
+    "drop_index": ("DROP INDEX idx_user_email;", "safe"),
+    "drop_constraint": ("ALTER TABLE tb_user DROP CONSTRAINT ck_user;", "safe"),
+    "drop_not_null": ("ALTER TABLE tb_user ALTER COLUMN email DROP NOT NULL;", "safe"),
+    "set_default": ("ALTER TABLE tb_user ALTER COLUMN active SET DEFAULT true;", "safe"),
+    "change_owner": ("ALTER TABLE tb_user OWNER TO app;", "safe"),
+    "grant": ("GRANT SELECT ON tb_user TO app_reader;", "safe"),
+    "comment": ("COMMENT ON TABLE tb_user IS 'users';", "safe"),
+    "insert": ("INSERT INTO tb_user (id) VALUES (1);", "safe"),
+    "update": ("UPDATE tb_user SET active = true;", "safe"),
+    "delete": ("DELETE FROM tb_user WHERE id = 1;", "safe"),
+}
+
+
+@pytest.mark.parametrize("name", list(COVERAGE))
+def test_statement_reaches_a_verdict(name: str) -> None:
+    """No statement in the corpus classifies to an empty list."""
+    sql, _safety = COVERAGE[name]
+    assert OperationClassifier().classify(sql), f"{name}: classified to nothing"
+
+
+@pytest.mark.parametrize("name", list(COVERAGE))
+def test_statement_safety(name: str) -> None:
+    sql, safety = COVERAGE[name]
+    ops = OperationClassifier().classify(sql)
+    verdicts = {classify_replica_safety(op).safety for op in ops}
+    assert verdicts == {safety}, f"{name}: {verdicts} != {{{safety!r}}}"
+
+
+@pytest.mark.parametrize("name", list(COVERAGE))
+def test_backends_agree(name: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """pglast and regex reach the same verdict for every row."""
+    sql, _safety = COVERAGE[name]
+    ast_ops = OperationClassifier().classify(sql)
+
+    monkeypatch.setenv("CONFITURE_REPLICA_FORCE_REGEX", "1")
+    regex_ops = OperationClassifier().classify(sql)
+
+    assert [classify_replica_safety(op).safety for op in ast_ops] == [
+        classify_replica_safety(op).safety for op in regex_ops
+    ], name
+
+
+_PLPGSQL_BODY = """\
+CREATE OR REPLACE FUNCTION fn_user() RETURNS int AS $$
+BEGIN
+  PERFORM 1;
+  RETURN 2;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+@pytest.mark.parametrize("force_regex", [False, True], ids=["ast", "regex"])
+def test_function_body_is_one_statement(force_regex: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dollar-quoted body is not split on its internal semicolons.
+
+    The regex backend used to shred it and silently drop the fragments. Now that
+    an unrecognised fragment becomes `Other`, shredding would emit a spurious
+    UNCLASSIFIED finding for every function in a migration — trading #206's
+    false-safe for exactly the false-unsafe wave it warned about.
+    """
+    if force_regex:
+        monkeypatch.setenv("CONFITURE_REPLICA_FORCE_REGEX", "1")
+
+    ops = OperationClassifier().classify(_PLPGSQL_BODY)
+    assert len(ops) == 1, [type(op).__name__ for op in ops]
+    assert not any(isinstance(op, Other) for op in ops)
+
+
+def test_unrecognised_statement_falls_back_to_other() -> None:
+    """A statement outside the matrix produces `Other`, never an empty list.
+
+    This is the property that closes the *class* of bug rather than one instance:
+    a statement type nobody thought about still denies.
+    """
+    ops = OperationClassifier().classify("CREATE STATISTICS st_user ON a, b FROM tb_user;")
+    assert ops, "unrecognised statement classified to nothing"
+    assert all(isinstance(op, Other) for op in ops)
+    assert classify_replica_safety(ops[0]).safety == "depends"
+
+
+@pytest.mark.parametrize("name", list(COVERAGE))
+def test_window_safe_end_to_end(name: str, tmp_path) -> None:
+    """The verdict reaches `migrate preflight --format json`'s `window_safe`."""
+    sql, safety = COVERAGE[name]
+    migrations = tmp_path / name
+    migrations.mkdir()
+    (migrations / "20260806120000_case.up.sql").write_text(sql)
+
+    result = CliRunner().invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(migrations), "--format", "json"],
+    )
+    payload = json.loads(result.stdout)
+    assert payload["window_safe"] is (safety == "safe"), name
+
+
+def test_drop_table_is_not_window_safe(tmp_path) -> None:
+    """#206's headline reproduction, pinned."""
+    migrations = tmp_path / "drop"
+    migrations.mkdir()
+    (migrations / "20260806120000_drop.up.sql").write_text("DROP TABLE tb_user;")
+
+    result = CliRunner().invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(migrations), "--format", "json"],
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["window_safe"] is False
+    assert [i for i in payload["issues"] if i["code"].startswith("PFLIGHT_REPLICA_")]

--- a/tests/unit/test_replica_statement_coverage.py
+++ b/tests/unit/test_replica_statement_coverage.py
@@ -155,6 +155,31 @@ def test_window_safe_end_to_end(name: str, tmp_path) -> None:
     assert payload["window_safe"] is (safety == "safe"), name
 
 
+def test_add_enum_value_is_window_safe_and_non_transactional(tmp_path) -> None:
+    """#199's `ADD VALUE` criterion, as three properties that must hold together.
+
+    Adding an enum value is online-safe, so it must not gate a window — but it
+    cannot run inside a transaction block below PostgreSQL 12, so preflight has
+    to keep saying so. Reporting only one of the two would be misleading in
+    either direction.
+    """
+    migrations = tmp_path / "enum"
+    migrations.mkdir()
+    (migrations / "20260806120000_v.up.sql").write_text("ALTER TYPE mood ADD VALUE 'ok';")
+    (migrations / "20260806120000_v.down.sql").write_text("SELECT 1;")
+
+    result = CliRunner().invoke(
+        app,
+        ["migrate", "preflight", "--migrations-dir", str(migrations), "--format", "json"],
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["window_safe"] is True
+    assert not [i for i in payload["issues"] if i["code"].startswith("PFLIGHT_REPLICA_")]
+    assert [i for i in payload["issues"] if i["code"] == "PFLIGHT_NON_TRANSACTIONAL"]
+    assert [c for c in payload["change_set"]["changes"] if c["tier"] == "additive"]
+
+
 def test_drop_table_is_not_window_safe(tmp_path) -> None:
     """#206's headline reproduction, pinned."""
     migrations = tmp_path / "drop"

--- a/tests/unit/test_type_lattice.py
+++ b/tests/unit/test_type_lattice.py
@@ -1,0 +1,151 @@
+"""Narrowing vs widening for `ALTER COLUMN … TYPE` (issue #199).
+
+`bigint`→`int` loses data and can abort mid-migration; `int`→`bigint` cannot.
+Preflight could not tell them apart because `ChangeColumnType` carried only the
+table and column.
+
+Two answers are kept separate on purpose: the *semantic* direction (is data at
+risk) and whether PostgreSQL *rewrites* the heap. `varchar(50)`→`text` is
+widening **and** rewrite-free; `int`→`bigint` is widening but still rewrites.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confiture.core.type_lattice import (
+    TypeChange,
+    changes_rewrite_table,
+    compare_types,
+    parse_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "name", "precision", "scale"),
+    [
+        ("bigint", "bigint", None, None),
+        ("int8", "bigint", None, None),
+        ("INTEGER", "integer", None, None),
+        ("varchar(50)", "varchar", 50, None),
+        ("character varying(50)", "varchar", 50, None),
+        ("numeric(10,2)", "numeric", 10, 2),
+        ("text", "text", None, None),
+        ("timestamp with time zone", "timestamptz", None, None),
+    ],
+)
+def test_parse_type(raw: str, name: str, precision: int | None, scale: int | None) -> None:
+    parsed = parse_type(raw)
+    assert parsed is not None
+    assert (parsed.name, parsed.precision, parsed.scale) == (name, precision, scale)
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "expected"),
+    [
+        # integers
+        ("integer", "bigint", TypeChange.WIDENING),
+        ("bigint", "integer", TypeChange.NARROWING),
+        ("smallint", "integer", TypeChange.WIDENING),
+        ("integer", "integer", TypeChange.IDENTICAL),
+        ("int4", "int8", TypeChange.WIDENING),
+        # strings
+        ("varchar(50)", "varchar(100)", TypeChange.WIDENING),
+        ("varchar(100)", "varchar(50)", TypeChange.NARROWING),
+        ("varchar(50)", "text", TypeChange.WIDENING),
+        ("text", "varchar(50)", TypeChange.NARROWING),
+        ("varchar(50)", "varchar(50)", TypeChange.IDENTICAL),
+        # numeric precision/scale
+        ("numeric(10,2)", "numeric(12,2)", TypeChange.WIDENING),
+        ("numeric(12,2)", "numeric(10,2)", TypeChange.NARROWING),
+        ("numeric(10,2)", "numeric(10,4)", TypeChange.NARROWING),
+        ("integer", "numeric(20,0)", TypeChange.WIDENING),
+        ("numeric", "integer", TypeChange.NARROWING),
+        # temporal
+        ("date", "timestamp", TypeChange.WIDENING),
+        ("timestamp", "date", TypeChange.NARROWING),
+        ("timestamp", "timestamptz", TypeChange.LATERAL),
+        # floats
+        ("real", "double precision", TypeChange.WIDENING),
+        ("double precision", "real", TypeChange.NARROWING),
+        # cross-family
+        ("integer", "text", TypeChange.LATERAL),
+        # unknown / user-defined
+        ("mood", "text", TypeChange.UNKNOWN),
+        ("text", "mood", TypeChange.UNKNOWN),
+    ],
+)
+def test_compare_types(old: str, new: str, expected: TypeChange) -> None:
+    assert compare_types(old, new) is expected
+
+
+def test_missing_old_type_is_unknown() -> None:
+    """SQL never carries the old type; absence must never read as safe."""
+    assert compare_types(None, "bigint") is TypeChange.UNKNOWN
+    assert compare_types("bigint", None) is TypeChange.UNKNOWN
+    assert compare_types(None, None) is TypeChange.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "rewrites"),
+    [
+        # PostgreSQL's documented binary-coercible cases: no rewrite.
+        ("varchar(50)", "varchar(100)", False),
+        ("varchar(50)", "text", False),
+        ("varchar", "text", False),
+        ("integer", "integer", False),
+        # Everything else rewrites, including a semantic widening.
+        ("integer", "bigint", True),
+        ("varchar(100)", "varchar(50)", True),
+        ("text", "varchar(50)", True),
+        ("numeric(10,2)", "numeric(12,2)", True),
+        # Unknown must not read as free.
+        ("mood", "text", True),
+        (None, "bigint", True),
+    ],
+)
+def test_changes_rewrite_table(old: str | None, new: str | None, rewrites: bool) -> None:
+    assert changes_rewrite_table(old, new) is rewrites
+
+
+def test_narrowing_is_not_symmetric_with_widening() -> None:
+    """A guard against a lattice that accidentally reports both directions alike."""
+    assert compare_types("integer", "bigint") is not compare_types("bigint", "integer")
+
+
+# --------------------------------------------------------------------------- #
+# The classifier carries the target type (cycle 3)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("force_regex", [False, True], ids=["ast", "regex"])
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        ("ALTER TABLE t ALTER COLUMN c TYPE bigint;", "bigint"),
+        ("ALTER TABLE t ALTER COLUMN c TYPE varchar(50);", "varchar(50)"),
+        ("ALTER TABLE t ALTER COLUMN c TYPE numeric(10,2);", "numeric(10, 2)"),
+        ("ALTER TABLE t ALTER COLUMN c SET DATA TYPE text;", "text"),
+        ("ALTER TABLE t ALTER COLUMN c TYPE integer USING c::integer;", "integer"),
+    ],
+)
+def test_classifier_carries_new_type(
+    sql: str, expected: str, force_regex: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both backends record the target type; the parsed form must agree."""
+    from confiture.core.replica.classifier import OperationClassifier
+
+    if force_regex:
+        monkeypatch.setenv("CONFITURE_REPLICA_FORCE_REGEX", "1")
+
+    [op] = OperationClassifier().classify(sql)
+    assert parse_type(op.new_type) == parse_type(expected)
+
+
+def test_old_type_is_absent_from_sql() -> None:
+    """SQL states only the target, so the direction stays unknown by default."""
+    from confiture.core.replica.classifier import OperationClassifier
+
+    [op] = OperationClassifier().classify("ALTER TABLE t ALTER COLUMN c TYPE bigint;")
+    assert op.old_type is None
+    assert compare_types(op.old_type, op.new_type) is TypeChange.UNKNOWN

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql-confiture"
-version = "0.43.0"
+version = "0.44.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Phase 10 of `.phases/2026-08-04-open-issues-backlog/`, plus #206.

Phase 08 was the planned 0.44.0. Its gate (D1, the canonical desired-state
artefact) **does not clear** — see "Why not phase 08" below — so phase 10, which
is blocked on nothing, took the slot.

## #206 — `window_safe` returned `true` for `DROP TABLE`

`OperationClassifier` mapped four AST node types and returned *nothing* for
anything else; the regex backend mirrored it. `window_safe` is computed from the
*presence* of `PFLIGHT_REPLICA_*` findings, so "nothing classified" and "nothing
unsafe" were indistinguishable:

```
"ALTER TYPE mood ADD VALUE 'ok';"  -> []
'DROP TABLE users;'                -> []
```

The `Other` dataclass existed for exactly this case and was never constructed.

Unrecognised statements now fall back to `Other(reason=…)` → 
`PFLIGHT_REPLICA_UNCLASSIFIED`, a warning, so opacity denies without
hard-blocking. The matrix was widened **in lockstep with the verdict table** so
the fix does not trade a false-safe for a wave of false-unsafes: additive
`CREATE`s, DML, `GRANT`, `COMMENT`, `DROP INDEX` and `ALTER TYPE … ADD VALUE`
classify as safe and emit nothing.

> ⚠️ **Behaviour change to a pinned cross-repo field.** Migrations that reported
> `window_safe: true` will start reporting `false` if they contain any of these
> statements. They were never window-safe. The `window_safe` **capability floor
> moves to 0.44.0** — the field's shape never changed, but its value was wrong on
> every release since 0.23.0, on both backends. An older Confiture is *misread*,
> not merely *less capable*, which is the case a floor exists for.

## #199 — preflight depth

- **`core/lock_profile.py`** — lock level, heap rewrite, what it blocks, and a
  coarse duration class (`metadata`/`seconds`/`minutes+`), never a predicted
  number. The two version-dependent rows are explicit; an unknown server version
  takes the older reading.
- **`core/type_lattice.py`** — narrowing vs widening. Semantic direction and heap
  rewrite are answered separately because they disagree: `varchar(50)`→`text` is
  widening *and* rewrite-free, `integer`→`bigint` is widening and still rewrites.
- **`core/schema_facts.py`** — `migrate preflight --against` reads the target's
  current column types and server version before replaying, supplying the one
  fact the SQL never states: the *source* type. Narrowing becomes `irreversible`,
  widening `lock_risky` or `reversible`. Strictly additive; collection never
  raises and the filesystem-only path is byte-identical to before.

```console
# with --against
"tier": "irreversible", "detail": "ALTER COLUMN id TYPE bigint → integer — narrowing, rewrites the table"
# without
(no tier)               "detail": "ALTER COLUMN id TYPE — … preflight cannot tell without the source and target types"
```

## The `change_set` wire shape is untouched

The lock profile wanted to be a `lock` key on each entry, and the contract
permits additive fields. It did not ship there: the entry shape is pinned
byte-for-byte by golden fixtures vendored in both repos, whose README requires a
paired fraisier-core change and a `contract_version` decision. Adding the key
turned 10 tests red — the pact working. It ships as a typed `ChangeEntry.lock`
and in `detail`, which the contract defines as free-form. `contract_version`
stays at `1`.

## Why not phase 08

`fraiseql#964` is named in the plan as D1's owner. It is the **port-timing**
decision, resolved (A) and closed; its closing comment says explicitly that "the
desired-state half is **not** decided here … That question needs its own issue".
No such issue was ever filed, so confiture#196, fraiseql#965 and specql#24 all
wait on a decision with no owner. The producer is not ready either — `fraiseql
compile --emit-ddl` writes one `CREATE TABLE` per type and is not the versioned,
deterministic artefact #965 specifies.

## Where the plan was wrong about the code

Corrected in the phase files rather than quietly worked around:

| Claim | Reality |
|---|---|
| `ADD VALUE` → `Other` → `window_safe: false`, "fail-safe" | → `[]` → `window_safe` **`true`**. Fail-**open**. |
| `ADD VALUE` needs a tier and a non-transactional flag | Both already present since 0.43.0 / earlier. |
| Cycle 5: extend phase 07's `RiskFlag` | `RiskFlag` does not exist — superseded by the ratified contract before implementation. |
| `old_type` comes from the differ | It is not in the SQL at all; it comes from the live database. |

## Verification

- 10799 passed, 64 skipped (full DB-backed suite, `postgresql://localhost/…`)
- `ruff check` + `ruff format --check` + `ty check` clean
- `cargo clippy` clean; archaeology grep clean over `python/`
- Cross-repo golden fixtures unchanged and green

Closes #199
Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)